### PR TITLE
Fix: Add SSH Host aliases to support multiple SSH credentials on same host

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -32,6 +32,7 @@ on the ServiceAccount for that. See the Kubernetes documentation:
   - [Configuring `basic-auth` authentication for Git](#configuring-basic-auth-authentication-for-git)
   - [Configuring `ssh-auth` authentication for Git](#configuring-ssh-auth-authentication-for-git)
   - [Using a custom port for SSH authentication](#using-a-custom-port-for-ssh-authentication)
+  - [Using multiple SSH credentials for different repositories on the same host](#using-multiple-ssh-credentials-for-different-repositories-on-the-same-host)
   - [Using SSH authentication in `git` type `Tasks`](#using-ssh-authentication-in-git-type-tasks)
 - [Configuring authentication for Docker](#configuring-authentication-for-docker)
   - [Configuring `basic-auth` authentication for Docker](#configuring-basic-auth-authentication-for-docker)
@@ -410,6 +411,94 @@ stringData:
   known_hosts: <known-hosts>
 ```
 
+#### Using multiple SSH credentials for different repositories on the same host
+
+When you need to access multiple repositories on the same Git server (e.g., `github.com/org/repo1` and `github.com/org/repo2`) with different SSH keys, you must include the repository path in the annotation URL:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: repo1-ssh-key
+  annotations:
+    tekton.dev/git-0: github.com/org/repo1  # Full path including repo
+type: kubernetes.io/ssh-auth
+stringData:
+  ssh-privatekey: <repo1-private-key>
+  known_hosts: <known-hosts>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: repo2-ssh-key
+  annotations:
+    tekton.dev/git-0: github.com/org/repo2  # Full path including repo
+type: kubernetes.io/ssh-auth
+stringData:
+  ssh-privatekey: <repo2-private-key>
+  known_hosts: <known-hosts>
+```
+
+When the annotation URL includes a path (e.g., `github.com/org/repo1`), Tekton creates an SSH `Host` alias in `~/.ssh/config` and adds `insteadOf` URL rewriting rules in `~/.gitconfig`. This ensures Git redirects the repository URL through the alias, selecting the correct SSH key.
+
+**Why host-only annotations don't work for this case:**
+
+Using the same host-only annotation (e.g., `tekton.dev/git-0: github.com`) for multiple secrets
+with different SSH keys will **fail**. In this configuration, all keys are listed under a single
+`Host github.com` block, and SSH tries them in order. Git hosting services like GitHub authenticate
+the *first valid key* and then check repository access. If the first key authenticates successfully
+but does not have access to the target repository, the server rejects with "Repository not found"
+instead of allowing SSH to try the next key. This means only the first repository will clone
+successfully, and subsequent repositories using different deploy keys will fail.
+
+To avoid this, include the repository path in the annotation URL for each secret. This instructs
+Tekton to create separate SSH Host aliases and Git URL rewriting rules, ensuring each repository
+uses its dedicated SSH key directly without relying on key ordering.
+
+You can also mix repo-specific credentials (with path) and host-wide credentials (without path). The host-wide credential will be used as a fallback for any repository on that host that doesn't have a specific SSH key:
+
+```yaml
+# Repo-specific SSH key for a private repository
+apiVersion: v1
+kind: Secret
+metadata:
+  name: private-repo-ssh-key
+  annotations:
+    tekton.dev/git-0: github.com/secret-org/private-repo
+type: kubernetes.io/ssh-auth
+stringData:
+  ssh-privatekey: <private-repo-key>
+  known_hosts: <known-hosts>
+---
+# Host-wide SSH key for all other repositories on github.com
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-default-ssh-key
+  annotations:
+    tekton.dev/git-0: github.com  # No path = works for all repos
+type: kubernetes.io/ssh-auth
+stringData:
+  ssh-privatekey: <default-key>
+  known_hosts: <known-hosts>
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-bot
+secrets:
+  - name: private-repo-ssh-key
+  - name: github-default-ssh-key
+```
+
+**How it works:**
+- When cloning `github.com/secret-org/private-repo`, Git rewrites the URL to use the repo-specific SSH Host alias and uses the dedicated SSH key
+- When cloning any other repository on `github.com`, Git uses the host-wide SSH key as a fallback
+
+**Note:** The order of secrets in the ServiceAccount does not affect credential matching. Tekton automatically orders SSH config entries so that host-wide credentials appear first (as fallbacks) and repo-specific credentials appear after.
+
+For a complete example, see [`git-ssh-auth-multiple-repos.yaml`](../examples/v1/taskruns/no-ci/git-ssh-auth-multiple-repos.yaml).
+
 ### Using SSH authentication in `git` type `Tasks`
 
 You can use SSH authentication as described earlier in this document when invoking `git` commands
@@ -660,6 +749,39 @@ Host url2.com
 {contents of known_hosts2}
 ...
 ```
+
+**Note:** If the annotation URL includes a path (e.g., `github.com/org/repo`), Tekton creates SSH Host aliases and Git URL rewriting rules:
+
+```
+=== ~/.ssh/config ===
+Host github.com
+    HostName github.com
+    Port 22
+    IdentityFile ~/.ssh/id_host_wide_key
+Host github.com-org-repo1
+    HostName github.com
+    Port 22
+    IdentityFile ~/.ssh/id_repo1_key
+Host github.com-org-repo2
+    HostName github.com
+    Port 22
+    IdentityFile ~/.ssh/id_repo2_key
+...
+=== ~/.gitconfig (appended) ===
+[url "git@github.com-org-repo1:org/repo1"]
+    insteadOf = git@github.com:org/repo1
+[url "ssh://github.com-org-repo1/org/repo1"]
+    insteadOf = ssh://github.com/org/repo1
+[url "git@github.com-org-repo2:org/repo2"]
+    insteadOf = git@github.com:org/repo2
+[url "ssh://github.com-org-repo2/org/repo2"]
+    insteadOf = ssh://github.com/org/repo2
+...
+```
+
+This enables Git to redirect repository-specific SSH URLs through a Host alias that maps to the correct SSH key, while host-wide credentials serve as fallbacks.
+
+**SSH config ordering:** Host-wide entries (without path) are always placed before repo-specific entries (with path) to ensure proper fallback behavior. The order of secrets in the ServiceAccount does not affect this.
 
 ### `basic-auth` for Docker
 

--- a/examples/v1/taskruns/no-ci/git-ssh-auth-multiple-repos.yaml
+++ b/examples/v1/taskruns/no-ci/git-ssh-auth-multiple-repos.yaml
@@ -1,0 +1,179 @@
+# This example demonstrates using multiple SSH credentials for different
+# repositories on the same host.
+#
+# When the annotation URL includes a path (e.g., github.com/org/repo), Tekton:
+# 1. Creates an SSH Host alias in ~/.ssh/config for that credential
+# 2. Adds insteadOf URL rewriting rules in ~/.gitconfig so Git redirects
+#    the repo URL through the alias, selecting the correct SSH key
+# 3. Automatically orders SSH config entries for proper fallback behavior
+#    (host-wide credentials first, repo-specific credentials after)
+#
+# Example use cases:
+# 1. Multiple repos on same host with different deploy keys (repo1-key, repo2-key)
+# 2. Mixed: one repo-specific SSH key + one host-wide SSH key
+#
+# Note: The order of secrets in the ServiceAccount does NOT affect credential matching.
+---
+# SSH key for a specific repository (repo-specific)
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/ssh-auth
+metadata:
+  name: github-repo1-ssh-key
+  annotations:
+    # Note: URL includes path (github.com/myorg/demo-repo-1) -> Host alias will be created
+    tekton.dev/git-0: github.com/myorg/demo-repo-1
+stringData:
+  ssh-privatekey: <private-key-for-repo1>
+  known_hosts: <known-hosts>
+---
+# SSH key for another specific repository (repo-specific)
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/ssh-auth
+metadata:
+  name: github-repo2-ssh-key
+  annotations:
+    # Note: URL includes path (github.com/myorg/demo-repo-2) -> Host alias will be created
+    tekton.dev/git-0: github.com/myorg/demo-repo-2
+stringData:
+  ssh-privatekey: <private-key-for-repo2>
+  known_hosts: <known-hosts>
+---
+# ServiceAccount with multiple repo-specific SSH secrets
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: git-ssh-multi-repo-sa
+secrets:
+  - name: github-repo1-ssh-key
+  - name: github-repo2-ssh-key
+---
+# TaskRun demonstrating cloning from multiple repos with different SSH keys
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: git-ssh-clone-multiple-repos
+spec:
+  serviceAccountName: git-ssh-multi-repo-sa
+  taskSpec:
+    steps:
+    - name: clone-repo1
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+      securityContext:
+        runAsUser: 0
+      script: |
+        #!/usr/bin/env sh
+        set -xe
+
+        if [ -d /tekton/home/.ssh ]; then
+          ln -sf /tekton/home/.ssh /root/.ssh
+        fi
+
+        echo "=== Checking SSH config ==="
+        cat ~/.ssh/config || echo "No SSH config"
+
+        echo "=== Checking .gitconfig (insteadOf entries) ==="
+        cat ~/.gitconfig || echo "No .gitconfig"
+
+        echo "=== Cloning demo-repo-1 ==="
+        # This will use SSH key from github-repo1-ssh-key
+        git clone git@github.com:myorg/demo-repo-1.git /workspace/repo1
+
+        echo "Successfully cloned repo1"
+        ls -la /workspace/repo1
+
+    - name: clone-repo2
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+      securityContext:
+        runAsUser: 0
+      script: |
+        #!/usr/bin/env sh
+        set -xe
+
+        if [ -d /tekton/home/.ssh ]; then
+          ln -sf /tekton/home/.ssh /root/.ssh
+        fi
+
+        # This will use SSH key from github-repo2-ssh-key
+        git clone git@github.com:myorg/demo-repo-2.git /workspace/repo2
+        ls -la /workspace/repo2
+---
+# Example 2: Mixed credentials - repo-specific + host-wide
+# This demonstrates using one specific SSH key alongside a host-wide SSH key.
+# Tekton automatically orders SSH config entries so host-wide works as fallback.
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/ssh-auth
+metadata:
+  name: github-specific-repo-ssh-key
+  annotations:
+    # Note: URL includes path -> Host alias will be created
+    tekton.dev/git-0: github.com/secret-org/private-repo
+stringData:
+  ssh-privatekey: <private-key-for-specific-repo>
+  known_hosts: <known-hosts>
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/ssh-auth
+metadata:
+  name: github-default-ssh-key
+  annotations:
+    # Note: URL does NOT include path -> standard Host entry, works as fallback
+    tekton.dev/git-0: github.com
+stringData:
+  ssh-privatekey: <default-private-key>
+  known_hosts: <known-hosts>
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: git-ssh-mixed-creds-sa
+secrets:
+  # Order does NOT matter - Tekton auto-orders SSH config for fallback
+  - name: github-specific-repo-ssh-key
+  - name: github-default-ssh-key
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: git-ssh-clone-mixed-credentials
+spec:
+  serviceAccountName: git-ssh-mixed-creds-sa
+  taskSpec:
+    steps:
+    - name: clone-specific-repo
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+      securityContext:
+        runAsUser: 0
+      script: |
+        #!/usr/bin/env sh
+        set -xe
+
+        if [ -d /tekton/home/.ssh ]; then
+          ln -sf /tekton/home/.ssh /root/.ssh
+        fi
+
+        # This will use github-specific-repo-ssh-key (via Host alias + insteadOf)
+        git clone git@github.com:secret-org/private-repo.git /workspace/specific
+
+        echo "Successfully cloned specific repo with dedicated SSH key"
+
+    - name: clone-org-repo
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+      securityContext:
+        runAsUser: 0
+      script: |
+        #!/usr/bin/env sh
+        set -xe
+
+        if [ -d /tekton/home/.ssh ]; then
+          ln -sf /tekton/home/.ssh /root/.ssh
+        fi
+
+        # This will use github-default-ssh-key as fallback
+        git clone git@github.com:myorg/another-repo.git /workspace/org
+
+        echo "Successfully cloned org repo with host-wide SSH key"

--- a/pkg/credentials/gitcreds/creds_test.go
+++ b/pkg/credentials/gitcreds/creds_test.go
@@ -524,6 +524,224 @@ ssh-rsa cccc`
 	}
 }
 
+func TestSSHFlagHandlingMultipleReposSameHost(t *testing.T) {
+	credmatcher.VolumePath = t.TempDir()
+
+	repo1Dir := credmatcher.VolumeName("repo1-secret")
+	if err := os.MkdirAll(repo1Dir, os.ModePerm); err != nil {
+		t.Fatalf("os.MkdirAll(%s) = %v", repo1Dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(repo1Dir, corev1.SSHAuthPrivateKey), []byte("key-for-repo1"), 0o777); err != nil {
+		t.Fatalf("os.WriteFile(ssh-privatekey) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo1Dir, "known_hosts"), []byte("ssh-rsa repo1-host-key"), 0o777); err != nil {
+		t.Fatalf("os.WriteFile(known_hosts) = %v", err)
+	}
+
+	repo2Dir := credmatcher.VolumeName("repo2-secret")
+	if err := os.MkdirAll(repo2Dir, os.ModePerm); err != nil {
+		t.Fatalf("os.MkdirAll(%s) = %v", repo2Dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(repo2Dir, corev1.SSHAuthPrivateKey), []byte("key-for-repo2"), 0o777); err != nil {
+		t.Fatalf("os.WriteFile(ssh-privatekey) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo2Dir, "known_hosts"), []byte("ssh-rsa repo2-host-key"), 0o777); err != nil {
+		t.Fatalf("os.WriteFile(known_hosts) = %v", err)
+	}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	AddFlags(fs)
+	err := fs.Parse([]string{
+		"-ssh-git=repo1-secret=github.com/org/repo1",
+		"-ssh-git=repo2-secret=github.com/org/repo2",
+	})
+	if err != nil {
+		t.Fatalf("flag.CommandLine.Parse() = %v", err)
+	}
+
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
+		t.Fatalf("Write() = %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "config"))
+	if err != nil {
+		t.Fatalf("os.ReadFile(.ssh/config) = %v", err)
+	}
+	expectedSSHConfig := fmt.Sprintf(`Host github.com--org--repo1
+    HostName github.com
+    Port 22
+    IdentityFile %s/.ssh/id_repo1-secret
+Host github.com--org--repo2
+    HostName github.com
+    Port 22
+    IdentityFile %s/.ssh/id_repo2-secret
+`, credmatcher.VolumePath, credmatcher.VolumePath)
+	if d := cmp.Diff(expectedSSHConfig, string(b)); d != "" {
+		t.Errorf("ssh_config diff %s", diff.PrintWantGot(d))
+	}
+
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".gitconfig"))
+	if err != nil {
+		t.Fatalf("os.ReadFile(.gitconfig) = %v", err)
+	}
+	expectedGitConfig := `[url "git@github.com--org--repo1:org/repo1.git"]
+	insteadOf = git@github.com:org/repo1.git
+[url "ssh://github.com--org--repo1/org/repo1.git"]
+	insteadOf = ssh://github.com/org/repo1.git
+[url "git@github.com--org--repo2:org/repo2.git"]
+	insteadOf = git@github.com:org/repo2.git
+[url "ssh://github.com--org--repo2/org/repo2.git"]
+	insteadOf = ssh://github.com/org/repo2.git
+`
+	if d := cmp.Diff(expectedGitConfig, string(b)); d != "" {
+		t.Errorf(".gitconfig diff %s", diff.PrintWantGot(d))
+	}
+
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "id_repo1-secret"))
+	if err != nil {
+		t.Fatalf("os.ReadFile(.ssh/id_repo1-secret) = %v", err)
+	}
+	if string(b) != "key-for-repo1" {
+		t.Errorf("got: %v, wanted: key-for-repo1", string(b))
+	}
+
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "id_repo2-secret"))
+	if err != nil {
+		t.Fatalf("os.ReadFile(.ssh/id_repo2-secret) = %v", err)
+	}
+	if string(b) != "key-for-repo2" {
+		t.Errorf("got: %v, wanted: key-for-repo2", string(b))
+	}
+}
+
+func TestSSHFlagHandlingMixedCredentials(t *testing.T) {
+	credmatcher.VolumePath = t.TempDir()
+
+	repoDir := credmatcher.VolumeName("repo-specific")
+	if err := os.MkdirAll(repoDir, os.ModePerm); err != nil {
+		t.Fatalf("os.MkdirAll(%s) = %v", repoDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, corev1.SSHAuthPrivateKey), []byte("repo-key"), 0o777); err != nil {
+		t.Fatalf("os.WriteFile(ssh-privatekey) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "known_hosts"), []byte("ssh-rsa repo-known"), 0o777); err != nil {
+		t.Fatalf("os.WriteFile(known_hosts) = %v", err)
+	}
+
+	hostDir := credmatcher.VolumeName("host-wide")
+	if err := os.MkdirAll(hostDir, os.ModePerm); err != nil {
+		t.Fatalf("os.MkdirAll(%s) = %v", hostDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(hostDir, corev1.SSHAuthPrivateKey), []byte("host-key"), 0o777); err != nil {
+		t.Fatalf("os.WriteFile(ssh-privatekey) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hostDir, "known_hosts"), []byte("ssh-rsa host-known"), 0o777); err != nil {
+		t.Fatalf("os.WriteFile(known_hosts) = %v", err)
+	}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	AddFlags(fs)
+	// Repo-specific secret listed first, host-wide second; sorting should
+	// place the host-wide entry first in the generated config.
+	err := fs.Parse([]string{
+		"-ssh-git=repo-specific=github.com/org/private-repo",
+		"-ssh-git=host-wide=github.com",
+	})
+	if err != nil {
+		t.Fatalf("flag.CommandLine.Parse() = %v", err)
+	}
+
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
+		t.Fatalf("Write() = %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "config"))
+	if err != nil {
+		t.Fatalf("os.ReadFile(.ssh/config) = %v", err)
+	}
+	// Host-wide entry must appear first regardless of insertion order.
+	expectedSSHConfig := fmt.Sprintf(`Host github.com
+    HostName github.com
+    Port 22
+    IdentityFile %s/.ssh/id_host-wide
+Host github.com--org--private-repo
+    HostName github.com
+    Port 22
+    IdentityFile %s/.ssh/id_repo-specific
+`, credmatcher.VolumePath, credmatcher.VolumePath)
+	if d := cmp.Diff(expectedSSHConfig, string(b)); d != "" {
+		t.Errorf("ssh_config diff %s", diff.PrintWantGot(d))
+	}
+
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".gitconfig"))
+	if err != nil {
+		t.Fatalf("os.ReadFile(.gitconfig) = %v", err)
+	}
+	// Only the repo-specific entry should produce insteadOf entries.
+	expectedGitConfig := `[url "git@github.com--org--private-repo:org/private-repo.git"]
+	insteadOf = git@github.com:org/private-repo.git
+[url "ssh://github.com--org--private-repo/org/private-repo.git"]
+	insteadOf = ssh://github.com/org/private-repo.git
+`
+	if d := cmp.Diff(expectedGitConfig, string(b)); d != "" {
+		t.Errorf(".gitconfig diff %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestSSHFlagHandlingRepoSpecificWithCustomPort(t *testing.T) {
+	credmatcher.VolumePath = t.TempDir()
+
+	dir := credmatcher.VolumeName("myrepo")
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, corev1.SSHAuthPrivateKey), []byte("custom-port-key"), 0o777); err != nil {
+		t.Fatalf("os.WriteFile(ssh-privatekey) = %v", err)
+	}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	AddFlags(fs)
+	err := fs.Parse([]string{
+		"-ssh-git=myrepo=gitlab.example.com:2222/team/project",
+	})
+	if err != nil {
+		t.Fatalf("flag.CommandLine.Parse() = %v", err)
+	}
+
+	t.Setenv("HOME", credmatcher.VolumePath)
+	if err := NewBuilder().Write(credmatcher.VolumePath); err != nil {
+		t.Fatalf("Write() = %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(credmatcher.VolumePath, ".ssh", "config"))
+	if err != nil {
+		t.Fatalf("os.ReadFile(.ssh/config) = %v", err)
+	}
+	expectedSSHConfig := fmt.Sprintf(`Host gitlab.example.com--team--project
+    HostName gitlab.example.com
+    Port 2222
+    IdentityFile %s/.ssh/id_myrepo
+`, credmatcher.VolumePath)
+	if d := cmp.Diff(expectedSSHConfig, string(b)); d != "" {
+		t.Errorf("ssh_config diff %s", diff.PrintWantGot(d))
+	}
+
+	b, err = os.ReadFile(filepath.Join(credmatcher.VolumePath, ".gitconfig"))
+	if err != nil {
+		t.Fatalf("os.ReadFile(.gitconfig) = %v", err)
+	}
+	expectedGitConfig := `[url "git@gitlab.example.com--team--project:team/project.git"]
+	insteadOf = git@gitlab.example.com:team/project.git
+[url "ssh://gitlab.example.com--team--project/team/project.git"]
+	insteadOf = ssh://gitlab.example.com:2222/team/project.git
+`
+	if d := cmp.Diff(expectedGitConfig, string(b)); d != "" {
+		t.Errorf(".gitconfig diff %s", diff.PrintWantGot(d))
+	}
+}
+
 func TestSSHFlagHandlingMissingFiles(t *testing.T) {
 	credmatcher.VolumePath = t.TempDir()
 	dir := credmatcher.VolumeName("not-found")
@@ -535,6 +753,36 @@ func TestSSHFlagHandlingMissingFiles(t *testing.T) {
 	cfg := sshGitConfig{entries: make(map[string][]sshEntry)}
 	if err := cfg.Set("not-found=github.com"); err == nil {
 		t.Error("Set(); got success, wanted error.")
+	}
+}
+
+func TestParseSSHURL(t *testing.T) {
+	tests := []struct {
+		raw      string
+		wantHost string
+		wantPort string
+		wantPath string
+	}{
+		{"github.com", "github.com", "22", ""},
+		{"github.com:2222", "github.com", "2222", ""},
+		{"github.com/org/repo", "github.com", "22", "/org/repo"},
+		{"github.com:2222/org/repo", "github.com", "2222", "/org/repo"},
+		{"gitlab.example.com", "gitlab.example.com", "22", ""},
+		{"gitlab.example.com:3333/team/project", "gitlab.example.com", "3333", "/team/project"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			host, port, path := parseSSHURL(tt.raw)
+			if host != tt.wantHost {
+				t.Errorf("host = %q, want %q", host, tt.wantHost)
+			}
+			if port != tt.wantPort {
+				t.Errorf("port = %q, want %q", port, tt.wantPort)
+			}
+			if path != tt.wantPath {
+				t.Errorf("path = %q, want %q", path, tt.wantPath)
+			}
+		})
 	}
 }
 

--- a/pkg/credentials/gitcreds/ssh.go
+++ b/pkg/credentials/gitcreds/ssh.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/credentials/common"
@@ -73,6 +74,11 @@ func (dc *sshGitConfig) Set(value string) error {
 
 // Write puts dc's ssh entries into files in a .ssh directory, under
 // the given directory. If dc has no entries then nothing is written.
+//
+// When an annotation URL includes a repo path (e.g., github.com/org/repo),
+// an SSH Host alias is created and a .gitconfig insteadOf entry is written
+// so that Git maps the repo URL to the correct SSH key. Host-only entries
+// are written first (as fallbacks), repo-specific entries after.
 func (dc *sshGitConfig) Write(directory string) error {
 	if len(dc.entries) == 0 {
 		return nil
@@ -82,35 +88,34 @@ func (dc *sshGitConfig) Write(directory string) error {
 		return err
 	}
 
-	// Walk each of the entries and for each do three things:
-	//  1. Write out: ~/.ssh/id_{secretName} with the secret key
-	//  2. Compute its part of "~/.ssh/config"
-	//  3. Compute its part of "~/.ssh/known_hosts"
+	sortedOrder := dc.sortedOrder()
+
 	var configEntries []string
-	var defaultPort = "22"
 	var knownHosts []string
-	for _, k := range dc.order {
-		var host, port string
-		var err error
-		if host, port, err = net.SplitHostPort(k); err != nil {
-			host = k
-			port = defaultPort
+	var gitConfigEntries []string
+	for _, k := range sortedOrder {
+		host, port, repoPath := parseSSHURL(k)
+
+		var sshHost string
+		if repoPath != "" {
+			sshHost = sshHostAlias(host, repoPath)
+			gitConfigEntries = append(gitConfigEntries, insteadOfEntries(sshHost, host, port, repoPath)...)
+		} else {
+			sshHost = host
 		}
-		configEntry := fmt.Sprintf(`Host %s
-    HostName %s
-    Port %s
-`, host, host, port)
+
+		var configEntry strings.Builder
+		fmt.Fprintf(&configEntry, "Host %s\n    HostName %s\n    Port %s\n", sshHost, host, port)
 		for _, e := range dc.entries[k] {
 			if err := e.Write(sshDir); err != nil {
 				return err
 			}
-			configEntry += fmt.Sprintf(`    IdentityFile %s
-`, e.path(sshDir))
+			fmt.Fprintf(&configEntry, "    IdentityFile %s\n", e.path(sshDir))
 			if e.knownHosts != "" {
 				knownHosts = append(knownHosts, e.knownHosts)
 			}
 		}
-		configEntries = append(configEntries, configEntry)
+		configEntries = append(configEntries, configEntry.String())
 	}
 	configPath := filepath.Join(sshDir, "config")
 	configContent := strings.Join(configEntries, "")
@@ -120,9 +125,106 @@ func (dc *sshGitConfig) Write(directory string) error {
 	if len(knownHosts) > 0 {
 		knownHostsPath := filepath.Join(sshDir, "known_hosts")
 		knownHostsContent := strings.Join(knownHosts, "\n")
-		return os.WriteFile(knownHostsPath, []byte(knownHostsContent), 0600)
+		if err := os.WriteFile(knownHostsPath, []byte(knownHostsContent), 0600); err != nil {
+			return err
+		}
 	}
+
+	if len(gitConfigEntries) > 0 {
+		gitConfigPath := filepath.Join(directory, ".gitconfig")
+		gitConfigContent := strings.Join(gitConfigEntries, "")
+		f, err := os.OpenFile(gitConfigPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		if _, err := f.WriteString(gitConfigContent); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+// sortedOrder returns dc.order sorted so that host-only entries come before
+// repo-specific entries. Within each group the original insertion order is
+// preserved. This ensures host-wide SSH keys act as fallbacks.
+func (dc *sshGitConfig) sortedOrder() []string {
+	sorted := make([]string, len(dc.order))
+	copy(sorted, dc.order)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		_, _, pi := parseSSHURL(sorted[i])
+		_, _, pj := parseSSHURL(sorted[j])
+		if (pi == "") != (pj == "") {
+			return pi == ""
+		}
+		return false
+	})
+	return sorted
+}
+
+// parseSSHURL splits a raw SSH annotation value into host, port, and an
+// optional repo path. Examples:
+//
+//	"github.com"              → ("github.com", "22", "")
+//	"github.com:2222"         → ("github.com", "2222", "")
+//	"github.com/org/repo"     → ("github.com", "22", "/org/repo")
+//	"github.com:2222/org/repo"→ ("github.com", "2222", "/org/repo")
+func parseSSHURL(raw string) (host, port, path string) {
+	const defaultPort = "22"
+
+	if idx := strings.Index(raw, "/"); idx != -1 {
+		path = raw[idx:]
+		raw = raw[:idx]
+	}
+
+	h, p, err := net.SplitHostPort(raw)
+	if err == nil {
+		host = h
+		port = p
+	} else {
+		host = raw
+		port = defaultPort
+	}
+
+	return
+}
+
+// sshHostAlias builds a deterministic SSH Host alias from the hostname and
+// repo path. Double-dash separators prevent collisions when repo names
+// contain hyphens (e.g. "org/my-repo" vs "org-my/repo").
+// For example ("github.com", "/org/repo") → "github.com--org--repo".
+func sshHostAlias(host, repoPath string) string {
+	sanitized := strings.TrimPrefix(repoPath, "/")
+	sanitized = strings.ReplaceAll(sanitized, "/", "--")
+	return host + "--" + sanitized
+}
+
+// insteadOfEntries returns .gitconfig url.*.insteadOf blocks that redirect
+// Git SSH URLs through the host alias so that the correct SSH key is used.
+// Both SCP-style (git@host:path) and SSH URL-style (ssh://host/path) are
+// handled. A ".git" suffix is appended to insteadOf values so that Git's
+// prefix-based matching does not accidentally rewrite URLs for repos that
+// share a common prefix (e.g. org/repo vs org/repo-other).
+func insteadOfEntries(alias, host, port, repoPath string) []string {
+	const defaultPort = "22"
+	pathTrimmed := strings.TrimPrefix(repoPath, "/")
+
+	entries := []string{
+		fmt.Sprintf("[url \"git@%s:%s.git\"]\n\tinsteadOf = git@%s:%s.git\n", alias, pathTrimmed, host, pathTrimmed),
+	}
+
+	if port != defaultPort {
+		entries = append(entries,
+			fmt.Sprintf("[url \"ssh://%s/%s.git\"]\n\tinsteadOf = ssh://%s:%s/%s.git\n", alias, pathTrimmed, host, port, pathTrimmed),
+		)
+	} else {
+		entries = append(entries,
+			fmt.Sprintf("[url \"ssh://%s/%s.git\"]\n\tinsteadOf = ssh://%s/%s.git\n", alias, pathTrimmed, host, pathTrimmed),
+		)
+	}
+
+	return entries
 }
 
 type sshEntry struct {

--- a/test/git_credentials_test.go
+++ b/test/git_credentials_test.go
@@ -20,6 +20,9 @@ package test
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
 	"fmt"
 	"net"
 	"os"
@@ -30,6 +33,7 @@ import (
 	"code.gitea.io/sdk/gitea"
 	"github.com/goccy/kpoward"
 	"github.com/tektoncd/pipeline/test/parse"
+	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
@@ -45,6 +49,14 @@ const (
 	multiCredUser2     = "user2"
 	multiCredPassword1 = "password1_ABC123"
 	multiCredPassword2 = "password2_XYZ789"
+
+	sshMultiCredRepo1 = "ssh-private-repo-1"
+	sshMultiCredRepo2 = "ssh-private-repo-2"
+	sshMultiCredOrg   = "ssh-multi-cred-org"
+	sshMultiCredUser1 = "sshuser1"
+	sshMultiCredUser2 = "sshuser2"
+	sshMultiCredPass1 = "sshpassword1_ABC123"
+	sshMultiCredPass2 = "sshpassword2_XYZ789"
 )
 
 // TestGitCredentials_MultipleReposSameHost tests that multiple repositories on the same
@@ -139,6 +151,99 @@ spec:
 	}
 
 	t.Log("TaskRun succeeded - multiple git credentials on same host working correctly")
+}
+
+// TestGitSSHCredentials_MultipleReposSameHost tests that multiple repositories
+// on the same Git host can use different SSH keys. This verifies that SSH Host
+// aliases and Git insteadOf URL rewriting are correctly configured when the
+// credential annotation URL includes a path, enabling per-repo SSH key selection.
+//
+// The test:
+// 1. Creates two private repos with different user credentials and SSH keys
+// 2. Configures repo-specific SSH credential secrets with path-based URLs
+// 3. Verifies that a TaskRun can clone both repos using the correct SSH keys
+//
+// @test:execution=parallel
+func TestGitSSHCredentials_MultipleReposSameHost(t *testing.T) {
+	ctx := t.Context()
+	c, namespace := setup(ctx, t)
+
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	giteaClusterHostname, secretName1, secretName2 := setupGiteaSSHMultiRepo(ctx, t, c, namespace)
+
+	saName := helpers.AppendRandomString("ssh-multi-cred-sa")
+	_, err := c.KubeClient.CoreV1().ServiceAccounts(namespace).Create(ctx, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: namespace,
+		},
+		Secrets: []corev1.ObjectReference{
+			{Name: secretName1},
+			{Name: secretName2},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create ServiceAccount: %v", err)
+	}
+
+	repo1URL := fmt.Sprintf("git@%s:%s/%s.git", giteaClusterHostname, sshMultiCredOrg, sshMultiCredRepo1)
+	repo2URL := fmt.Sprintf("git@%s:%s/%s.git", giteaClusterHostname, sshMultiCredOrg, sshMultiCredRepo2)
+
+	trName := helpers.ObjectNameForTest(t)
+	tr := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  serviceAccountName: %s
+  taskSpec:
+    steps:
+    - name: clone-both-repos
+      image: docker.io/alpine/git:latest
+      script: |
+        #!/usr/bin/env sh
+        set -ex
+
+        echo "=== Checking SSH config (should have Host aliases) ==="
+        cat ~/.ssh/config || echo "No SSH config"
+
+        echo "=== Checking .gitconfig (should have insteadOf entries) ==="
+        cat ~/.gitconfig || echo "No .gitconfig"
+
+        echo "=== Cloning repo1 with SSH key 1 ==="
+        GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone %s /workspace/repo1
+        echo "Successfully cloned repo1"
+        ls -la /workspace/repo1
+
+        echo "=== Cloning repo2 with SSH key 2 ==="
+        GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone %s /workspace/repo2
+        echo "Successfully cloned repo2"
+        ls -la /workspace/repo2
+
+        echo "=== Both repos cloned successfully with different SSH keys ==="
+`,
+		trName,
+		namespace,
+		saName,
+		repo1URL,
+		repo2URL,
+	))
+
+	_, err = c.V1TaskRunClient.Create(ctx, tr, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create TaskRun: %v", err)
+	}
+
+	t.Logf("Waiting for TaskRun %s in namespace %s to complete", trName, namespace)
+	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSuccess", v1Version); err != nil {
+		t.Fatalf("Error waiting for TaskRun %s to finish: %s", trName, err)
+	}
+
+	t.Log("TaskRun succeeded - multiple SSH git credentials on same host working correctly")
 }
 
 // setupGiteaMultiRepo sets up gitea with two private repositories, each with its own user and credentials.
@@ -328,4 +433,222 @@ spec:
 	}
 
 	return giteaInternalHostname, secretName1, secretName2
+}
+
+// generateSSHKeyPair returns a PEM-encoded Ed25519 private key and an
+// authorized_keys-formatted public key.
+func generateSSHKeyPair(t *testing.T) (privateKeyPEM []byte, authorizedKey []byte) {
+	t.Helper()
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+
+	privBytes, err := ssh.MarshalPrivateKey(privKey, "")
+	if err != nil {
+		t.Fatalf("ssh.MarshalPrivateKey: %v", err)
+	}
+	privateKeyPEM = pem.EncodeToMemory(privBytes)
+
+	sshPub, err := ssh.NewPublicKey(pubKey)
+	if err != nil {
+		t.Fatalf("ssh.NewPublicKey: %v", err)
+	}
+	authorizedKey = ssh.MarshalAuthorizedKey(sshPub)
+	return
+}
+
+// setupGiteaSSHMultiRepo creates a gitea instance with two private repos,
+// each accessible by a different user with a unique SSH key. Returns the
+// gitea cluster hostname and the names of the two Kubernetes secrets.
+func setupGiteaSSHMultiRepo(ctx context.Context, t *testing.T, c *clients, namespace string) (string, string, string) {
+	t.Helper()
+
+	giteaYaml, err := os.ReadFile(filepath.Join("git-resolver", "gitea.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read gitea.yaml: %v", err)
+	}
+
+	giteaYaml = defaultNamespaceRE.ReplaceAll(giteaYaml, []byte("namespace: "+namespace))
+	giteaYaml = defaultSvcRE.ReplaceAll(giteaYaml, []byte(fmt.Sprintf(".%s.svc.cluster", namespace)))
+
+	giteaHTTPHostname := fmt.Sprintf("gitea-http.%s.svc.cluster.local", namespace)
+	giteaSSHHostname := fmt.Sprintf("gitea-ssh.%s.svc.cluster.local", namespace)
+
+	kcOutput, err := kubectlCreate(giteaYaml, namespace)
+	if err != nil {
+		t.Logf("failed 'kubectl create' output: %s", string(kcOutput))
+		t.Fatalf("failed to 'kubectl create' for gitea: %v", err)
+	}
+
+	time.Sleep(5 * time.Second)
+	if err := WaitForPodState(ctx, c, "gitea-0", namespace, func(r *corev1.Pod) (bool, error) {
+		if r.Status.Phase == corev1.PodRunning {
+			for _, cs := range r.Status.ContainerStatuses {
+				return cs.Name == "gitea" && cs.State.Running != nil && cs.Ready, nil
+			}
+		}
+		return false, nil
+	}, "PodRunning"); err != nil {
+		t.Fatalf("Error waiting for gitea-0 pod to be running: %v", err)
+	}
+
+	// Create users via admin API (using HTTP service)
+	user1JSON := fmt.Sprintf(`{"admin":false,"email":"%s@example.com","full_name":"%s","login_name":"%s","must_change_password":false,"password":"%s","send_notify":false,"source_id":0,"username":"%s"}`,
+		sshMultiCredUser1, sshMultiCredUser1, sshMultiCredUser1, sshMultiCredPass1, sshMultiCredUser1)
+	user2JSON := fmt.Sprintf(`{"admin":false,"email":"%s@example.com","full_name":"%s","login_name":"%s","must_change_password":false,"password":"%s","send_notify":false,"source_id":0,"username":"%s"}`,
+		sshMultiCredUser2, sshMultiCredUser2, sshMultiCredUser2, sshMultiCredPass2, sshMultiCredUser2)
+
+	trName := helpers.AppendRandomString("ssh-creds-setup-users")
+	setupUsersTaskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  taskSpec:
+    steps:
+    - image: docker.io/alpine/curl
+      script: |
+        #!/bin/ash
+        set -ex
+        curl -X POST "http://gitea_admin:%s@%s:3000/api/v1/admin/users" -H "accept: application/json" -H "Content-Type: application/json" -d '%s'
+        curl -X POST "http://gitea_admin:%s@%s:3000/api/v1/admin/users" -H "accept: application/json" -H "Content-Type: application/json" -d '%s'
+        echo "Users created successfully"
+`,
+		trName, namespace,
+		scmGiteaAdminPassword, giteaHTTPHostname, user1JSON,
+		scmGiteaAdminPassword, giteaHTTPHostname, user2JSON))
+
+	if _, err := c.V1TaskRunClient.Create(ctx, setupUsersTaskRun, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create user setup TaskRun: %s", err)
+	}
+
+	t.Logf("Waiting for user setup TaskRun in namespace %s to succeed", namespace)
+	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSucceed", v1Version); err != nil {
+		t.Fatalf("Error waiting for user setup TaskRun to finish: %s", err)
+	}
+
+	// Generate SSH key pairs for each user
+	privKey1, authKey1 := generateSSHKeyPair(t)
+	privKey2, authKey2 := generateSSHKeyPair(t)
+
+	restCfg, err := knativetest.BuildClientConfig(knativetest.Flags.Kubeconfig, knativetest.Flags.Cluster)
+	if err != nil {
+		t.Fatalf("failed to create configuration obj: %s", err)
+	}
+
+	kpow := kpoward.New(restCfg, "gitea-0", 3000)
+	kpow.SetNamespace(namespace)
+
+	if err := kpow.Run(ctx, func(ctx context.Context, localPort uint16) error {
+		giteaURL := fmt.Sprintf("http://localhost:%d/", localPort)
+
+		adminClient, err := gitea.NewClient(giteaURL, gitea.SetBasicAuth("gitea_admin", scmGiteaAdminPassword))
+		if err != nil {
+			return fmt.Errorf("failed to create admin Gitea client: %w", err)
+		}
+
+		// Create organization
+		_, _, err = adminClient.CreateOrg(gitea.CreateOrgOption{Name: sshMultiCredOrg})
+		if err != nil {
+			return fmt.Errorf("failed to create org %s: %w", sshMultiCredOrg, err)
+		}
+
+		// Create private repos
+		_, _, err = adminClient.CreateOrgRepo(sshMultiCredOrg, gitea.CreateRepoOption{
+			Name: sshMultiCredRepo1, Private: true, AutoInit: true, DefaultBranch: "main",
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create repo1: %w", err)
+		}
+		_, _, err = adminClient.CreateOrgRepo(sshMultiCredOrg, gitea.CreateRepoOption{
+			Name: sshMultiCredRepo2, Private: true, AutoInit: true, DefaultBranch: "main",
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create repo2: %w", err)
+		}
+
+		// Grant access
+		readPerm := gitea.AccessModeRead
+		_, err = adminClient.AddCollaborator(sshMultiCredOrg, sshMultiCredRepo1, sshMultiCredUser1, gitea.AddCollaboratorOption{Permission: &readPerm})
+		if err != nil {
+			return fmt.Errorf("failed to add user1 as collaborator to repo1: %w", err)
+		}
+		_, err = adminClient.AddCollaborator(sshMultiCredOrg, sshMultiCredRepo2, sshMultiCredUser2, gitea.AddCollaboratorOption{Permission: &readPerm})
+		if err != nil {
+			return fmt.Errorf("failed to add user2 as collaborator to repo2: %w", err)
+		}
+
+		// Add SSH public keys for each user
+		user1Client, err := gitea.NewClient(giteaURL, gitea.SetBasicAuth(sshMultiCredUser1, sshMultiCredPass1))
+		if err != nil {
+			return fmt.Errorf("failed to create user1 client: %w", err)
+		}
+		_, _, err = user1Client.CreatePublicKey(gitea.CreateKeyOption{
+			Title:    "test-key-1",
+			Key:      string(authKey1),
+			ReadOnly: true,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add SSH key for user1: %w", err)
+		}
+
+		user2Client, err := gitea.NewClient(giteaURL, gitea.SetBasicAuth(sshMultiCredUser2, sshMultiCredPass2))
+		if err != nil {
+			return fmt.Errorf("failed to create user2 client: %w", err)
+		}
+		_, _, err = user2Client.CreatePublicKey(gitea.CreateKeyOption{
+			Title:    "test-key-2",
+			Key:      string(authKey2),
+			ReadOnly: true,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add SSH key for user2: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to set up gitea org/repos/keys: %v", err)
+	}
+
+	// Create Kubernetes SSH auth secrets with repo-specific annotation URLs
+	secretName1 := helpers.AppendRandomString("ssh-creds-repo1")
+	repo1AnnotationURL := fmt.Sprintf("%s/%s/%s", giteaSSHHostname, sshMultiCredOrg, sshMultiCredRepo1)
+	_, err = c.KubeClient.CoreV1().Secrets(namespace).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName1,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"tekton.dev/git-0": repo1AnnotationURL,
+			},
+		},
+		Type: corev1.SecretTypeSSHAuth,
+		Data: map[string][]byte{
+			corev1.SSHAuthPrivateKey: privKey1,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create SSH secret1: %v", err)
+	}
+
+	secretName2 := helpers.AppendRandomString("ssh-creds-repo2")
+	repo2AnnotationURL := fmt.Sprintf("%s/%s/%s", giteaSSHHostname, sshMultiCredOrg, sshMultiCredRepo2)
+	_, err = c.KubeClient.CoreV1().Secrets(namespace).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName2,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"tekton.dev/git-0": repo2AnnotationURL,
+			},
+		},
+		Type: corev1.SecretTypeSSHAuth,
+		Data: map[string][]byte{
+			corev1.SSHAuthPrivateKey: privKey2,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create SSH secret2: %v", err)
+	}
+
+	return giteaSSHHostname, secretName1, secretName2
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR fixes a bug where multiple Git repositories on the same SSH host could not use different SSH keys. When users linked multiple SSH auth secrets to a ServiceAccount for different repositories on the same Git server (e.g., github.com/org/repo1 and github.com/org/repo2), SSH would use the first key for all repositories since it only matched by hostname, causing authentication failures for deploy-key setups.


The fix introduces SSH Host aliases and Git url.*.insteadOf rewriting when the secret annotation URL includes a repo path:
  1. parseSSHURL() -  Extracts host, port, and optional repo path from annotation URLs
  2. sshHostAlias() - Creates a deterministic SSH Host alias per repo
  3. insteadOfEntries() - Writes .gitconfig insteadOf blocks so Git transparently rewrites clone URLs through the alias, selecting the correct SSH key. Handles both SCP-style (git@host:path) and SSH URL-style (ssh://host/path)
  4. sortedOrder() - Ensures host-only entries appear before repo-specific entries, so host-wide SSH keys act as fallbacks

/kind bug

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed SSH credential matching to support multiple repositories on the same host with different SSH keys. Previously, when using multiple SSH auth secrets for different repositories on the same Git server (e.g., github.com/org/repo1 and github.com/org/repo2), SSH would use the first key for all repositories, causing authentication failures with deploy keys. SSH Host aliases and Git `url.*.insteadOf` rewriting now enable per-repository SSH key selection when the secret annotation URL includes a repo path.
```
