### PR TITLE
fix: respect per-resolver TTL override in cache

### DIFF
--- a/pkg/remoteresolution/resolver/bundle/resolver.go
+++ b/pkg/remoteresolution/resolver/bundle/resolver.go
@@ -111,6 +111,7 @@ func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSp
 
 	if cache.ShouldUse(ctx, r, req.Params) {
 		return cache.Get(ctx).GetCachedOrResolveFromRemote(
+			ctx,
 			req.Params,
 			LabelValueBundleResolverType,
 			func() (resolutionframework.ResolvedResource, error) {

--- a/pkg/remoteresolution/resolver/cluster/resolver.go
+++ b/pkg/remoteresolution/resolver/cluster/resolver.go
@@ -90,6 +90,7 @@ func (r *Resolver) IsImmutable([]v1.Param) bool {
 func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
 	if cache.ShouldUse(ctx, r, req.Params) {
 		return cache.Get(ctx).GetCachedOrResolveFromRemote(
+			ctx,
 			req.Params,
 			LabelValueClusterResolverType,
 			func() (resolutionframework.ResolvedResource, error) {

--- a/pkg/remoteresolution/resolver/cluster/resolver_test.go
+++ b/pkg/remoteresolution/resolver/cluster/resolver_test.go
@@ -636,7 +636,7 @@ func TestResolveWithCacheHit(t *testing.T) {
 	resolveFn := func() (framework.ResolvedResource, error) {
 		return mockResource, nil
 	}
-	cache.Get(ctx).GetCachedOrResolveFromRemote(params, cluster.LabelValueClusterResolverType, resolveFn)
+	cache.Get(ctx).GetCachedOrResolveFromRemote(ctx, params, cluster.LabelValueClusterResolverType, resolveFn)
 
 	// create request with same parameters
 	req := &v1beta1.ResolutionRequestSpec{Params: params}

--- a/pkg/remoteresolution/resolver/framework/cache/cache.go
+++ b/pkg/remoteresolution/resolver/framework/cache/cache.go
@@ -83,6 +83,7 @@ func (c *resolverCache) MaxSize() int {
 }
 
 func (c *resolverCache) GetCachedOrResolveFromRemote(
+	ctx context.Context,
 	params []pipelinev1.Param,
 	resolverType string,
 	resolveFromRemote resolveFn,
@@ -113,8 +114,13 @@ func (c *resolverCache) GetCachedOrResolveFromRemote(
 
 		// Store annotated resource with store operation and return annotated resource
 		// to indicate it was stored in cache
-		c.infow("Adding to cache", "key", key, "expiration", c.ttl)
-		c.cache.Add(key, annotated, c.ttl)
+
+		effectiveTTL := c.ttl
+		if resolverTTL := getResolverTTL(ctx); resolverTTL > 0 {
+			effectiveTTL = resolverTTL
+		}
+		c.infow("Adding to cache", "key", key, "expiration", effectiveTTL)
+		c.cache.Add(key, annotated, effectiveTTL)
 		return annotated, nil
 	})
 	if err != nil {
@@ -145,6 +151,17 @@ func (c *resolverCache) Clear() {
 	c.infow("Clearing all cache entries")
 	// predicate that returns true clears all entries
 	c.cache.RemoveAll(func(_ any) bool { return true })
+}
+
+// getResolverTTL reads the TTL(=Time-To-Live) from the resolver-specific ConfigMap, returning 0 if unset.
+func getResolverTTL(ctx context.Context) time.Duration {
+	conf := resolutionframework.GetResolverConfigFromContext(ctx)
+	if ttlStr, ok := conf[ttlConfigMapKey]; ok {
+		if parsed, err := time.ParseDuration(ttlStr); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return 0
 }
 
 func generateCacheKey(resolverType string, params []pipelinev1.Param) string {

--- a/pkg/remoteresolution/resolver/framework/cache/cache_test.go
+++ b/pkg/remoteresolution/resolver/framework/cache/cache_test.go
@@ -156,7 +156,7 @@ func TestCacheTTLExpiration(t *testing.T) {
 	// WHEN
 	cache := newResolverCacheWithClock(100, ttl, &fc).withLogger(zaptest.NewLogger(t).Sugar())
 	defer cache.Clear()
-	resource, err := cache.GetCachedOrResolveFromRemote(params, resolverType, resolveFn)
+	resource, err := cache.GetCachedOrResolveFromRemote(t.Context(), params, resolverType, resolveFn)
 
 	// THEN
 	if err != nil {
@@ -169,7 +169,7 @@ func TestCacheTTLExpiration(t *testing.T) {
 
 	// WHEN
 	fc.Advance(ttl + time.Second)
-	resource, err = cache.GetCachedOrResolveFromRemote(params, resolverType, resolveFn)
+	resource, err = cache.GetCachedOrResolveFromRemote(t.Context(), params, resolverType, resolveFn)
 
 	// THEN: Verify entry is no longer in cache after TTL expiration
 	if err != nil {
@@ -180,6 +180,42 @@ func TestCacheTTLExpiration(t *testing.T) {
 	// (a cache hit would produce cacheOperationRetrieve instead)
 	if resource.Annotations()[cacheOperationKey] != cacheOperationStore {
 		t.Fatalf("expected cache miss and cache operation 'store', got %s", resource.Annotations()[cacheOperationKey])
+	}
+}
+
+func TestCacheSpecificTTLOverride(t *testing.T) {
+	// GIVEN: cache with global TTL of 10m
+	resolverType := "bundle"
+	fc := fakeClock{time.Now()}
+	globalTTL := 10 * time.Minute
+	resolverSpecificTTL := 2 * time.Minute
+	params := []pipelinev1.Param{
+		{Name: resolverType, Value: pipelinev1.ParamValue{Type: pipelinev1.ParamTypeString, StringVal: "registry.io/repo@sha256:abcdef"}},
+	}
+	resolveFn := func() (resolutionframework.ResolvedResource, error) {
+		return &mockResolvedResource{data: []byte("test data")}, nil
+	}
+	cache := newResolverCacheWithClock(100, globalTTL, &fc)
+	defer cache.Clear()
+
+	// Inject the resolver specific TTL into context
+	ctx := resolutionframework.InjectResolverConfigToContext(t.Context(), map[string]string{
+		"ttl": "2m",
+	})
+
+	// WHEN: resolve (populates cache with resolver-specific TTL)
+	cache.GetCachedOrResolveFromRemote(ctx, params, resolverType, resolveFn)
+
+	// Advance past per-resolver TTL but within global TTL
+	fc.Advance(resolverSpecificTTL + time.Second)
+
+	// THEN: entry should be expired (per-resolver TTL was used, not global)
+	resource, err := cache.GetCachedOrResolveFromRemote(ctx, params, resolverType, resolveFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resource.Annotations()[cacheOperationKey] != cacheOperationStore {
+		t.Fatal("Expected cache miss after per-resolver TTL expiration — entry should have expired at 2m, not the global 10m")
 	}
 }
 
@@ -228,11 +264,11 @@ func TestCacheMaxSizeLRUEviction(t *testing.T) {
 				data: []byte(entry.name),
 			}, nil
 		}
-		cache.GetCachedOrResolveFromRemote(entry.params, resolverType, resolveFn)
+		cache.GetCachedOrResolveFromRemote(t.Context(), entry.params, resolverType, resolveFn)
 	}
 
 	// Access entry1 to make it recently used (entry2 becomes LRU)
-	if _, err := cache.GetCachedOrResolveFromRemote(entries[0].params, resolverType, resolveFnErr); err != nil {
+	if _, err := cache.GetCachedOrResolveFromRemote(t.Context(), entries[0].params, resolverType, resolveFnErr); err != nil {
 		t.Errorf("Expected cache hit for entry1, but got error %v", err)
 	}
 
@@ -245,25 +281,25 @@ func TestCacheMaxSizeLRUEviction(t *testing.T) {
 			data: []byte("entry4"),
 		}, nil
 	}
-	cache.GetCachedOrResolveFromRemote(entry4Params, resolverType, resolveFnEntry4)
+	cache.GetCachedOrResolveFromRemote(t.Context(), entry4Params, resolverType, resolveFnEntry4)
 
 	// Verify entry2 (LRU after entry1 was accessed) was evicted
-	if _, err := cache.GetCachedOrResolveFromRemote(entries[1].params, resolverType, resolveFnErr); err == nil {
+	if _, err := cache.GetCachedOrResolveFromRemote(t.Context(), entries[1].params, resolverType, resolveFnErr); err == nil {
 		t.Error("Expected entry2 to be evicted (LRU), but it was still in cache")
 	}
 
 	// Verify entry1 (accessed recently) is still in cache
-	if _, err := cache.GetCachedOrResolveFromRemote(entries[0].params, resolverType, resolveFnErr); err != nil {
+	if _, err := cache.GetCachedOrResolveFromRemote(t.Context(), entries[0].params, resolverType, resolveFnErr); err != nil {
 		t.Errorf("Expected entry1 to still be in cache after being accessed, but got cache miss and error %v", err)
 	}
 
 	// Verify entry3 is still in cache
-	if _, err := cache.GetCachedOrResolveFromRemote(entries[2].params, resolverType, resolveFnErr); err != nil {
+	if _, err := cache.GetCachedOrResolveFromRemote(t.Context(), entries[2].params, resolverType, resolveFnErr); err != nil {
 		t.Errorf("Expected entry3 to still be in cache, but got cache miss and error %v", err)
 	}
 
 	// Verify entry4 is in cache
-	if _, err := cache.GetCachedOrResolveFromRemote(entry4Params, resolverType, resolveFnErr); err != nil {
+	if _, err := cache.GetCachedOrResolveFromRemote(t.Context(), entry4Params, resolverType, resolveFnErr); err != nil {
 		t.Errorf("Expected entry4 to be in cache, but got cache miss and error %v", err)
 	}
 }
@@ -291,12 +327,14 @@ func TestGetCachedOrResolveFromRemote(t *testing.T) {
 
 		// WHEN
 		cachePopulationResult, cachePopulationErr := cache.GetCachedOrResolveFromRemote(
+			t.Context(),
 			params,
 			bundleresolution.LabelValueBundleResolverType,
 			resolveFn,
 		)
 
 		cacheHitResult, cacheHitErr := cache.GetCachedOrResolveFromRemote(
+			t.Context(),
 			params,
 			bundleresolution.LabelValueBundleResolverType,
 			resolveFn,
@@ -336,11 +374,13 @@ func TestGetCachedOrResolveFromRemote(t *testing.T) {
 
 		// WHEN
 		result, firstTryErr := cache.GetCachedOrResolveFromRemote(
+			t.Context(),
 			params,
 			bundleresolution.LabelValueBundleResolverType,
 			resolveErrFn,
 		)
 		retryResult, retryErr := cache.GetCachedOrResolveFromRemote(
+			t.Context(),
 			params,
 			bundleresolution.LabelValueBundleResolverType,
 			resolveSuccessFn,
@@ -384,12 +424,14 @@ func TestGetCachedOrResolveFromRemote(t *testing.T) {
 
 		// WHEN
 		cachePopulationResult, cachePopulationErr := cacheWrapper.GetCachedOrResolveFromRemote(
+			t.Context(),
 			params,
 			bundleresolution.LabelValueBundleResolverType,
 			resolveFn,
 		)
 		cacheWrapper.cache.Add(key, "poisoned-resource", cacheWrapper.TTL())
 		result, castingFailedErr := cacheWrapper.GetCachedOrResolveFromRemote(
+			t.Context(),
 			params,
 			bundleresolution.LabelValueBundleResolverType,
 			resolveFn,
@@ -424,17 +466,20 @@ func TestGetCachedOrResolveFromRemote(t *testing.T) {
 
 		// WHEN
 		firstAttemptResult, firstAttemptErr := cacheWrapper.GetCachedOrResolveFromRemote(
+			t.Context(),
 			params,
 			bundleresolution.LabelValueBundleResolverType,
 			resolveFn,
 		)
 		cacheWrapper.cache.Add(key, "poisoned-resource", cacheWrapper.TTL())
 		secondAttemptResult, castingFailedErr := cacheWrapper.GetCachedOrResolveFromRemote(
+			t.Context(),
 			params,
 			bundleresolution.LabelValueBundleResolverType,
 			resolveFn,
 		)
 		thirdAttemptResult, thirdAttemptErr := cacheWrapper.GetCachedOrResolveFromRemote(
+			t.Context(),
 			params,
 			bundleresolution.LabelValueBundleResolverType,
 			resolveFn,

--- a/pkg/remoteresolution/resolver/framework/cache/setup_test.go
+++ b/pkg/remoteresolution/resolver/framework/cache/setup_test.go
@@ -78,10 +78,10 @@ func TestCacheSharing(t *testing.T) {
 	}
 
 	// Add to cache1
-	cache1.GetCachedOrResolveFromRemote(testParams, resolverType, resolveFn)
+	cache1.GetCachedOrResolveFromRemote(ctx1, testParams, resolverType, resolveFn)
 
 	// Verify it exists in cache2 (proving they share the same underlying storage)
-	retrieved, err := cache2.GetCachedOrResolveFromRemote(testParams, resolverType, resolveFnErr)
+	retrieved, err := cache2.GetCachedOrResolveFromRemote(ctx2, testParams, resolverType, resolveFnErr)
 	if err != nil {
 		t.Fatalf("Expected to find resource in cache2 that was added to cache1 - caches are not shared: %v", err)
 	}

--- a/pkg/remoteresolution/resolver/git/resolver.go
+++ b/pkg/remoteresolution/resolver/git/resolver.go
@@ -170,6 +170,7 @@ func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSp
 
 	if cache.ShouldUse(ctx, r, req.Params) {
 		return cache.Get(ctx).GetCachedOrResolveFromRemote(
+			ctx,
 			req.Params,
 			labelValueGitResolverType,
 			func() (resolutionframework.ResolvedResource, error) {


### PR DESCRIPTION
### Bug desription: 
Fixes #9659
The resolver caching mechanism causes the global cache configuration to take precedence over specific resolver configurations. Even when a specific resolver (e.g., bundleresolver-config) is configured with a shorter TTL, the system defaults to the resolver-cache-config global TTL value.
This fix reads the resolver-specific TTL from the resolver's ConfigMap context and uses it when > 0, falling back to the global TTL otherwise.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The GetCachedOrResolveFromRemote() method always used the global resolver-cache-config TTL (c.ttl), ignoring TTL values set in individual resolver ConfigMaps (e.g., bundleresolver-config).

## Root cause

GetCachedOrResolveFromRemote() unconditionally used c.ttl (the global TTL from resolver-cache-config) for every cache entry, regardless of resolver type. Even when a specific resolver ConfigMap defined its own ttl key, the value was never read at cache insertion time.

## Fix

- cache.go: Added ctx context.Context parameter to GetCachedOrResolveFromRemote(). Inside the singleflight callback, the resolver-specific TTL is read via getResolverTTL(ctx) and used when > 0, falling back to the global c.ttl otherwise.

- bundle/resolver.go, git/resolver.go, cluster/resolver.go: Pass ctx to GetCachedOrResolveFromRemote().

- Test files: Updated all GetCachedOrResolveFromRemote() call sites to include the new ctx parameter.

## Verification 
_note the ,"expiration" val at the end_

**Config:**

// resolver-cache-config (global)
{ "ttl": "10m", "max-size": "1000" }

// bundleresolver-config (resolver-specific)
{ "default-kind": "task", "default-service-account": "default", "ttl": "5m" }

**logs before the fix:** 

`{"severity":"info","timestamp":"2026-03-16T16:19:07.355Z","logger":"controller","caller":"cache/cache.go:96","message":"Adding to cache","commit":"b69b57da43d37038b1447b346ad96a88b29d3ccb","knative.dev/traceid":"0bdbf47d-5803-4ddf-bb72-7422ef281ea1","knative.dev/key":"default/bundles-3f7a1917989503e3b20b16c68519e49c","key":"578e4be4a398aed274404ad432f4f667f32cec581d03ed69fed9c73a03f0fb90","expiration":600}`

**logs after the fix:**

`{"level":"info","ts":"2026-03-25T15:57:04.972Z","logger":"controller","caller":"cache/cache.go:145","msg":"Adding to cache","commit":"546de63-dirty","knative.dev/pod":"tekton-pipelines-remote-resolvers-8546f9b646-tfkmf","knative.dev/traceid":"db8f9c14-28e2-4af1-be40-61bf4ee2f061","knative.dev/key":"default/bundles-642b4bc656c55b13c64f33b00db6674a","key":"578e4be4a398aed274404ad432f4f667f32cec581d03ed69fed9c73a03f0fb90","expiration":300}`


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: resolver cache now respects per-resolver TTL values set in individual
resolver ConfigMaps (e.g., bundleresolver-config, git-resolver-config),
instead of always using the global resolver-cache-config TTL.
```
