### PR TITLE
[TEP-0137] Move PipelineRun notifications to events controller

### DIFF
--- a/cmd/events/main.go
+++ b/cmd/events/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/tektoncd/pipeline/pkg/reconciler/notifications/customrun"
+	"github.com/tektoncd/pipeline/pkg/reconciler/notifications/pipelinerun"
 	"github.com/tektoncd/pipeline/pkg/reconciler/notifications/taskrun"
 	"knative.dev/pkg/injection/sharedmain"
 )
@@ -50,7 +51,8 @@ func main() {
 	// start the events controllers
 	sharedmain.Main(eventsControllerName,
 		customrun.NewController(),
-		taskrun.NewController())
+		taskrun.NewController(),
+		pipelinerun.NewController())
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {

--- a/docs/events.md
+++ b/docs/events.md
@@ -53,10 +53,10 @@ but the underlying `TaskRun` do.
 When you [configure a sink](./additional-configs.md#configuring-cloudevents-notifications), Tekton emits
 CloudEvents as described in the table below.
 
-CloudEvents for `TaskRun` and `CustomRun` are sent by the dedicated `tekton-events-controller`,
-which watches those resources and sends events independently of the core reconcilers.
-Operators must ensure the `tekton-events-controller` Deployment is running.
-CloudEvents for `PipelineRun` are still sent by the core `pipelinerun` reconciler.
+All CloudEvents are sent by the dedicated `tekton-events-controller`, which watches
+`TaskRun`, `PipelineRun`, and `CustomRun` resources and sends events independently of
+the core reconcilers. Operators must ensure the `tekton-events-controller` Deployment
+is running.
 
 The controller sends cloud events in a parallel routine to allow for retries without blocking
 reconciliation. Retries are sent using an exponential back-off strategy.
@@ -65,42 +65,44 @@ Because of retries, events are not guaranteed to be sent to the target sink in t
 The controller uses an in-memory cache to deduplicate events. In case of controller restart,
 the cache is reset and a small number of duplicate events may be sent.
 
-Resource      |Event    |Event Type                                                 |Sent by
-:-------------|:-------:|:----------------------------------------------------------:|:------
-`TaskRun`     | `Queued` | `dev.tekton.event.taskrun.queued.v1`                     | `tekton-events-controller`
-`TaskRun`     | `Started` | `dev.tekton.event.taskrun.started.v1`                   | `tekton-events-controller`
-`TaskRun`     | `Running` | `dev.tekton.event.taskrun.running.v1`                   | `tekton-events-controller`
-`TaskRun`     | `Condition Change while Running` | `dev.tekton.event.taskrun.unknown.v1`  | `tekton-events-controller`
-`TaskRun`     | `Succeed` | `dev.tekton.event.taskrun.successful.v1`                | `tekton-events-controller`
-`TaskRun`     | `Failed`  | `dev.tekton.event.taskrun.failed.v1`                    | `tekton-events-controller`
-`PipelineRun` | `Started` | `dev.tekton.event.pipelinerun.started.v1`               | core `pipelinerun` reconciler
-`PipelineRun` | `Running` | `dev.tekton.event.pipelinerun.running.v1`               | core `pipelinerun` reconciler
-`PipelineRun` | `Condition Change while Running` | `dev.tekton.event.pipelinerun.unknown.v1` | core `pipelinerun` reconciler
-`PipelineRun` | `Succeed` | `dev.tekton.event.pipelinerun.successful.v1`            | core `pipelinerun` reconciler
-`PipelineRun` | `Failed`  | `dev.tekton.event.pipelinerun.failed.v1`                | core `pipelinerun` reconciler
-`CustomRun`   | `Started` | `dev.tekton.event.customrun.started.v1`                 | `tekton-events-controller`
-`CustomRun`   | `Running` | `dev.tekton.event.customrun.running.v1`                 | `tekton-events-controller`
-`CustomRun`   | `Succeed` | `dev.tekton.event.customrun.successful.v1`              | `tekton-events-controller`
-`CustomRun`   | `Failed`  | `dev.tekton.event.customrun.failed.v1`                  | `tekton-events-controller`
+Resource      |Event                             |Event Type
+:-------------|:--------------------------------:|:---------------------------------------------------------:
+`TaskRun`     | `Queued`                         | `dev.tekton.event.taskrun.queued.v1`
+`TaskRun`     | `Started`                        | `dev.tekton.event.taskrun.started.v1`
+`TaskRun`     | `Running`                        | `dev.tekton.event.taskrun.running.v1`
+`TaskRun`     | `Condition Change while Running` | `dev.tekton.event.taskrun.unknown.v1`
+`TaskRun`     | `Succeed`                        | `dev.tekton.event.taskrun.successful.v1`
+`TaskRun`     | `Failed`                         | `dev.tekton.event.taskrun.failed.v1`
+`PipelineRun` | `Queued`                         | `dev.tekton.event.pipelinerun.queued.v1`
+`PipelineRun` | `Started`                        | `dev.tekton.event.pipelinerun.started.v1`
+`PipelineRun` | `Running`                        | `dev.tekton.event.pipelinerun.running.v1`
+`PipelineRun` | `Condition Change while Running` | `dev.tekton.event.pipelinerun.unknown.v1`
+`PipelineRun` | `Succeed`                        | `dev.tekton.event.pipelinerun.successful.v1`
+`PipelineRun` | `Failed`                         | `dev.tekton.event.pipelinerun.failed.v1`
+`CustomRun`   | `Started`                        | `dev.tekton.event.customrun.started.v1`
+`CustomRun`   | `Running`                        | `dev.tekton.event.customrun.running.v1`
+`CustomRun`   | `Succeed`                        | `dev.tekton.event.customrun.successful.v1`
+`CustomRun`   | `Failed`                         | `dev.tekton.event.customrun.failed.v1`
 
-The `Queued` event is sent when a `TaskRun` has been created but not yet picked up by the
-core reconciler (no `Succeeded` condition set yet). It provides early notification that
-the resource exists and is waiting to be processed.
+The `Queued` event is sent when a `TaskRun` or `PipelineRun` has been created but not yet
+picked up by the core reconciler (no `Succeeded` condition set yet). It provides early
+notification that the resource exists and is waiting to be processed.
 
 CloudEvents are only sent when enabled in the [configuration](./additional-configs.md#configuring-cloudevents-notifications).
 
 ## Delivery visibility
 
 Each send attempt by the `tekton-events-controller` is recorded as a Kubernetes Event on the
-`TaskRun` resource:
+`TaskRun` or `PipelineRun` resource:
 
 - `CloudEventSent`: the event was delivered successfully to the sink.
 - `CloudEventFailed`: the event could not be delivered after retries.
 
-Use `kubectl describe taskrun <name>` to inspect these events.
+Use `kubectl describe taskrun <name>` or `kubectl describe pipelinerun <name>` to inspect these events.
 
-**Note**: `status.cloudEvents` on `TaskRun` is deprecated and is no longer populated by the
-`tekton-events-controller`. Use `kubectl describe` (see above) for delivery visibility instead.
+**Note**: `status.cloudEvents` on `TaskRun` and `PipelineRun` is deprecated and is no longer
+populated by the `tekton-events-controller`. Use `kubectl describe` (see above) for delivery
+visibility instead.
 
 ## Format of `CloudEvents`
 

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller.go
@@ -77,7 +77,11 @@ func EmitCloudEvents(ctx context.Context, object runtime.Object) {
 	}
 }
 
-// EmitCloudEventsWhenConditionChange emits CloudEvents when there is a change in condition
+// EmitCloudEventsWhenConditionChange emits CloudEvents when there is a change in condition.
+//
+// Deprecated: CloudEvents are now sent by the dedicated tekton-events-controller
+// (pkg/reconciler/notifications). This function is no longer called by any core reconciler
+// and will be removed in a future release.
 func EmitCloudEventsWhenConditionChange(ctx context.Context, beforeCondition *apis.Condition, afterCondition *apis.Condition, object runtime.Object) {
 	logger := logging.FromContext(ctx)
 	runObject, ok := object.(v1beta1.RunObject)

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
@@ -128,14 +128,19 @@ func TestSendCloudEventWithRetriesQueued(t *testing.T) {
 	}
 }
 
-// TestSendCloudEventWithRetriesInvalid verifies that objects with no condition
-// and no queued event type defined return an error.
-func TestSendCloudEventWithRetriesInvalid(t *testing.T) {
-	// PipelineRun with nil condition has no queued event type defined yet.
-	ctx := setupFakeContext(t, cloudevent.FakeClientBehaviour{SendSuccessfully: true}, true, 0)
-	err := cloudevent.SendCloudEventWithRetries(ctx, &v1.PipelineRun{Status: v1.PipelineRunStatus{}})
-	if err == nil {
-		t.Fatalf("Expected an error sending cloud events for PipelineRun with no condition, got none")
+// TestSendCloudEventWithRetriesQueuedPipelineRun verifies that a PipelineRun with no condition
+// (not yet picked up by the core reconciler) sends a queued event successfully.
+func TestSendCloudEventWithRetriesQueuedPipelineRun(t *testing.T) {
+	ctx := setupFakeContext(t, cloudevent.FakeClientBehaviour{SendSuccessfully: true}, true, 1)
+	object := &v1.PipelineRun{Status: v1.PipelineRunStatus{}}
+	if err := cloudevent.SendCloudEventWithRetries(ctx, object); err != nil {
+		t.Fatalf("Unexpected error sending queued cloud event: %v", err)
+	}
+	ceClient := cloudevent.Get(ctx).(cloudevent.FakeClient)
+	ceClient.CheckCloudEventsUnordered(t, "queued pipelinerun", []string{"Context Attributes,"})
+	recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
+	if err := k8sevent.CheckEventsOrdered(t, recorder.Events, "queued pipelinerun", []string{"Normal CloudEventSent"}); err != nil {
+		t.Fatal(err.Error())
 	}
 }
 

--- a/pkg/reconciler/events/cloudevent/cloudevent.go
+++ b/pkg/reconciler/events/cloudevent/cloudevent.go
@@ -48,6 +48,9 @@ const (
 	TaskRunSuccessfulEventV1 TektonEventType = "dev.tekton.event.taskrun.successful.v1"
 	// TaskRunFailedEventV1 is sent for TaskRuns with "ConditionSucceeded" "False"
 	TaskRunFailedEventV1 TektonEventType = "dev.tekton.event.taskrun.failed.v1"
+	// PipelineRunQueuedEventV1 is sent for PipelineRuns that have been created but not yet
+	// picked up by the core PipelineRun reconciler (no condition set yet)
+	PipelineRunQueuedEventV1 TektonEventType = "dev.tekton.event.pipelinerun.queued.v1"
 	// PipelineRunStartedEventV1 is sent for PipelineRuns with "ConditionSucceeded" "Unknown"
 	// the first time they are picked up by the reconciler
 	PipelineRunStartedEventV1 TektonEventType = "dev.tekton.event.pipelinerun.started.v1"
@@ -182,6 +185,9 @@ func getEventType(runObject v1beta1.RunObject) (*TektonEventType, error) {
 		switch runObject.(type) {
 		case *v1.TaskRun, *v1beta1.TaskRun:
 			eventType = TaskRunQueuedEventV1
+			return &eventType, nil
+		case *v1.PipelineRun, *v1beta1.PipelineRun:
+			eventType = PipelineRunQueuedEventV1
 			return &eventType, nil
 		case *v1beta1.CustomRun:
 			eventType = CustomRunStartedEventV1

--- a/pkg/reconciler/events/event.go
+++ b/pkg/reconciler/events/event.go
@@ -25,17 +25,16 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-// Emit emits events for object
-// Two types of events are supported, k8s and cloud events.
+// Emit emits events for object.
 //
-// k8s events are always sent if afterCondition is different from beforeCondition
-// Cloud events are always sent if enabled, i.e. if a sink is available
+// k8s events are sent if afterCondition is different from beforeCondition.
 func Emit(ctx context.Context, beforeCondition *apis.Condition, afterCondition *apis.Condition, object runtime.Object) {
 	k8sevent.EmitK8sEvents(ctx, beforeCondition, afterCondition, object)
-	cloudevent.EmitCloudEventsWhenConditionChange(ctx, beforeCondition, afterCondition, object)
 }
 
-// EmitCloudEvents is refactored to cloudevent, this is to avoid breaking change
+// EmitCloudEvents is refactored to cloudevent, this is to avoid breaking change.
+//
+// Deprecated: Use pkg/reconciler/events/cloudevent.EmitCloudEvents directly.
 var EmitCloudEvents = cloudevent.EmitCloudEvents
 
 // EmitError is refactored to k8sevent, this is to avoid breaking change

--- a/pkg/reconciler/events/event_test.go
+++ b/pkg/reconciler/events/event_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events"
-	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/k8sevent"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,55 +52,20 @@ func TestEmit(t *testing.T) {
 		Message: "just starting",
 	}
 	testcases := []struct {
-		name            string
-		defaults        map[string]string
-		events          map[string]string
-		wantEvents      []string
-		wantCloudEvents []string
+		name       string
+		wantEvents []string
 	}{{
-		name:            "without sink",
-		defaults:        map[string]string{},
-		events:          map[string]string{},
-		wantEvents:      []string{"Normal Started"},
-		wantCloudEvents: []string{},
-	}, {
-		name:            "with empty string sink",
-		defaults:        map[string]string{},
-		events:          map[string]string{"sink": ""},
-		wantEvents:      []string{"Normal Started"},
-		wantCloudEvents: []string{},
-	}, {
-		name:            "with sink in events",
-		defaults:        map[string]string{},
-		events:          map[string]string{"sink": "http://mysink"},
-		wantEvents:      []string{"Normal Started", "Normal CloudEventSent"},
-		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.started.v1.*test1`},
-	}, {
-		name:            "with sink in defaults",
-		defaults:        map[string]string{"default-cloud-events-sink": "http://mysink"},
-		events:          map[string]string{},
-		wantEvents:      []string{"Normal Started", "Normal CloudEventSent"},
-		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.started.v1.*test1`},
-	}, {
-		name:            "with sink in both",
-		defaults:        map[string]string{"default-cloud-events-sink": "http://mysink.defaults"},
-		events:          map[string]string{"sink": "http://mysink.events"},
-		wantEvents:      []string{"Normal Started", "Normal CloudEventSent"},
-		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.started.v1.*test1`},
+		name:       "condition change emits k8s event",
+		wantEvents: []string{"Normal Started"},
 	}}
 
 	for _, tc := range testcases {
-		// Setup the context and seed test data
 		ctx, _ := rtesting.SetupFakeContext(t)
-		ctx = cloudevent.WithFakeClient(ctx, &cloudevent.FakeClientBehaviour{SendSuccessfully: true}, len(tc.wantCloudEvents))
-		fakeClient := cloudevent.Get(ctx).(cloudevent.FakeClient)
 
-		// Setup the config and add it to the context
-		eventsConfig, _ := config.NewEventsFromMap(tc.events)
-		defaultsConfig, _ := config.NewDefaultsFromMap(tc.defaults)
+		eventsConfig, _ := config.NewEventsFromMap(map[string]string{"sink": "http://mysink"})
 		cfg := &config.Config{
 			Events:       eventsConfig,
-			Defaults:     defaultsConfig,
+			Defaults:     config.DefaultConfig.DeepCopy(),
 			FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
 		}
 		ctx = config.ToContext(ctx, cfg)
@@ -111,6 +75,5 @@ func TestEmit(t *testing.T) {
 		if err := k8sevent.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
 			t.Fatal(err.Error())
 		}
-		fakeClient.CheckCloudEventsUnordered(t, tc.name, tc.wantCloudEvents)
 	}
 }

--- a/pkg/reconciler/events/event_test.go
+++ b/pkg/reconciler/events/event_test.go
@@ -51,29 +51,21 @@ func TestEmit(t *testing.T) {
 		Status:  corev1.ConditionUnknown,
 		Message: "just starting",
 	}
-	testcases := []struct {
-		name       string
-		wantEvents []string
-	}{{
-		name:       "condition change emits k8s event",
-		wantEvents: []string{"Normal Started"},
-	}}
 
-	for _, tc := range testcases {
-		ctx, _ := rtesting.SetupFakeContext(t)
+	ctx, _ := rtesting.SetupFakeContext(t)
 
-		eventsConfig, _ := config.NewEventsFromMap(map[string]string{"sink": "http://mysink"})
-		cfg := &config.Config{
-			Events:       eventsConfig,
-			Defaults:     config.DefaultConfig.DeepCopy(),
-			FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
-		}
-		ctx = config.ToContext(ctx, cfg)
+	eventsConfig, _ := config.NewEventsFromMap(map[string]string{"sink": "http://mysink"})
+	cfg := &config.Config{
+		Events:       eventsConfig,
+		Defaults:     config.DefaultConfig.DeepCopy(),
+		FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
+	}
+	ctx = config.ToContext(ctx, cfg)
 
-		recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
-		events.Emit(ctx, nil, after, object)
-		if err := k8sevent.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
-			t.Fatal(err.Error())
-		}
+	recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
+	events.Emit(ctx, nil, after, object)
+	wantEvents := []string{"Normal Started"}
+	if err := k8sevent.CheckEventsOrdered(t, recorder.Events, "condition change emits k8s event", wantEvents); err != nil {
+		t.Fatal(err.Error())
 	}
 }

--- a/pkg/reconciler/notifications/pipelinerun/controller.go
+++ b/pkg/reconciler/notifications/pipelinerun/controller.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"context"
+
+	pipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1/pipelinerun"
+	pipelinerunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/pipelinerun"
+	"github.com/tektoncd/pipeline/pkg/reconciler/notifications"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+)
+
+const controllerName = "PipelineRunEvents"
+
+// NewController instantiates a new controller.Impl from knative.dev/pkg/controller
+// This is a read-only controller, hence the SkipStatusUpdates set to true
+func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
+	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+		configStore := notifications.ConfigStoreFromContext(ctx, cmw)
+
+		ceClient, cacheClient := notifications.EventClientsFromContext(ctx)
+		c := NewReconciler(ceClient, cacheClient)
+
+		impl := pipelinerunreconciler.NewImpl(ctx, c, notifications.ControllerOptions(controllerName, configStore))
+
+		pipelineRunInformer := pipelineruninformer.Get(ctx)
+		if _, err := pipelineRunInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue)); err != nil {
+			logging.FromContext(ctx).Panicf("Couldn't register PipelineRun informer event handler: %w", err)
+		}
+
+		return impl
+	}
+}

--- a/pkg/reconciler/notifications/pipelinerun/controller_test.go
+++ b/pkg/reconciler/notifications/pipelinerun/controller_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
+	"github.com/tektoncd/pipeline/pkg/reconciler/notifications/pipelinerun"
+	ntesting "github.com/tektoncd/pipeline/pkg/reconciler/notifications/testing"
+	"github.com/tektoncd/pipeline/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	cminformer "knative.dev/pkg/configmap/informer"
+	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/system"
+	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
+)
+
+func InitializeTestController(t *testing.T, d test.Data, a test.Assets) test.Assets {
+	t.Helper()
+	configMapWatcher := cminformer.NewInformedWatcher(a.Clients.Kube, system.Namespace())
+	ctl := pipelinerun.NewController()(a.Ctx, configMapWatcher)
+	if err := configMapWatcher.Start(a.Ctx.Done()); err != nil {
+		t.Fatalf("error starting configmap watcher: %v", err)
+	}
+
+	if la, ok := ctl.Reconciler.(pkgreconciler.LeaderAware); ok {
+		la.Promote(pkgreconciler.UniversalBucket(), func(pkgreconciler.Bucket, types.NamespacedName) {})
+	}
+	a.Controller = ctl
+	return a
+}
+
+// TestReconcileNewController tests that the controller can be created and reconciles correctly
+func TestReconcileNewController(t *testing.T) {
+	ignoreResourceVersion := cmpopts.IgnoreFields(v1.PipelineRun{}, "ObjectMeta.ResourceVersion")
+
+	cms := []*corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetEventsConfigName(), Namespace: system.Namespace()},
+			Data:       map[string]string{"sink": "http://sink:8080"},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+			Data:       map[string]string{"send-cloudevents-for-runs": "true"},
+		},
+	}
+
+	pr := v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipelinerun",
+			Namespace: "foo",
+		},
+		Status: v1.PipelineRunStatus{
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+					Reason: v1.PipelineRunReasonSuccessful.String(),
+				}},
+			},
+		},
+	}
+	wantCloudEvents := []string{`(?s)dev.tekton.event.pipelinerun.successful.v1.*test-pipelinerun`}
+
+	d := test.Data{
+		PipelineRuns:            []*v1.PipelineRun{&pr},
+		ConfigMaps:              cms,
+		ExpectedCloudEventCount: len(wantCloudEvents),
+	}
+	testAssets, cancel := ntesting.InitializeTestAssets(t, &d)
+	defer cancel()
+	clients := testAssets.Clients
+
+	testAssets = InitializeTestController(t, d, testAssets)
+	c := testAssets.Controller
+
+	if err := c.Reconciler.Reconcile(testAssets.Ctx, ntesting.GetTestResourceName(&pr)); err != nil {
+		t.Errorf("didn't expect an error, but got one: %v", err)
+	}
+
+	for _, a := range clients.Kube.Actions() {
+		aVerb := a.GetVerb()
+		if aVerb != "get" && aVerb != "list" && aVerb != "watch" {
+			t.Errorf("Expected only read actions to be logged in the kubeclient, got %s", aVerb)
+		}
+	}
+
+	prAfter, err := clients.Pipeline.TektonV1().PipelineRuns(pr.Namespace).Get(testAssets.Ctx, pr.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting updated PipelineRun: %v", err)
+	}
+	if d := cmp.Diff(&pr, prAfter, ignoreResourceVersion); d != "" {
+		t.Fatalf("PipelineRun should not have changed, got %v instead", d)
+	}
+
+	ceClient := clients.CloudEvents.(cloudevent.FakeClient)
+	ceClient.CheckCloudEventsUnordered(t, "controller test", wantCloudEvents)
+
+	// Try and reconcile again - expect no event (deduplication via cache)
+	if err := c.Reconciler.Reconcile(testAssets.Ctx, ntesting.GetTestResourceName(&pr)); err != nil {
+		t.Errorf("didn't expect an error, but got one: %v", err)
+	}
+	ceClient.CheckCloudEventsUnordered(t, "controller test duplicate", []string{})
+}

--- a/pkg/reconciler/notifications/pipelinerun/reconciler.go
+++ b/pkg/reconciler/notifications/pipelinerun/reconciler.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"context"
+
+	bc "github.com/allegro/bigcache/v3"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinerunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/pipelinerun"
+	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
+	"github.com/tektoncd/pipeline/pkg/reconciler/notifications"
+	pkgreconciler "knative.dev/pkg/reconciler"
+)
+
+// Reconciler implements controller.Reconciler for PipelineRun resources.
+type Reconciler struct {
+	cloudEventClient cloudevent.CEClient
+	cacheClient      *bc.BigCache
+}
+
+// NewReconciler creates a new Reconciler with the given clients.
+func NewReconciler(ceClient cloudevent.CEClient, cacheClient *bc.BigCache) *Reconciler {
+	return &Reconciler{
+		cloudEventClient: ceClient,
+		cacheClient:      cacheClient,
+	}
+}
+
+func (c *Reconciler) GetCloudEventsClient() cloudevent.CEClient {
+	return c.cloudEventClient
+}
+
+func (c *Reconciler) GetCacheClient() *bc.BigCache {
+	return c.cacheClient
+}
+
+// Check that our Reconciler implements pipelinerunreconciler.Interface
+var _ pipelinerunreconciler.Interface = (*Reconciler)(nil)
+
+// ReconcileKind observes the resource conditions and triggers notifications accordingly.
+func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgreconciler.Event {
+	return notifications.ReconcileRunObject(ctx, c, pr)
+}

--- a/pkg/reconciler/notifications/pipelinerun/reconciler_test.go
+++ b/pkg/reconciler/notifications/pipelinerun/reconciler_test.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
+	"github.com/tektoncd/pipeline/pkg/reconciler/notifications"
+	"github.com/tektoncd/pipeline/pkg/reconciler/notifications/pipelinerun"
+	ntesting "github.com/tektoncd/pipeline/pkg/reconciler/notifications/testing"
+	"github.com/tektoncd/pipeline/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/system"
+	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
+)
+
+var (
+	cmSinkOn = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: config.GetEventsConfigName(), Namespace: system.Namespace()},
+		Data:       map[string]string{"sink": "http://sink:8080"},
+	}
+	cmSinkOff = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: config.GetEventsConfigName(), Namespace: system.Namespace()},
+		Data:       map[string]string{"sink": ""},
+	}
+	cmRunsOn = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+		Data:       map[string]string{"send-cloudevents-for-runs": "true"},
+	}
+	cmRunsOff = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+		Data:       map[string]string{"send-cloudevents-for-runs": "false"},
+	}
+)
+
+// TestReconcileKind_CloudEvents tests cloud event emission for the PipelineRun notifications reconciler
+func TestReconcileKind_CloudEvents(t *testing.T) {
+	ignoreResourceVersion := cmpopts.IgnoreFields(v1.PipelineRun{}, "ObjectMeta.ResourceVersion")
+
+	testcases := []struct {
+		name            string
+		condition       *apis.Condition
+		wantCloudEvents []string
+	}{{
+		name:            "PipelineRun with no condition (queued)",
+		condition:       nil,
+		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.queued.v1.*test-pipelinerun`},
+	}, {
+		name: "PipelineRun with unknown/started condition",
+		condition: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+			Reason: v1.PipelineRunReasonStarted.String(),
+		},
+		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.started.v1.*test-pipelinerun`},
+	}, {
+		name: "PipelineRun with unknown/running condition",
+		condition: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+			Reason: v1.PipelineRunReasonRunning.String(),
+		},
+		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.running.v1.*test-pipelinerun`},
+	}, {
+		name: "PipelineRun with successful condition",
+		condition: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+			Reason: v1.PipelineRunReasonSuccessful.String(),
+		},
+		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.successful.v1.*test-pipelinerun`},
+	}, {
+		name: "PipelineRun with failed condition",
+		condition: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+			Reason: v1.PipelineRunReasonFailed.String(),
+		},
+		wantCloudEvents: []string{`(?s)dev.tekton.event.pipelinerun.failed.v1.*test-pipelinerun`},
+	}}
+
+	cms := []*corev1.ConfigMap{cmSinkOn, cmRunsOn}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			objectStatus := duckv1.Status{
+				Conditions: []apis.Condition{},
+			}
+			if tc.condition != nil {
+				objectStatus.Conditions = append(objectStatus.Conditions, *tc.condition)
+			}
+			pr := v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pipelinerun",
+					Namespace: "foo",
+				},
+				Spec: v1.PipelineRunSpec{},
+				Status: v1.PipelineRunStatus{
+					Status: objectStatus,
+				},
+			}
+			pipelineRuns := []*v1.PipelineRun{&pr}
+
+			d := test.Data{
+				PipelineRuns:            pipelineRuns,
+				ConfigMaps:              cms,
+				ExpectedCloudEventCount: len(tc.wantCloudEvents),
+			}
+			testAssets, cancel := ntesting.InitializeTestAssets(t, &d)
+			defer cancel()
+			clients := testAssets.Clients
+
+			ceClient, cacheClient := notifications.EventClientsFromContext(testAssets.Ctx)
+			reconciler := pipelinerun.NewReconciler(ceClient, cacheClient)
+
+			if err := reconciler.ReconcileKind(testAssets.Ctx, &pr); err != nil {
+				t.Errorf("didn't expect an error, but got one: %v", err)
+			}
+
+			for _, a := range clients.Kube.Actions() {
+				aVerb := a.GetVerb()
+				if aVerb != "get" && aVerb != "list" && aVerb != "watch" {
+					t.Errorf("Expected only read actions to be logged in the kubeclient, got %s", aVerb)
+				}
+			}
+
+			prAfter, err := clients.Pipeline.TektonV1().PipelineRuns(pr.Namespace).Get(testAssets.Ctx, pr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("getting updated pipelineRun: %v", err)
+			}
+			if d := cmp.Diff(&pr, prAfter, ignoreResourceVersion); d != "" {
+				t.Errorf("PipelineRun should not have changed, got %v instead", d)
+			}
+
+			ceClientFake := ceClient.(cloudevent.FakeClient)
+			ceClientFake.CheckCloudEventsUnordered(t, tc.name, tc.wantCloudEvents)
+
+			// Try and reconcile again - expect no event (deduplication via cache)
+			if err := reconciler.ReconcileKind(testAssets.Ctx, &pr); err != nil {
+				t.Errorf("didn't expect an error, but got one: %v", err)
+			}
+			ceClientFake.CheckCloudEventsUnordered(t, tc.name+" (duplicate)", []string{})
+		})
+	}
+}
+
+// TestReconcileKind_RunningAfterQueued tests that when a PipelineRun is first seen in Running
+// state (no prior Started observation), only the running event is sent.
+func TestReconcileKind_RunningAfterQueued(t *testing.T) {
+	cms := []*corev1.ConfigMap{cmSinkOn, cmRunsOn}
+
+	pr := v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipelinerun",
+			Namespace: "foo",
+		},
+		Status: v1.PipelineRunStatus{
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionUnknown,
+					Reason: v1.PipelineRunReasonRunning.String(),
+				}},
+			},
+		},
+	}
+
+	d := test.Data{
+		PipelineRuns:            []*v1.PipelineRun{&pr},
+		ConfigMaps:              cms,
+		ExpectedCloudEventCount: 1,
+	}
+	testAssets, cancel := ntesting.InitializeTestAssets(t, &d)
+	defer cancel()
+
+	ceClient, cacheClient := notifications.EventClientsFromContext(testAssets.Ctx)
+	reconciler := pipelinerun.NewReconciler(ceClient, cacheClient)
+
+	if err := reconciler.ReconcileKind(testAssets.Ctx, &pr); err != nil {
+		t.Errorf("didn't expect an error, but got one: %v", err)
+	}
+
+	ceClientFake := ceClient.(cloudevent.FakeClient)
+	ceClientFake.CheckCloudEventsUnordered(t, "running event", []string{
+		`(?s)dev.tekton.event.pipelinerun.running.v1.*test-pipelinerun`,
+	})
+}
+
+// TestReconcileKind_NoSink tests that no events are sent when no sink is configured
+func TestReconcileKind_NoSink(t *testing.T) {
+	pr := v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipelinerun", Namespace: "foo"},
+		Status: v1.PipelineRunStatus{
+			Status: duckv1.Status{Conditions: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionTrue,
+				Reason: v1.PipelineRunReasonSuccessful.String(),
+			}}},
+		},
+	}
+
+	d := test.Data{
+		PipelineRuns: []*v1.PipelineRun{&pr},
+		ConfigMaps:   []*corev1.ConfigMap{cmSinkOff, cmRunsOn},
+	}
+	testAssets, cancel := ntesting.InitializeTestAssets(t, &d)
+	defer cancel()
+
+	ceClient, cacheClient := notifications.EventClientsFromContext(testAssets.Ctx)
+	reconciler := pipelinerun.NewReconciler(ceClient, cacheClient)
+
+	if err := reconciler.ReconcileKind(testAssets.Ctx, &pr); err != nil {
+		t.Fatalf("didn't expect an error, but got one: %v", err)
+	}
+
+	ceClientFake := ceClient.(cloudevent.FakeClient)
+	ceClientFake.CheckCloudEventsUnordered(t, "no sink", []string{})
+}
+
+// TestReconcileKind_FeatureFlagOff tests that no events are sent when feature flag is off
+func TestReconcileKind_FeatureFlagOff(t *testing.T) {
+	pr := v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipelinerun", Namespace: "foo"},
+		Status: v1.PipelineRunStatus{
+			Status: duckv1.Status{Conditions: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionTrue,
+				Reason: v1.PipelineRunReasonSuccessful.String(),
+			}}},
+		},
+	}
+
+	d := test.Data{
+		PipelineRuns: []*v1.PipelineRun{&pr},
+		ConfigMaps:   []*corev1.ConfigMap{cmSinkOn, cmRunsOff},
+	}
+	testAssets, cancel := ntesting.InitializeTestAssets(t, &d)
+	defer cancel()
+
+	ceClient, cacheClient := notifications.EventClientsFromContext(testAssets.Ctx)
+	reconciler := pipelinerun.NewReconciler(ceClient, cacheClient)
+
+	if err := reconciler.ReconcileKind(testAssets.Ctx, &pr); err != nil {
+		t.Fatalf("didn't expect an error, but got one: %v", err)
+	}
+
+	ceClientFake := ceClient.(cloudevent.FakeClient)
+	ceClientFake.CheckCloudEventsUnordered(t, "feature flag off", []string{})
+}

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -31,7 +31,6 @@ import (
 	resolutionclient "github.com/tektoncd/pipeline/pkg/client/resolution/injection/client"
 	resolutioninformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	"github.com/tektoncd/pipeline/pkg/pipelinerunmetrics"
-	cloudeventclient "github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	resolution "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
 	"github.com/tektoncd/pipeline/pkg/tracing"
@@ -91,7 +90,6 @@ func NewController(opts *pipeline.Options, clock clock.PassiveClock) func(contex
 			taskRunLister:            taskRunInformer.Lister(),
 			customRunLister:          customRunInformer.Lister(),
 			verificationPolicyLister: verificationpolicyInformer.Lister(),
-			cloudEventClient:         cloudeventclient.Get(ctx),
 			metrics:                  pipelinerunmetricsRecorder,
 			pvcHandler:               volumeclaim.NewPVCHandler(kubeclientset, logger),
 			resolutionRequester:      resolution.NewCRDRequester(resolutionclient.Get(ctx), resolutionInformer.Lister()),

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -47,7 +47,6 @@ import (
 	tknreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events"
-	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	rprp "github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/pipelinespec"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
@@ -166,7 +165,6 @@ type Reconciler struct {
 	taskRunLister            listers.TaskRunLister
 	customRunLister          beta1listers.CustomRunLister
 	verificationPolicyLister alpha1listers.VerificationPolicyLister
-	cloudEventClient         cloudevent.CEClient
 	metrics                  *pipelinerunmetrics.Recorder
 	pvcHandler               volumeclaim.PvcHandler
 	resolutionRequester      resolution.Requester
@@ -184,7 +182,6 @@ var (
 // resource with the current status of the resource.
 func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
-	ctx = cloudevent.ToContext(ctx, c.cloudEventClient)
 	ctx = initTracing(ctx, c.tracerProvider, pr)
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "PipelineRun:ReconcileKind")
 	defer span.End()

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -42,7 +42,6 @@ import (
 	resolutionv1beta1 "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/internal/affinityassistant"
 	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
-	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/k8sevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
@@ -156,7 +155,6 @@ func getPipelineRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 func initializePipelineRunControllerAssets(t *testing.T, d test.Data, opts pipeline.Options) (test.Assets, func()) {
 	t.Helper()
 	ctx, _ := th.SetupFakeContext(t)
-	ctx = th.SetupFakeCloudClientContext(ctx, d.ExpectedCloudEventCount)
 	ctx, cancel := context.WithCancel(ctx)
 	test.EnsureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
@@ -8508,97 +8506,6 @@ func getTaskRunStatus(t string, status corev1.ConditionStatus) *v1.PipelineRunTa
 	}
 }
 
-// TestReconcile_CloudEvents runs reconcile with a cloud event sink configured
-// to ensure that events are sent in different cases
-func TestReconcile_CloudEvents(t *testing.T) {
-	names.TestingSeed()
-
-	prs := []*v1.PipelineRun{
-		parse.MustParseV1PipelineRun(t, `
-metadata:
-  name: test-pipelinerun
-  namespace: foo
-  selfLink: /pipeline/1234
-spec:
-  pipelineRef:
-    name: test-pipeline
-`),
-	}
-	ps := []*v1.Pipeline{
-		parse.MustParseV1Pipeline(t, `
-metadata:
-  name: test-pipeline
-  namespace: foo
-spec:
-  tasks:
-    - name: test-1
-      taskRef:
-        name: test-task
-`),
-	}
-	ts := []*v1.Task{
-		parse.MustParseV1Task(t, `
-metadata:
-  name: test-task
-  namespace: foo
-spec:
-  steps:
-    - name: simple-step
-      image: foo
-      command: ["/mycmd"]
-      env:
-       - name: foo
-         value: bar
-`),
-	}
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetDefaultsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"default-cloud-events-sink": "http://synk:8080",
-			},
-		},
-	}
-	t.Logf("config maps: %s", cms)
-
-	d := test.Data{
-		PipelineRuns:            prs,
-		Pipelines:               ps,
-		Tasks:                   ts,
-		ConfigMaps:              cms,
-		ExpectedCloudEventCount: 2,
-	}
-	prt := newPipelineRunTest(t, d)
-	defer prt.Cancel()
-
-	// Reconcile without checking k8s events yet — cloud events are sent asynchronously
-	// and their "CloudEventSent" k8s recorder events may interleave with status events.
-	reconciledRun, clients := prt.reconcileRun("foo", "test-pipelinerun", nil, false)
-
-	// This PipelineRun is in progress now and the status should reflect that
-	th.CheckPipelineRunConditionStatusAndReason(t, reconciledRun.Status, corev1.ConditionUnknown, v1.PipelineRunReasonRunning.String())
-
-	th.VerifyTaskRunStatusesCount(t, reconciledRun.Status, 1)
-
-	wantCloudEvents := []string{
-		`(?s)dev.tekton.event.pipelinerun.started.v1.*test-pipelinerun`,
-		`(?s)dev.tekton.event.pipelinerun.running.v1.*test-pipelinerun`,
-	}
-	ceClient := clients.CloudEvents.(cloudevent.FakeClient)
-	// Wait for all cloud event goroutines to finish before checking k8s events,
-	// so that "CloudEventSent" recorder events are already in the channel.
-	ceClient.CheckCloudEventsUnordered(t, "reconcile-cloud-events", wantCloudEvents)
-
-	wantEvents := []string{
-		"Normal Started",
-		"Normal CloudEventSent Sent dev.tekton.event.pipelinerun.started.v1",
-		"Normal Running Tasks Completed: 0",
-		"Normal CloudEventSent Sent dev.tekton.event.pipelinerun.running.v1",
-	}
-	if err := k8sevent.CheckEventsOrdered(t, prt.TestAssets.Recorder.Events, "test-pipelinerun", wantEvents); err != nil {
-		t.Error(err.Error())
-	}
-}
 
 // this test validates taskSpec metadata is embedded into task run
 func TestReconcilePipeline_TaskSpecMetadata(t *testing.T) {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -400,7 +400,6 @@ func getTaskRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 func initializeTaskRunControllerAssets(t *testing.T, d test.Data, opts pipeline.Options) (test.Assets, func()) {
 	t.Helper()
 	ctx, _ := ttesting.SetupFakeContext(t)
-	ctx = ttesting.SetupFakeCloudClientContext(ctx, d.ExpectedCloudEventCount)
 	ctx, cancel := context.WithCancel(ctx)
 	test.EnsureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
@@ -573,9 +572,6 @@ spec:
 	d := test.Data{
 		Tasks:    []*v1.Task{task},
 		TaskRuns: []*v1.TaskRun{taskRun},
-		// No CE sink configured: the core reconciler no longer injects a CE client,
-		// so no cloud events should be sent even if the test infra wires one up.
-		ExpectedCloudEventCount: 0,
 	}
 
 	testAssets, cancel := getTaskRunController(t, d)


### PR DESCRIPTION
# Dependencies (stacked):

- [x] #9674
- [x] #6914
- [x] #6889

Once the dependency is merged, the PR will contain 1 commit only.

# Future PRs

- [ ] Deprecate `send-cloudevents-for-runs` config flag
- [ ] Add `formats` to `config-events`, in preparation for additional event formats
- [ ] Add CDEvents support
- [ ] Add Tekton v2 support (with v1 resources)

# Changes

Add PipelineRun notifications controller; remove CloudEvents from core PipelineRun reconciler.

- Add `PipelineRunQueuedEventV1` event type; fire it for PipelineRuns with no condition set yet
- Add `pkg/reconciler/notifications/pipelinerun` reconciler and controller
- Register `pipelinerun.NewController()` in `cmd/events/main.go`
- Remove `cloudEventClient` from core PipelineRun reconciler; use `events.Emit` for k8s events only (consistent with TaskRun)
- Add tests for PipelineRun notifications reconciler and controller

Now that both TaskRun and PipelineRun CloudEvents are managed by the dedicated `tekton-events-controller`:

- `events.Emit`: remove `EmitCloudEventsWhenConditionChange` call; now emits k8s events only
- `cloudevent.EmitCloudEventsWhenConditionChange`: deprecated, no longer called by any core reconciler
- `cloudevent.GetCloudEventDeliveryCompareOptions`: deprecated, `status.cloudEvents` no longer populated
- `events.EmitCloudEvents`: deprecated alias
- Core reconciler tests (`pipelinerun_test.go`, `taskrun_test.go`, `event_test.go`): remove CE test infrastructure; CloudEvent behaviour is tested in `pkg/reconciler/notifications/`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required: CloudEvents for PipelineRuns are now sent by the dedicated
tekton-events-controller and no longer by the PipelineRun controller.
Operators must ensure the tekton-events-controller Deployment is running.

A new dev.tekton.event.pipelinerun.queued.v1 event is sent when a PipelineRun
is created but not yet processed by the core reconciler.

CloudEvent delivery visibility is available via
`kubectl describe pipelinerun` (CloudEventSent/CloudEventFailed k8s Events).
```

/kind feature