### PR TITLE
docs: fix typo in config feature flags comment

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -126,7 +126,7 @@ data:
   disable-inline-spec: ""
   # Setting this flag to "true" will enable the use of concise resolver syntax
   enable-concise-resolver-syntax: "false"
-  # Setthing this flag to "true" will enable native Kubernetes Sidecar support
+  # Setting this flag to "true" will enable native Kubernetes Sidecar support
   enable-kubernetes-sidecar: "false"
   # Setting this flag to "false" will have no effect since StepActions are a stable feature
   enable-step-actions: "true"


### PR DESCRIPTION
## Summary
- fix typo in `config/config-feature-flags.yaml` comment: `Setthing` -> `Setting`

Fixes #9615

## Validation
- `git diff --check HEAD~1..HEAD`