### PR TITLE
fix: Pin Ubuntu, Bash & alpine container images to digests in examples/v1/taskruns/ (alpha.beta,no-ci)

### DIFF
--- a/examples/v1/taskruns/alpha/param-enum.yaml
+++ b/examples/v1/taskruns/alpha/param-enum.yaml
@@ -9,7 +9,7 @@ spec:
     default: "v1"
   steps:
   - name: build
-    image: mirror.gcr.io/bash
+    image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
     script: |
       echo "$(params.message)"
 ---

--- a/examples/v1/taskruns/alpha/produce-consume-artifacts.yaml
+++ b/examples/v1/taskruns/alpha/produce-consume-artifacts.yaml
@@ -11,7 +11,7 @@ spec:
         default: true
     steps:
       - name: artifacts-producer
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         script: |
           cat > $(step.artifacts.path) << EOF
           {
@@ -46,7 +46,7 @@ spec:
           }
           EOF
       - name: artifacts-consumer
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         script: |
           echo $(steps.artifacts-producer.inputs.input-artifacts)
       - name: artifacts-consumer-python

--- a/examples/v1/taskruns/alpha/step-stream-results.yaml
+++ b/examples/v1/taskruns/alpha/step-stream-results.yaml
@@ -28,7 +28,7 @@ spec:
       # This step redirects stdout and stderr to the path for the Task
       # result `combined`.
       - name: error
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         onError: continue
         script: echo "combined message" && nonsense
         stdoutConfig:
@@ -38,7 +38,7 @@ spec:
       # This step prints out the contents of the task results
       # if they exist
       - name: log-results
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         script: |
           if [[ -f $(results.digest.path) ]]
           then

--- a/examples/v1/taskruns/alpha/step-stream-volumes.yaml
+++ b/examples/v1/taskruns/alpha/step-stream-volumes.yaml
@@ -10,7 +10,7 @@ spec:
       - name: data
     steps:
       - name: echo
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         volumeMounts:
           - name: data
             mountPath: /data
@@ -18,7 +18,7 @@ spec:
         stdoutConfig:
           path: /data/step-echo-stdout
       - name: error
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         onError: continue
         volumeMounts:
           - name: data
@@ -29,7 +29,7 @@ spec:
         stderrConfig:
           path: /data/step-error-stderr
       - name: combined
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         onError: continue
         volumeMounts:
           - name: data
@@ -40,7 +40,7 @@ spec:
         stderrConfig:
           path: /data/step-combined
       - name: cat
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         volumeMounts:
           - name: data
             mountPath: /data
@@ -48,7 +48,7 @@ spec:
         stdoutConfig:
           path: /data/step-cat-stdout
       - name: log-data
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         volumeMounts:
           - name: data
             mountPath: /data

--- a/examples/v1/taskruns/alpha/step-stream-workspace.yaml
+++ b/examples/v1/taskruns/alpha/step-stream-workspace.yaml
@@ -43,26 +43,26 @@ spec:
           - wrong
         stderrConfig:
           path: $(results.error2.path)
-      - image: mirror.gcr.io/bash
+      - image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         workspaces:
           - name: data
         onError: continue
         args:
           - -c
           - "echo foobar >$(workspaces.data.path)/foobar.txt"
-      - image: mirror.gcr.io/bash
+      - image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         onError: continue
         args:
           - -c
           - "2>$(results.error.path) >&2 echo -n fooerr"
-      - image: mirror.gcr.io/bash
+      - image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         workspaces:
           - name: data
         workingDir: $(workspaces.data.path)
         onError: continue
         script: |
           echo local >out.txt
-      - image: mirror.gcr.io/bash
+      - image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         workspaces:
           - name: data
         onError: continue

--- a/examples/v1/taskruns/alpha/stepaction-when.yaml
+++ b/examples/v1/taskruns/alpha/stepaction-when.yaml
@@ -15,7 +15,7 @@ kind: StepAction
 metadata:
   name: step-action-when
 spec:
-  image: mirror.gcr.io/alpine
+  image: mirror.gcr.io/alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
   script: |
     echo "I am a Step Action!!!"
 ---
@@ -40,7 +40,7 @@ spec:
             operator: in
             values: ["true"]
       - name: should-skip
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         script: |
           #!/usr/bin/env bash
           echo skipskipskip
@@ -49,19 +49,19 @@ spec:
             operator: in
             values: ["true"]
       - name: should-continue
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         script: |
           #!/usr/bin/env bash
           echo blabalbaba
       - name: produce-step
-        image: mirror.gcr.io/alpine
+        image: mirror.gcr.io/alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
         results:
           - name: result2
             type: string
         script: |
           echo -n "foo" | tee $(step.results.result2.path)
       - name: run-based-on-step-results
-        image: mirror.gcr.io/alpine
+        image: mirror.gcr.io/alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
         script: |
           echo "wooooooo"
         when:

--- a/examples/v1/taskruns/alpha/task-artifacts.yaml
+++ b/examples/v1/taskruns/alpha/task-artifacts.yaml
@@ -8,7 +8,7 @@ spec:
       A simple task that produces artifacts
     steps:
       - name: produce-artifacts
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         script: |
           #!/usr/bin/env bash
           cat > $(artifacts.path) << EOF

--- a/examples/v1/taskruns/beta/emit-array-results.yaml
+++ b/examples/v1/taskruns/beta/emit-array-results.yaml
@@ -12,12 +12,12 @@ spec:
       description: The array results
   steps:
     - name: write-array
-      image: mirror.gcr.io/bash
+      image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
       script: |
         #!/usr/bin/env bash
         echo -n "[\"hello\",\"world\"]" | tee $(results.array-results.path)
     - name: check-results-array
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       script: |
         #!/bin/bash
         VALUE=$(cat $(results.array-results.path))

--- a/examples/v1/taskruns/beta/large-task-result.yaml
+++ b/examples/v1/taskruns/beta/large-task-result.yaml
@@ -14,13 +14,13 @@ spec:
       - name: result5
     steps:
       - name: step1
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         script: |
           #!/usr/bin/env bash
           cat /dev/urandom | head -c 2500 | base64 | tee $(results.result1.path) #about 1 K result
           cat /dev/urandom | head -c 2500 | base64 | tee $(results.result2.path) #about 4 K result
       - name: step2
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         script: |
           #!/usr/bin/env bash
           cat /dev/urandom | head -c 2500 | base64 | tee $(results.result3.path) #about 1 K result

--- a/examples/v1/taskruns/beta/param_array_indexing.yaml
+++ b/examples/v1/taskruns/beta/param_array_indexing.yaml
@@ -15,14 +15,14 @@ spec:
     steps:
       # this step should echo "foo"
       - name: echo-params-1
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         args: [
           "echo",
           "$(params.array-to-echo[0])",
         ]
       # this step should echo "bar"
       - name: echo-params-2
-        image: mirror.gcr.io/ubuntu
+        image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
         script: |
           #!/bin/bash
           VALUE=$(params.array-to-echo[1])

--- a/examples/v1/taskruns/beta/propagated-object-parameters.yaml
+++ b/examples/v1/taskruns/beta/propagated-object-parameters.yaml
@@ -11,7 +11,7 @@ spec:
   taskSpec:
     steps:
       - name: echo-object-params
-        image: mirror.gcr.io/bash
+        image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92
         args: [
           "echo",
           "--url=$(params.gitrepo.url)",

--- a/examples/v1/taskruns/beta/workspace-in-sidecar.yaml
+++ b/examples/v1/taskruns/beta/workspace-in-sidecar.yaml
@@ -17,7 +17,7 @@ spec:
     workspaces:
     - name: signals
     steps:
-    - image: mirror.gcr.io/alpine
+    - image: mirror.gcr.io/alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
       computeResources:
         requests:
           memory: "16Mi"
@@ -33,7 +33,7 @@ spec:
         echo "Sidecar responded: ${response}"
         echo "Step Done."
     sidecars:
-    - image: mirror.gcr.io/alpine
+    - image: mirror.gcr.io/alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
       computeResources:
         requests:
           memory: "16Mi"

--- a/examples/v1/taskruns/beta/workspace-isolation.yaml
+++ b/examples/v1/taskruns/beta/workspace-isolation.yaml
@@ -18,7 +18,7 @@ spec:
     - name: signals
     steps:
     - name: await-sidecar-signal
-      image: mirror.gcr.io/alpine
+      image: mirror.gcr.io/alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
       workspaces:
       - name: signals
       script: |
@@ -32,7 +32,7 @@ spec:
         done
         echo "Saw ready file"
     - name: check-signals-access
-      image: mirror.gcr.io/alpine
+      image: mirror.gcr.io/alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
       script: |
         #!/usr/bin/env ash
         if [ -f "$(workspaces.signals.path)"/start ] ; then
@@ -41,7 +41,7 @@ spec:
         fi
     sidecars:
     - name: await-step-signal
-      image: mirror.gcr.io/alpine
+      image: mirror.gcr.io/alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
       workspaces:
       - name: signals
       script: |

--- a/examples/v1/taskruns/no-ci/default-workspaces.yaml
+++ b/examples/v1/taskruns/no-ci/default-workspaces.yaml
@@ -7,11 +7,11 @@ spec:
   - name: source
   steps:
   - name: write-file
-    image: mirror.gcr.io/ubuntu
+    image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
     script: |
       echo "Hello, world!" > /workspace/source/hello.txt || exit 0
   - name: read-file
-    image: mirror.gcr.io/ubuntu
+    image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
     script: |
       grep "Hello, world" /workspace/source/hello.txt
 ---

--- a/examples/v1/taskruns/no-ci/limitrange.yaml
+++ b/examples/v1/taskruns/no-ci/limitrange.yaml
@@ -25,7 +25,7 @@ metadata:
 spec:
   steps:
     - name: echo
-      image: mirror.gcr.io/ubuntu
+      image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932
       command:
         - echo
       args:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
to mitigate registry rate limiting during e2e tests, below changes were done:

Pin **Ubuntu** container image references from tags to digests in the directory **`examples/v1/taskruns/alpha`, `examples/v1/taskruns/beta` & `examples/v1/taskruns/no-ci`**

Pin **Bash** container image references from tags to digests in the directory **`examples/v1/taskruns/alpha`, `examples/v1/taskruns/beta` & `examples/v1/taskruns/no-ci`**

Pin **alpine** container image references from tags to digests in the directory **`examples/v1/taskruns/alpha`, `examples/v1/taskruns/beta` & `examples/v1/taskruns/no-ci`**

1. Discovered the affected files using the command `grep -rn "image:" examples/ | grep -v "@sha256:" | grep -v "\\$(" | grep -v "KO_DOCKER_REPO"`
2. Generated digest 
```bash
crane digest mirror.gcr.io/ubuntu
sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932

crane digest mirror.gcr.io/bash
sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92

crane digest mirror.gcr.io/alpine
sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
```

3. Pin image references to digest

**Ubuntu**
```
OLD
image: mirror.gcr.io/ubuntu
NEW
image: mirror.gcr.io/ubuntu@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932

```

**Bash**
```
OLD
image: mirror.gcr.io/bash

NEW
image: mirror.gcr.io/bash@sha256:e320b40b14abc61f053286705070342c46034a549a276b798e64541457c4af92

```


**Alpine**
```
OLD
image: mirror.gcr.io/alpine

NEW
image: mirror.gcr.io/alpine@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659

```

4. Files Updated:

**Ubuntu**
- examples/v1/taskruns/beta/emit-array-results.yaml
- examples/v1/taskruns/beta/param_array_indexing.yaml
- examples/v1/taskruns/no-ci/default-workspaces.yaml
- examples/v1/taskruns/no-ci/limitrange.yaml

**Bash**
- examples/v1/taskruns/alpha/param-enum.yaml
- examples/v1/taskruns/alpha/produce-consume-artifacts.yaml
- examples/v1/taskruns/alpha/step-stream-results.yaml
- examples/v1/taskruns/alpha/step-stream-volumes.yaml
- examples/v1/taskruns/alpha/step-stream-workspace.yaml
- examples/v1/taskruns/alpha/stepaction-when.yaml
- examples/v1/taskruns/alpha/task-artifacts.yaml
- examples/v1/taskruns/beta/emit-array-results.yaml
- examples/v1/taskruns/beta/large-task-result.yaml
- examples/v1/taskruns/beta/param_array_indexing.yaml
- examples/v1/taskruns/beta/propagated-object-parameters.yaml

**Alpine**
- examples/v1/taskruns/alpha/stepaction-when.yaml
- examples/v1/taskruns/beta/workspace-in-sidecar.yaml
- examples/v1/taskruns/beta/workspace-isolation.yaml

Fixes issue #9084 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind flake