### PR TITLE
fix: surface pod event messages in image pull failure errors

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -62,10 +62,10 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "persistentvolumeclaims"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  # Write permissions to publish events.
+  # Write permissions to publish events, read to surface error details.
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["create", "update", "patch"]
+    verbs: ["create", "update", "patch", "list"]
   # Read-only access to these.
   - apiGroups: [""]
     resources: ["configmaps", "limitranges", "secrets", "serviceaccounts"]

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -339,6 +339,9 @@ func (c *Reconciler) checkContainerFailure(
 		}
 		// ImagePullBackOff timeout exceeded or not configured
 		message := fmt.Sprintf(`the %s %q in TaskRun %q failed to pull the image %q. The pod errored with the message: "%s."`, containerType, name, tr.Name, imageID, waiting.Message)
+		if eventMsg := c.getImagePullEventMessage(ctx, tr); eventMsg != "" {
+			message += fmt.Sprintf(` The most recent event message: "%s."`, eventMsg)
+		}
 		return true, v1.TaskRunReasonImagePullFailed, message
 	}
 
@@ -351,12 +354,39 @@ func (c *Reconciler) checkContainerFailure(
 	// Handle InvalidImageName (unrecoverable error)
 	if waiting.Reason == InvalidImageName {
 		message := fmt.Sprintf(`the %s %q in TaskRun %q failed to pull the image %q. The pod errored with the message: "%s."`, containerType, name, tr.Name, imageID, waiting.Message)
+		if eventMsg := c.getImagePullEventMessage(ctx, tr); eventMsg != "" {
+			message += fmt.Sprintf(` The most recent event message: "%s."`, eventMsg)
+		}
 		return true, v1.TaskRunReasonImagePullFailed, message
 	}
 
 	// Handle CreateContainerError and other generic failures
 	message := fmt.Sprintf(`the %s %q in TaskRun %q failed to start. The pod errored with the message: "%s."`, containerType, name, tr.Name, waiting.Message)
 	return true, v1.TaskRunReasonPodCreationFailed, message
+}
+
+// getImagePullEventMessage queries pod events to find the most recent image pull
+// failure event message. Kubelet events contain richer error details from the
+// container runtime (e.g., "unauthorized", "manifest not found", "rate limit")
+// than the generic ContainerStateWaiting.Message.
+func (c *Reconciler) getImagePullEventMessage(ctx context.Context, tr *v1.TaskRun) string {
+	if tr.Status.PodName == "" {
+		return ""
+	}
+	eventList, err := c.KubeClientSet.CoreV1().Events(tr.Namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod,reason=Failed", tr.Status.PodName),
+	})
+	if err != nil || len(eventList.Items) == 0 {
+		return ""
+	}
+	// Return the most recent event message
+	latest := eventList.Items[0]
+	for _, e := range eventList.Items[1:] {
+		if e.LastTimestamp.After(latest.LastTimestamp.Time) {
+			latest = e
+		}
+	}
+	return latest.Message
 }
 
 func (c *Reconciler) durationAndCountMetrics(ctx context.Context, tr *v1.TaskRun, beforeCondition *apis.Condition) {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2862,6 +2862,80 @@ status:
 	}
 }
 
+func TestReconcilePodFailuresWithEventMessage(t *testing.T) {
+	taskRun := parse.MustParseV1TaskRun(t, `
+metadata:
+  name: test-imagepull-event
+  namespace: foo
+spec:
+  taskSpec:
+    steps:
+    - image: registry.example.com/private:v1
+status:
+  podName: "pod-1"
+  steps:
+  - container: step-unnamed-0
+    name: unnamed-0
+    imageID: registry.example.com/private:v1
+  taskSpec:
+    steps:
+    - image: registry.example.com/private:v1
+`)
+	taskRun.Status.Steps[0].Waiting = &corev1.ContainerStateWaiting{
+		Reason:  "ImagePullBackOff",
+		Message: `Back-off pulling image "registry.example.com/private:v1"`,
+	}
+
+	d := test.Data{
+		TaskRuns: []*v1.TaskRun{taskRun},
+		Pods: []*corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "foo"},
+		}},
+	}
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+
+	// Create a pod event that mimics what kubelet would produce
+	_, err := testAssets.Clients.Kube.CoreV1().Events("foo").Create(testAssets.Ctx, &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1.image-pull-failed",
+			Namespace: "foo",
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Name: "pod-1",
+			Kind: "Pod",
+		},
+		Reason:        "Failed",
+		Message:       `Failed to pull image "registry.example.com/private:v1": rpc error: code = Unknown desc = unauthorized: authentication required`,
+		LastTimestamp: metav1.Now(),
+		Type:          "Warning",
+		Source:        corev1.EventSource{Component: "kubelet"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test event: %v", err)
+	}
+
+	if err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRunName(taskRun)); err != nil {
+		t.Fatalf("Unexpected error when reconciling: %v", err)
+	}
+
+	newTr, err := testAssets.Clients.Pipeline.TektonV1().TaskRuns(taskRun.Namespace).Get(testAssets.Ctx, taskRun.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Expected TaskRun to exist: %v", err)
+	}
+
+	condition := newTr.Status.GetCondition(apis.ConditionSucceeded)
+	if condition == nil {
+		t.Fatal("Expected a condition on the TaskRun")
+	}
+	if !strings.Contains(condition.Message, "unauthorized: authentication required") {
+		t.Errorf("Expected condition message to contain the event message with registry error details, got: %s", condition.Message)
+	}
+	if !strings.Contains(condition.Message, "The most recent event message") {
+		t.Errorf("Expected condition message to include event forwarding prefix, got: %s", condition.Message)
+	}
+}
+
 func TestReconcileContainerFailures(t *testing.T) {
 	testCases := []struct {
 		name           string


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When a TaskRun fails due to `ImagePullBackOff` or `InvalidImageName`, the
error message now includes the most recent pod event message from kubelet.

**Before:**
```
the step "build" in TaskRun "my-tr" failed to pull the image "registry.example.com/private:v1".
The pod errored with the message: "Back-off pulling image \"registry.example.com/private:v1\"."
```

**After:**
```
the step "build" in TaskRun "my-tr" failed to pull the image "registry.example.com/private:v1".
The pod errored with the message: "Back-off pulling image \"registry.example.com/private:v1\"."
The most recent event message: "Failed to pull image \"registry.example.com/private:v1\":
rpc error: code = Unknown desc = unauthorized: authentication required."
```

Pod events contain richer error details from the container runtime —
`unauthorized`, `manifest not found`, `rate limit exceeded`, `forbidden`,
`certificate error` — that are not available in the generic
`ContainerStateWaiting.Message`. This helps users diagnose image pull
failures without having to manually run `kubectl describe pod`.

## Implementation

- **RBAC**: Added `list` verb to the existing events rule in the controller
  ClusterRole. The controller already has `create`, `update`, `patch` for
  publishing events; `list` is needed to read pod events.
- **Event query**: New `getImagePullEventMessage()` helper queries pod events
  filtered by `involvedObject.name` and `reason=Failed`. Only called when
  the TaskRun is already going to fail — no performance impact on the happy path.
- **Graceful fallback**: If no events are found (e.g., events expired or API
  error), the original error message is used unchanged.

## Related Issues

- Closes #7385 (Better Container termination status when failing TaskRun for Image pull errors)
- Related to #4802 (Some useful Pod status do not bubble up in TaskRun status)

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md#principles) including completing the contributor CLA
- [x] Each commit in the PR has a meaningful subject line and body

# Release Note

```release-note
Image pull failure errors (ImagePullBackOff, InvalidImageName) now include
the most recent pod event message from kubelet, surfacing container runtime
details like "unauthorized", "manifest not found", or "rate limit exceeded"
directly in the TaskRun condition message.
```