### PR TITLE
test(e2e): fix flaky matrix and retry example tests

### DIFF
--- a/examples/v1/pipelineruns/beta/pipelinerun-with-matrix.yaml
+++ b/examples/v1/pipelineruns/beta/pipelinerun-with-matrix.yaml
@@ -32,7 +32,6 @@ spec:
             - name: platform
               value:
                 - linux
-                - mac
             - name: browser
               value:
                 - chrome
@@ -45,7 +44,6 @@ spec:
             - name: platform
               value:
                 - linux
-                - mac
         params:
           - name: browser
             value: chrome
@@ -81,7 +79,6 @@ spec:
             - name: version
               value:
                 - "1"
-                - "2"
         taskSpec:
           params:
             - name: version
@@ -100,7 +97,6 @@ spec:
             - name: version
               value:
                 - "1"
-                - "2"
         taskSpec:
           params:
             - name: version

--- a/examples/v1/pipelineruns/beta/using-retries-and-retry-count-variables.yaml
+++ b/examples/v1/pipelineruns/beta/using-retries-and-retry-count-variables.yaml
@@ -8,21 +8,18 @@ spec:
   pipelineSpec:
     tasks:
     - name: retry-me
-      retries: 5
+      retries: 1
       params:
       - name: pipelineTask-retries
         value: "$(context.pipelineTask.retries)"
-      - name: pipelineTask-retry-count
-        value: "$(context.task.retry-count)"
       taskSpec:
         params:
         - name: pipelineTask-retries
-        - name: pipelineTask-retry-count
         steps:
         - image: mirror.gcr.io/alpine
           script: |
             #!/usr/bin/env sh
-            if [ "$(params.pipelineTask-retry-count)" == "$(params.pipelineTask-retries)" ]; then
+            if [ "$(context.task.retry-count)" == "$(params.pipelineTask-retries)" ]; then
               echo "This is the last retry."
               exit 0;
             fi


### PR DESCRIPTION
# Changes

Fix the root cause of timeout in `pipelinerun-with-matrix` and `using-retries-and-retry-count-variables` e2e tests, and move them back from `no-ci/` to `beta/`.

**Two issues fixed:**

1. **`using-retries` test:** `$(context.task.retry-count)` was passed as a pipeline-level param, which doesn't update on retries. Fixed by using the context variable directly in the step script. Also reduced `retries` from 5 to 1 (6 attempts × ~150s pod overhead = 900s, hitting the 15-minute timeout).

2. **`pipelinerun-with-matrix` test:** Reduced matrix dimensions to lower total TaskRun count from 13 to 7, preventing resource pressure timeouts on CI clusters. All matrix features (basic, params, include, empty array, onError, retries) are still covered with fewer combinations.

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [x] Has a kind label (`/kind flake`)
- [x] Release notes block below has been updated
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

Fixes #9201