### PR TITLE
Re-enable pipeline-api.md generation

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -1255,8 +1255,8 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -1351,11 +1351,11 @@ TaskRunStatus
 <h3 id="tekton.dev/v1.Artifact">Artifact
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Artifacts">Artifacts</a>, <a href="#tekton.dev/v1.StepState">StepState</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.Artifacts">Artifacts</a>)
 </p>
 <div>
-<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
-It directly uses the Artifact type for its structure.</p>
+<p>Artifact represents an artifact within a system, potentially containing multiple values
+associated with it.</p>
 </div>
 <table>
 <thead>
@@ -1581,7 +1581,9 @@ string
 <td>
 <code>spec</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
@@ -1606,7 +1608,9 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>-</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
 k8s.io/apimachinery/pkg/runtime.Object
+</a>
 </em>
 </td>
 <td>
@@ -1934,10 +1938,12 @@ Used to distinguish between a single string and an array of strings.</p>
 <h3 id="tekton.dev/v1.ParamValue">ParamValue
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.Param">Param</a>, <a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1.TaskRunResult">TaskRunResult</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.Param">Param</a>, <a href="#tekton.dev/v1.ParamSpec">ParamSpec</a>)
 </p>
 <div>
-<p>ResultValue is a type alias of ParamValue</p>
+<p>ParamValue is a type that can hold a single string, string array, or string map.
+Used in JSON unmarshalling so that a single JSON field can accept
+either an individual string or an array of strings.</p>
 </div>
 <table>
 <thead>
@@ -2115,8 +2121,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -2298,8 +2304,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -3264,8 +3270,8 @@ string
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -3344,8 +3350,8 @@ Kubernetes core/v1.ResourceRequirements
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -3372,9 +3378,8 @@ string
 (<em>Appears on:</em><a href="#tekton.dev/v1.PipelineSpec">PipelineSpec</a>)
 </p>
 <div>
-<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
+<p>PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
 is expected to populate with a workspace binding.</p>
-<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
 </div>
 <table>
 <thead>
@@ -3594,7 +3599,7 @@ string
 <td>
 <p>EntryPoint identifies the entry point into the build. This is often a path to a
 build definition file and/or a target label within that file.
-Example: &ldquo;task/git-clone/0.8/git-clone.yaml&rdquo;</p>
+Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
 </td>
 </tr>
 </tbody>
@@ -3715,6 +3720,14 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1.ResultValue">ResultValue
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1.TaskRunResult">TaskRunResult</a>)
+</p>
+<div>
+<p>ResultValue is a type alias of ParamValue</p>
+</div>
 <h3 id="tekton.dev/v1.ResultsType">ResultsType
 (<code>string</code> alias)</h3>
 <p>
@@ -4689,8 +4702,8 @@ The Results declared by the StepActions will be stored here instead.</p>
 <td>
 <code>when</code><br/>
 <em>
-<a href="#tekton.dev/v1.WhenExpressions">
-WhenExpressions
+<a href="#tekton.dev/v1.StepWhenExpressions">
+StepWhenExpressions
 </a>
 </em>
 </td>
@@ -4865,8 +4878,8 @@ string
 <td>
 <code>results</code><br/>
 <em>
-<a href="#tekton.dev/v1.TaskRunResult">
-[]TaskRunResult
+<a href="#tekton.dev/v1.TaskRunStepResult">
+[]TaskRunStepResult
 </a>
 </em>
 </td>
@@ -4899,8 +4912,8 @@ string
 <td>
 <code>inputs</code><br/>
 <em>
-<a href="#tekton.dev/v1.Artifact">
-[]Artifact
+<a href="#tekton.dev/v1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
 </a>
 </em>
 </td>
@@ -4911,8 +4924,8 @@ string
 <td>
 <code>outputs</code><br/>
 <em>
-<a href="#tekton.dev/v1.Artifact">
-[]Artifact
+<a href="#tekton.dev/v1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
 </a>
 </em>
 </td>
@@ -5118,6 +5131,13 @@ More info: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/sec
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1.StepWhenExpressions">StepWhenExpressions
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.Step">Step</a>)
+</p>
+<div>
+</div>
 <h3 id="tekton.dev/v1.TaskBreakpoints">TaskBreakpoints
 </h3>
 <p>
@@ -5325,8 +5345,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -5468,10 +5488,10 @@ that task failed runtime validation</p>
 <h3 id="tekton.dev/v1.TaskRunResult">TaskRunResult
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.StepState">StepState</a>, <a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.TaskRunStatusFields">TaskRunStatusFields</a>)
 </p>
 <div>
-<p>TaskRunStepResult is a type alias of TaskRunResult</p>
+<p>TaskRunResult used to describe the results of a task</p>
 </div>
 <table>
 <thead>
@@ -5511,8 +5531,8 @@ is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in follow
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -5706,8 +5726,8 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -6025,6 +6045,23 @@ map[string]string
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1.TaskRunStepArtifact">TaskRunStepArtifact
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
+It directly uses the Artifact type for its structure.</p>
+</div>
+<h3 id="tekton.dev/v1.TaskRunStepResult">TaskRunStepResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepResult is a type alias of TaskRunResult</p>
+</div>
 <h3 id="tekton.dev/v1.TaskRunStepSpec">TaskRunStepSpec
 </h3>
 <p>
@@ -6299,7 +6336,9 @@ string
 <td>
 <code>operator</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/selection#Operator">
 k8s.io/apimachinery/pkg/selection.Operator
+</a>
 </em>
 </td>
 <td>
@@ -6337,7 +6376,7 @@ More info about CEL syntax: <a href="https://github.com/google/cel-spec/blob/mas
 <h3 id="tekton.dev/v1.WhenExpressions">WhenExpressions
 (<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1.WhenExpression</code> alias)</h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1.Step">Step</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineTask">PipelineTask</a>)
 </p>
 <div>
 <p>WhenExpressions are used to specify whether a Task should be executed or skipped
@@ -6565,6 +6604,13 @@ this field is false and so declared workspaces are required.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1.WorkspacePipelineDeclaration">WorkspacePipelineDeclaration
+</h3>
+<div>
+<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
+is expected to populate with a workspace binding.</p>
+<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
+</div>
 <h3 id="tekton.dev/v1.WorkspacePipelineTaskBinding">WorkspacePipelineTaskBinding
 </h3>
 <p>
@@ -6835,8 +6881,8 @@ string
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -7315,7 +7361,9 @@ used to populate a UI.</p>
 <td>
 <code>type</code><br/>
 <em>
-string
+<a href="#tekton.dev/v1alpha1.PipelineResourceType">
+PipelineResourceType
+</a>
 </em>
 </td>
 <td>
@@ -7442,7 +7490,9 @@ PipelineTaskMetadata
 <td>
 <code>spec</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
@@ -7467,7 +7517,9 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>-</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
 k8s.io/apimachinery/pkg/runtime.Object
+</a>
 </em>
 </td>
 <td>
@@ -7609,6 +7661,11 @@ Hub resource: <a href="https://artifacthub.io/*">https://artifacthub.io/*</a>,</
 <div>
 <p>RunReason is an enum used to store all Run reason for the Succeeded condition that are controlled by the Run itself.</p>
 </div>
+<h3 id="tekton.dev/v1alpha1.RunResult">RunResult
+</h3>
+<div>
+<p>RunResult used to describe the results of a task</p>
+</div>
 <h3 id="tekton.dev/v1alpha1.RunSpec">RunSpec
 </h3>
 <p>
@@ -7724,8 +7781,8 @@ string
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -7780,6 +7837,21 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 </p>
 <div>
 <p>RunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.RunStatus">RunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.Run">Run</a>)
+</p>
+<div>
+<p>RunStatus defines the observed state of Run.</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.RunStatusFields">RunStatusFields
+</h3>
+<div>
+<p>RunStatusFields holds the fields of Run&rsquo;s status.  This is defined
+separately and inlined so that other types can readily consume these fields
+via duck typing.</p>
 </div>
 <h3 id="tekton.dev/v1alpha1.StepActionObject">StepActionObject
 </h3>
@@ -8069,7 +8141,9 @@ used to populate a UI.</p>
 <td>
 <code>type</code><br/>
 <em>
-string
+<a href="#tekton.dev/v1alpha1.PipelineResourceType">
+PipelineResourceType
+</a>
 </em>
 </td>
 <td>
@@ -8113,11 +8187,19 @@ string
 do not have a status</p>
 <p>Deprecated: Unused, preserved only for backwards compatibility</p>
 </div>
-<h3 id="tekton.dev/v1alpha1.ResourceDeclaration">ResourceDeclaration
+<h3 id="tekton.dev/v1alpha1.PipelineResourceType">PipelineResourceType
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskResource">TaskResource</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.PipelineResourceSpec">PipelineResourceSpec</a>, <a href="#tekton.dev/v1alpha1.ResourceDeclaration">ResourceDeclaration</a>)
 </p>
+<div>
+<p>PipelineResourceType represents the type of endpoint the pipelineResource is, so that the
+controller will know this pipelineResource shouldx be fetched and optionally what
+additional metatdata should be provided for it.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<h3 id="tekton.dev/v1alpha1.ResourceDeclaration">ResourceDeclaration
+</h3>
 <div>
 <p>ResourceDeclaration defines an input or output PipelineResource declared as a requirement
 by another type such as a Task or Condition. The Name field will be used to refer to these
@@ -8151,7 +8233,9 @@ Task&rsquo;s steps.</p>
 <td>
 <code>type</code><br/>
 <em>
-string
+<a href="#tekton.dev/v1alpha1.PipelineResourceType">
+PipelineResourceType
+</a>
 </em>
 </td>
 <td>
@@ -8332,7 +8416,7 @@ string
 <h3 id="tekton.dev/v1alpha1.RunStatus">RunStatus
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.Run">Run</a>, <a href="#tekton.dev/v1alpha1.RunStatusFields">RunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1alpha1.RunStatusFields">RunStatusFields</a>)
 </p>
 <div>
 <p>RunStatus defines the observed state of Run</p>
@@ -8457,7 +8541,9 @@ tasks in a pipeline.</p>
 <td>
 <code>extraFields</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
@@ -9045,8 +9131,8 @@ Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="ht
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -9748,8 +9834,8 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -9841,14 +9927,20 @@ TaskRunStatus
 <div>
 <p>Algorithm Standard cryptographic hash algorithm</p>
 </div>
+<h3 id="tekton.dev/v1beta1.ArrayOrString">ArrayOrString
+</h3>
+<div>
+<p>ArrayOrString is deprecated, this is to keep backward compatibility</p>
+<p>Deprecated: Use ParamValue instead.</p>
+</div>
 <h3 id="tekton.dev/v1beta1.Artifact">Artifact
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Artifacts">Artifacts</a>, <a href="#tekton.dev/v1beta1.StepState">StepState</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Artifacts">Artifacts</a>)
 </p>
 <div>
-<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
-It directly uses the Artifact type for its structure.</p>
+<p>Artifact represents an artifact within a system, potentially containing multiple values
+associated with it.</p>
 </div>
 <table>
 <thead>
@@ -10220,7 +10312,7 @@ string
 <td>
 <p>EntryPoint identifies the entry point into the build. This is often a path to a
 build definition file and/or a target label within that file.
-Example: &ldquo;task/git-clone/0.8/git-clone.yaml&rdquo;</p>
+Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
 </td>
 </tr>
 </tbody>
@@ -10229,6 +10321,11 @@ Example: &ldquo;task/git-clone/0.8/git-clone.yaml&rdquo;</p>
 (<code>string</code> alias)</h3>
 <div>
 <p>CustomRunReason is an enum used to store all Run reason for the Succeeded condition that are controlled by the CustomRun itself.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.CustomRunResult">CustomRunResult
+</h3>
+<div>
+<p>CustomRunResult used to describe the results of a task</p>
 </div>
 <h3 id="tekton.dev/v1beta1.CustomRunSpec">CustomRunSpec
 </h3>
@@ -10384,6 +10481,21 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 <div>
 <p>CustomRunSpecStatusMessage defines human readable status messages for the TaskRun.</p>
 </div>
+<h3 id="tekton.dev/v1beta1.CustomRunStatus">CustomRunStatus
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRun">CustomRun</a>, <a href="#tekton.dev/v1beta1.PipelineRunRunStatus">PipelineRunRunStatus</a>)
+</p>
+<div>
+<p>CustomRunStatus defines the observed state of CustomRun.</p>
+</div>
+<h3 id="tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields
+</h3>
+<div>
+<p>CustomRunStatusFields holds the fields of CustomRun&rsquo;s status.  This is defined
+separately and inlined so that other types can readily consume these fields
+via duck typing.</p>
+</div>
 <h3 id="tekton.dev/v1beta1.EmbeddedCustomRunSpec">EmbeddedCustomRunSpec
 </h3>
 <p>
@@ -10417,7 +10529,9 @@ PipelineTaskMetadata
 <td>
 <code>spec</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
@@ -10442,7 +10556,9 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>-</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
 k8s.io/apimachinery/pkg/runtime.Object
+</a>
 </em>
 </td>
 <td>
@@ -10475,7 +10591,9 @@ structs.</p>
 <td>
 <code>spec</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
@@ -10500,7 +10618,9 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>-</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Object">
 k8s.io/apimachinery/pkg/runtime.Object
+</a>
 </em>
 </td>
 <td>
@@ -10850,10 +10970,12 @@ Used to distinguish between a single string and an array of strings.</p>
 <h3 id="tekton.dev/v1beta1.ParamValue">ParamValue
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Param">Param</a>, <a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>, <a href="#tekton.dev/v1beta1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1beta1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1beta1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1beta1.TaskRunResult">TaskRunResult</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Param">Param</a>, <a href="#tekton.dev/v1beta1.ParamSpec">ParamSpec</a>)
 </p>
 <div>
-<p>ResultValue is a type alias of ParamValue</p>
+<p>ParamValue is a type that can hold a single string or string array.
+Used in JSON unmarshalling so that a single JSON field can accept
+either an individual string or an array of strings.</p>
 </div>
 <table>
 <thead>
@@ -10953,7 +11075,9 @@ PipelineResources that will be bound in the PipelineRun.</p>
 <td>
 <code>type</code><br/>
 <em>
-string
+<a href="#tekton.dev/v1beta1.PipelineResourceType">
+PipelineResourceType
+</a>
 </em>
 </td>
 <td>
@@ -11160,6 +11284,26 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.PipelineResourceResult">PipelineResourceResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+</p>
+<div>
+<p>PipelineResourceResult has been deprecated with the migration of PipelineResources
+Deprecated: Use RunResult instead</p>
+</div>
+<h3 id="tekton.dev/v1beta1.PipelineResourceType">PipelineResourceType
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineDeclaredResource">PipelineDeclaredResource</a>)
+</p>
+<div>
+<p>PipelineResourceType represents the type of endpoint the pipelineResource is, so that the
+controller will know this pipelineResource should be fetched and optionally what
+additional metatdata should be provided for it.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
 <h3 id="tekton.dev/v1beta1.PipelineResult">PipelineResult
 </h3>
 <p>
@@ -11218,8 +11362,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -11265,8 +11409,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -11470,8 +11614,8 @@ Refer to Go&rsquo;s ParseDuration documentation for expected format: <a href="ht
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -12473,8 +12617,8 @@ string
 <td>
 <code>taskPodTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -12539,9 +12683,8 @@ Kubernetes core/v1.ResourceRequirements
 (<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineSpec">PipelineSpec</a>)
 </p>
 <div>
-<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
+<p>PipelineWorkspaceDeclaration creates a named slot in a Pipeline that a PipelineRun
 is expected to populate with a workspace binding.</p>
-<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
 </div>
 <table>
 <thead>
@@ -12774,7 +12917,7 @@ string
 <td>
 <p>EntryPoint identifies the entry point into the build. This is often a path to a
 build definition file and/or a target label within that file.
-Example: &ldquo;task/git-clone/0.8/git-clone.yaml&rdquo;</p>
+Example: &ldquo;task/git-clone/0.10/git-clone.yaml&rdquo;</p>
 </td>
 </tr>
 </tbody>
@@ -12839,6 +12982,26 @@ the chosen resolver.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.ResourceDeclaration">ResourceDeclaration
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskResource">TaskResource</a>)
+</p>
+<div>
+<p>ResourceDeclaration defines an input or output PipelineResource declared as a requirement
+by another type such as a Task or Condition. The Name field will be used to refer to these
+PipelineResources within the type&rsquo;s definition, and when provided as an Input, the Name will be the
+path to the volume mounted containing this PipelineResource as an input (e.g.
+an input Resource named <code>workspace</code> will be mounted at <code>/workspace</code>).</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ResourceParam">ResourceParam
+</h3>
+<div>
+<p>ResourceParam declares a string value to use for the parameter called Name, and is used in
+the specific context of PipelineResources.</p>
+<p>Deprecated: Unused, preserved only for backwards compatibility</p>
+</div>
 <h3 id="tekton.dev/v1beta1.ResultRef">ResultRef
 </h3>
 <div>
@@ -12894,6 +13057,20 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.ResultType">ResultType
+</h3>
+<div>
+<p>ResultType of PipelineResourceResult has been deprecated with the migration of PipelineResources
+Deprecated: v1beta1.ResultType is only kept for backward compatibility</p>
+</div>
+<h3 id="tekton.dev/v1beta1.ResultValue">ResultValue
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineResult">PipelineResult</a>, <a href="#tekton.dev/v1beta1.PipelineRunResult">PipelineRunResult</a>, <a href="#tekton.dev/v1beta1.TaskResult">TaskResult</a>, <a href="#tekton.dev/v1beta1.TaskRunResult">TaskRunResult</a>)
+</p>
+<div>
+<p>ResultValue is a type alias of ParamValue</p>
+</div>
 <h3 id="tekton.dev/v1beta1.ResultsType">ResultsType
 (<code>string</code> alias)</h3>
 <p>
@@ -12910,6 +13087,12 @@ this ResultsType.</p>
 </h3>
 <div>
 <p>RunObject is implemented by CustomRun and Run</p>
+</div>
+<h3 id="tekton.dev/v1beta1.RunResult">RunResult
+</h3>
+<div>
+<p>RunResult is used to write key/value pairs to TaskRun pod termination messages.
+It has been migrated to the result package and kept for backward compatibility</p>
 </div>
 <h3 id="tekton.dev/v1beta1.Sidecar">Sidecar
 </h3>
@@ -13984,8 +14167,8 @@ The Results declared by the StepActions will be stored here instead.</p>
 <td>
 <code>when</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.WhenExpressions">
-WhenExpressions
+<a href="#tekton.dev/v1beta1.StepWhenExpressions">
+StepWhenExpressions
 </a>
 </em>
 </td>
@@ -14280,8 +14463,8 @@ string
 <td>
 <code>results</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.TaskRunResult">
-[]TaskRunResult
+<a href="#tekton.dev/v1beta1.TaskRunStepResult">
+[]TaskRunStepResult
 </a>
 </em>
 </td>
@@ -14304,8 +14487,8 @@ Provenance
 <td>
 <code>inputs</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Artifact">
-[]Artifact
+<a href="#tekton.dev/v1beta1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
 </a>
 </em>
 </td>
@@ -14316,8 +14499,8 @@ Provenance
 <td>
 <code>outputs</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.Artifact">
-[]Artifact
+<a href="#tekton.dev/v1beta1.TaskRunStepArtifact">
+[]TaskRunStepArtifact
 </a>
 </em>
 </td>
@@ -14707,6 +14890,13 @@ Default is false.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.StepWhenExpressions">StepWhenExpressions
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.Step">Step</a>)
+</p>
+<div>
+</div>
 <h3 id="tekton.dev/v1beta1.TaskBreakpoints">TaskBreakpoints
 </h3>
 <p>
@@ -14880,7 +15070,7 @@ an input Resource named <code>workspace</code> will be mounted at <code>/workspa
 <td>
 <code>ResourceDeclaration</code><br/>
 <em>
-<a href="#tekton.dev/v1alpha1.ResourceDeclaration">
+<a href="#tekton.dev/v1beta1.ResourceDeclaration">
 ResourceDeclaration
 </a>
 </em>
@@ -15062,8 +15252,8 @@ string
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -15237,10 +15427,10 @@ reasons that emerge from underlying resources are not included here</p>
 <h3 id="tekton.dev/v1beta1.TaskRunResult">TaskRunResult
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepState">StepState</a>, <a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.TaskRunStatusFields">TaskRunStatusFields</a>)
 </p>
 <div>
-<p>TaskRunStepResult is a type alias of TaskRunResult</p>
+<p>TaskRunResult used to describe the results of a task</p>
 </div>
 <table>
 <thead>
@@ -15280,8 +15470,8 @@ is currently &ldquo;string&rdquo; and will support &ldquo;array&rdquo; in follow
 <td>
 <code>value</code><br/>
 <em>
-<a href="#tekton.dev/v1beta1.ParamValue">
-ParamValue
+<a href="#tekton.dev/v1beta1.ResultValue">
+ResultValue
 </a>
 </em>
 </td>
@@ -15489,8 +15679,8 @@ Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https
 <td>
 <code>podTemplate</code><br/>
 <em>
-<a href="#tekton.dev/unversioned.Template">
-Template
+<a href="#tekton.dev/unversioned.PodTemplate">
+PodTemplate
 </a>
 </em>
 </td>
@@ -15731,7 +15921,9 @@ See TaskRun.status (API version: tekton.dev/v1beta1)</p>
 <td>
 <code>resourcesResult</code><br/>
 <em>
-[]github.com/tektoncd/pipeline/pkg/result.RunResult
+<a href="#tekton.dev/v1beta1.PipelineResourceResult">
+[]PipelineResourceResult
+</a>
 </em>
 </td>
 <td>
@@ -15810,6 +16002,15 @@ map[string]string
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.TaskRunStepArtifact">TaskRunStepArtifact
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepArtifact represents an artifact produced or used by a step within a task run.
+It directly uses the Artifact type for its structure.</p>
+</div>
 <h3 id="tekton.dev/v1beta1.TaskRunStepOverride">TaskRunStepOverride
 </h3>
 <p>
@@ -15852,6 +16053,14 @@ Kubernetes core/v1.ResourceRequirements
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.TaskRunStepResult">TaskRunStepResult
+</h3>
+<p>
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.StepState">StepState</a>)
+</p>
+<div>
+<p>TaskRunStepResult is a type alias of TaskRunResult</p>
+</div>
 <h3 id="tekton.dev/v1beta1.TaskSpec">TaskSpec
 </h3>
 <p>
@@ -16101,7 +16310,9 @@ string
 <td>
 <code>operator</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/selection#Operator">
 k8s.io/apimachinery/pkg/selection.Operator
+</a>
 </em>
 </td>
 <td>
@@ -16139,7 +16350,7 @@ More info about CEL syntax: <a href="https://github.com/google/cel-spec/blob/mas
 <h3 id="tekton.dev/v1beta1.WhenExpressions">WhenExpressions
 (<code>[]github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.WhenExpression</code> alias)</h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>, <a href="#tekton.dev/v1beta1.Step">Step</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1beta1.PipelineTask">PipelineTask</a>)
 </p>
 <div>
 <p>WhenExpressions are used to specify whether a Task should be executed or skipped
@@ -16367,6 +16578,13 @@ this field is false and so declared workspaces are required.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="tekton.dev/v1beta1.WorkspacePipelineDeclaration">WorkspacePipelineDeclaration
+</h3>
+<div>
+<p>WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun
+is expected to populate with a workspace binding.</p>
+<p>Deprecated: use PipelineWorkspaceDeclaration type instead</p>
+</div>
 <h3 id="tekton.dev/v1beta1.WorkspacePipelineTaskBinding">WorkspacePipelineTaskBinding
 </h3>
 <p>
@@ -16507,7 +16725,7 @@ string
 <h3 id="tekton.dev/v1beta1.CustomRunStatus">CustomRunStatus
 </h3>
 <p>
-(<em>Appears on:</em><a href="#tekton.dev/v1beta1.CustomRun">CustomRun</a>, <a href="#tekton.dev/v1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1beta1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields</a>)
+(<em>Appears on:</em><a href="#tekton.dev/v1.PipelineRunRunStatus">PipelineRunRunStatus</a>, <a href="#tekton.dev/v1beta1.CustomRunStatusFields">CustomRunStatusFields</a>)
 </p>
 <div>
 <p>CustomRunStatus defines the observed state of CustomRun</p>
@@ -16633,7 +16851,9 @@ See CustomRun.status (API version: tekton.dev/v1beta1)</p>
 <td>
 <code>extraFields</code><br/>
 <em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20220720053627-e327d0730470 // Waiting for https://github.com/ahmetb/gen-crd-api-reference-docs/pull/43/files to merge
+	github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c // Waiting for https://github.com/ahmetb/gen-crd-api-reference-docs/pull/43/files to merge
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.20.3
@@ -234,4 +234,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
 )
 
-replace github.com/ahmetb/gen-crd-api-reference-docs => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20220729140133-6ce2d5aafcb4 // Waiting for https://github.com/ahmetb/gen-crd-api-reference-docs/pull/43/files to merge
+replace github.com/ahmetb/gen-crd-api-reference-docs => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c // Waiting for https://github.com/ahmetb/gen-crd-api-reference-docs/pull/43/files to merge

--- a/go.sum
+++ b/go.sum
@@ -1066,8 +1066,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
-github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20220729140133-6ce2d5aafcb4 h1:E5MV/fepEo6WUfYi+rE5y4oL5BUncZmO7e1FJm7F+sI=
-github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20220729140133-6ce2d5aafcb4/go.mod h1:lQON0TD5PnAUl7Q6H5FNV+/AqCSeltYf72OGIkegB/o=
+github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c h1:zhs32gUzwxtgNvKV29nQR2n+pfNM82kKLFd3AwIGUug=
+github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c/go.mod h1:lQON0TD5PnAUl7Q6H5FNV+/AqCSeltYf72OGIkegB/o=
 github.com/tektoncd/plumbing v0.0.0-20220817140952-3da8ce01aeeb h1:LUUCR8pLF+MzdQ7kOQQrMzDahIPZLdPCzfnNow1Um3Y=
 github.com/tektoncd/plumbing v0.0.0-20220817140952-3da8ce01aeeb/go.mod h1:uJBaI0AL/kjPThiMYZcWRujEz7D401v643d6s/21GAg=
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C1wj2THlRK+oAhjeS/TRQwMfkIuet3w0=

--- a/hack/reference-docs-gen-config.json
+++ b/hack/reference-docs-gen-config.json
@@ -16,6 +16,14 @@
             "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
+            "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/runtime\\.",
+            "docsURLTemplate": "https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#{{.TypeIdentifier}}"
+        },
+        {
+            "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/selection\\.",
+            "docsURLTemplate": "https://pkg.go.dev/k8s.io/apimachinery/pkg/selection#{{.TypeIdentifier}}"
+        },
+        {
             "typeMatchPrefix": "^knative\\.dev/pkg/apis/duck",
             "docsURLTemplate": "https://pkg.go.dev/knative.dev/pkg/apis/duck/{{arrIndex .PackageSegments -1}}#{{.TypeIdentifier}}"
         },

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -100,7 +100,7 @@ ${REPO_ROOT_DIR}/hack/update-deps.sh
 ${REPO_ROOT_DIR}/hack/update-openapigen.sh
 
 # Make sure the generated API reference docs are up-to-date
-# ${REPO_ROOT_DIR}/hack/update-reference-docs.sh
+${REPO_ROOT_DIR}/hack/update-reference-docs.sh
 
 # Make sure the CRD's structural OpenAPI schema are up-to-date
 ${REPO_ROOT_DIR}/hack/update-schemas.sh

--- a/vendor/github.com/ahmetb/gen-crd-api-reference-docs/main.go
+++ b/vendor/github.com/ahmetb/gen-crd-api-reference-docs/main.go
@@ -498,7 +498,8 @@ func typeDisplayName(t *types.Type, c generatorConfig, typePkgMap map[*types.Typ
 		types.Alias,
 		types.Pointer,
 		types.Slice,
-		types.Builtin:
+		types.Builtin,
+		types.Unsupported: // Go type aliases (type X = Y) are parsed as Unsupported by gengo
 		// noop
 	case types.Map:
 		// return original name

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -156,7 +156,7 @@ github.com/Microsoft/go-winio/internal/fs
 github.com/Microsoft/go-winio/internal/socket
 github.com/Microsoft/go-winio/internal/stringbuffer
 github.com/Microsoft/go-winio/pkg/guid
-# github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20220720053627-e327d0730470 => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20220729140133-6ce2d5aafcb4
+# github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c
 ## explicit; go 1.17
 github.com/ahmetb/gen-crd-api-reference-docs
 # github.com/antlr4-go/antlr/v4 v4.13.0
@@ -1893,4 +1893,4 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # github.com/aws/aws-sdk-go-v2/service/ecr => github.com/aws/aws-sdk-go-v2/service/ecr v1.27.3
 # github.com/aws/aws-sdk-go-v2/service/ecrpublic => github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.23.3
-# github.com/ahmetb/gen-crd-api-reference-docs => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20220729140133-6ce2d5aafcb4
+# github.com/ahmetb/gen-crd-api-reference-docs => github.com/tektoncd/ahmetb-gen-crd-api-reference-docs v0.3.1-0.20260316152250-6bbddc29119c


### PR DESCRIPTION
This picks up a fix in the forked/vendored tool that adds minimal support for aliased types. It also enhances the configuration to address some missing external URLs.

With the update in, the generation of docs/pipeline-api.md can be re-enabled.

Merging this might trigger rebase for other PRs, but it's best done sooner than later as the current docs we publish to tekton.dev is slightly out of date.

Cherry-pick of: https://github.com/tektoncd/pipeline/pull/9604

# Release Notes

```release-note
Update the pipeline API published at https://tekton.dev/docs/pipelines/pipeline-api/
```

/kind documentation