### PR TITLE
fix: record metrics for cancelled PipelineRuns

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -196,6 +196,9 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 	// Read the initial condition
 	before := pr.Status.GetCondition(apis.ConditionSucceeded)
 
+	// Record the duration and count after the reconcile cycle.
+	defer c.durationAndCountMetrics(ctx, pr, before)
+
 	// Check if we are failing to mark this as timed out for a while. If we are, mark immediately and finish the
 	// reconcile. We are assuming here that if the PipelineRun has timed out for a long time, it had time to run
 	// before and it kept failing. One reason that can happen is exceeding etcd request size limit. Finishing it early
@@ -267,7 +270,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 
 	// Reconcile this copy of the pipelinerun and then write back any status or label
 	// updates regardless of whether the reconciliation errored out.
-	if err = c.reconcile(ctx, pr, getPipelineFunc, before); err != nil {
+	if err = c.reconcile(ctx, pr, getPipelineFunc); err != nil {
 		logger.Errorf("Reconcile error: %v", err.Error())
 	}
 
@@ -456,10 +459,9 @@ func (c *Reconciler) resolvePipelineState(
 	return pst, nil
 }
 
-func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipelineFunc rprp.GetPipeline, beforeCondition *apis.Condition) error {
+func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipelineFunc rprp.GetPipeline) error {
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "reconcile")
 	defer span.End()
-	defer c.durationAndCountMetrics(ctx, pr, beforeCondition)
 	logger := logging.FromContext(ctx)
 	pr.SetDefaults(ctx)
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -58,6 +59,9 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
 	"github.com/tektoncd/pipeline/test/parse"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"gomodules.xyz/jsonpatch/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -120,6 +124,18 @@ var (
 	now       = time.Date(2022, time.January, 1, 0, 0, 0, 0, time.UTC)
 	testClock = clock.NewFakePassiveClock(now)
 )
+
+// testMetricsReader is initialised in TestMain before any test creates a
+// controller, so the pipelinerunmetrics singleton picks up this provider when
+// it calls otel.GetMeterProvider() on first use.
+var testMetricsReader *sdkmetric.ManualReader
+
+func TestMain(m *testing.M) {
+	testMetricsReader = sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(testMetricsReader))
+	otel.SetMeterProvider(provider)
+	os.Exit(m.Run())
+}
 
 type PipelineRunTest struct {
 	test.Data  `json:"inline"`
@@ -1540,6 +1556,119 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 				if !(actionType == "testing.UpdateActionImpl" || actionType == "testing.GetActionImpl") {
 					t.Errorf("Expected a TaskRun to be get/updated, but it was %s", actionType)
 				}
+			}
+		})
+	}
+}
+
+// TestReconcilePipelineRunRecordsMetrics verifies that all three terminal
+// statuses (success, failed, cancelled) are reflected in the
+// tekton_pipelines_controller_pipelinerun_total counter after reconcile.
+func TestReconcilePipelineRunRecordsMetrics(t *testing.T) {
+	countForStatus := func(status string) int64 {
+		var rm metricdata.ResourceMetrics
+		if err := testMetricsReader.Collect(t.Context(), &rm); err != nil {
+			t.Fatalf("failed to collect metrics: %v", err)
+		}
+		for _, sm := range rm.ScopeMetrics {
+			for _, m := range sm.Metrics {
+				if m.Name != "tekton_pipelines_controller_pipelinerun_total" {
+					continue
+				}
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				if !ok {
+					continue
+				}
+				for _, dp := range sum.DataPoints {
+					for _, kv := range dp.Attributes.ToSlice() {
+						if string(kv.Key) == "status" && kv.Value.AsString() == status {
+							return dp.Value
+						}
+					}
+				}
+			}
+		}
+		return 0
+	}
+
+	for _, tc := range []struct {
+		name        string
+		pipelineRun *v1.PipelineRun
+		taskRun     *v1.TaskRun
+		wantStatus  string
+	}{{
+		name: "success",
+		pipelineRun: parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: metrics-pr-success
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  taskRunTemplate:
+    serviceAccountName: test-sa
+status:
+  startTime: "2022-01-01T00:00:00Z"
+  childReferences:
+  - apiVersion: tekton.dev/v1
+    kind: TaskRun
+    name: metrics-pr-success-tr
+    pipelineTaskName: hello-world-1
+`),
+		taskRun: createHelloWorldTaskRunWithStatus(t, "metrics-pr-success-tr", "foo",
+			"metrics-pr-success", "test-pipeline", "",
+			apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionTrue,
+			}),
+		wantStatus: "success",
+	}, {
+		name: "failed",
+		pipelineRun: parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: metrics-pr-failed
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  taskRunTemplate:
+    serviceAccountName: test-sa
+status:
+  startTime: "2022-01-01T00:00:00Z"
+  childReferences:
+  - apiVersion: tekton.dev/v1
+    kind: TaskRun
+    name: metrics-pr-failed-tr
+    pipelineTaskName: hello-world-1
+`),
+		taskRun: createHelloWorldTaskRunWithStatus(t, "metrics-pr-failed-tr", "foo",
+			"metrics-pr-failed", "test-pipeline", "",
+			apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionFalse,
+			}),
+		wantStatus: "failed",
+	}, {
+		name:        "cancelled",
+		pipelineRun: createCancelledPipelineRun(t, "metrics-pr-cancelled", v1.PipelineRunSpecStatusCancelled),
+		taskRun:     createHelloWorldTaskRun(t, "metrics-pr-cancelled-tr", "foo", "metrics-pr-cancelled", "test-pipeline"),
+		wantStatus:  "cancelled",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := test.Data{
+				PipelineRuns: []*v1.PipelineRun{tc.pipelineRun},
+				Pipelines:    []*v1.Pipeline{simpleHelloWorldPipeline},
+				Tasks:        []*v1.Task{simpleHelloWorldTask},
+				TaskRuns:     []*v1.TaskRun{tc.taskRun},
+				ConfigMaps:   th.NewFeatureFlagsConfigMapInSlice(),
+			}
+			prt := newPipelineRunTest(t, d)
+			defer prt.Cancel()
+
+			baseline := countForStatus(tc.wantStatus)
+			prt.reconcileRun("foo", tc.pipelineRun.Name, nil, false)
+			if after := countForStatus(tc.wantStatus); after != baseline+1 {
+				t.Errorf("pipelinerun_total{status=%s}: got %d after reconcile, want %d", tc.wantStatus, after, baseline+1)
 			}
 		})
 	}


### PR DESCRIPTION
durationAndCountMetrics was deferred inside reconcile(), but ReconcileKind short-circuits to cancelPipelineRun() for cancelled PRs without calling reconcile(). Move the defer to ReconcileKind so it fires on all code paths, matching the existing pattern in the TaskRun reconciler.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
