### PR TITLE
docs(examples): remove stale v1beta1 references from examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,17 +16,11 @@ push to from inside your cluster. If you are following instructions
 `$KO_DOCKER_REPO` instead of `gcr.io/christiewilson-catfactory`.
 
 ```bash
-# To invoke the build-push Task only
-kubectl apply -f examples/v1beta1/taskruns/task-output-image.yaml
+# To invoke a TaskRun
+kubectl apply -f examples/v1/taskruns/
 
-# To invoke the simple Pipeline
-kubectl apply -f examples/v1beta1/pipelineruns/pipelinerun.yaml
-
-# To invoke the Pipeline that links outputs
-kubectl apply -f examples/v1beta1/pipelineruns/output-pipelinerun.yaml
-
-# To invoke the TaskRun with embedded Resource spec and task Spec
-kubectl apply -f examples/v1beta1/taskruns/git-resource.yaml
+# To invoke a PipelineRun
+kubectl apply -f examples/v1/pipelineruns/
 ```
 
 ## Results


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Remove dead `v1beta1` code block from `examples/README.md` and replace with current `v1` paths. The `examples/v1beta1/` directory was removed previously, but the README still had `kubectl apply` commands pointing to those old paths — anyone copying them would get a 404.

Fixes #9499

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```