### PR TITLE
docs: clarify retry-count substitution behavior with taskRef

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1242,6 +1242,10 @@ parameter of `PipelineTask`. Variables like `context.pipelineTask.retries` and
 `context.pipelineTask.retries` will be replaced by `retries` of the `PipelineTask`, while
 `context.task.retry-count` will be replaced by current retry number of the `PipelineTask`.
 
+**Note:** `context.task.retry-count` is currently substituted when the `PipelineTask`
+uses an inline `taskSpec`. When a `PipelineTask` uses `taskRef`, this variable is not
+resolved and remains a literal string (for example, `$(context.task.retry-count)`).
+
 ```yaml
 params:
 - name: pipelineTask-retries


### PR DESCRIPTION
## Summary
- clarify that `context.task.retry-count` is substituted for inline `taskSpec`
- document that the same variable is currently not resolved when the `PipelineTask` uses `taskRef`
- include a concrete literal example to set expectations for authors

Fixes #7063

## Testing
- `git diff --check`
