### PR TITLE
test: add e2e test for TaskRun pending status

### DIFF
--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -708,3 +708,70 @@ spec:
 		t.Fatalf("-got, +want: %v", d)
 	}
 }
+
+// TestTaskRunPending tests that a Pending TaskRun is not run until the pending
+// status is cleared. This mirrors TestPipelineRunPending for PipelineRun.
+// @test:execution=parallel
+func TestTaskRunPending(t *testing.T) {
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t)
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	trName := helpers.ObjectNameForTest(t)
+
+	t.Logf("Creating Pending TaskRun %s in namespace %s", trName, namespace)
+
+	if _, err := c.V1TaskRunClient.Create(ctx, parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  taskSpec:
+    steps:
+    - image: mirror.gcr.io/busybox
+      command: ['/bin/sh']
+      args: ['-c', 'echo hello, world']
+  status: TaskRunPending
+`, trName, namespace)), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create TaskRun `%s`: %s", trName, err)
+	}
+
+	t.Logf("Waiting for TaskRun %s in namespace %s to be marked pending", trName, namespace)
+	if err := WaitForTaskRunState(ctx, c, trName, TaskRunPending(trName), "TaskRunPending", v1Version); err != nil {
+		t.Fatalf("Error waiting for TaskRun %s to be marked pending: %s", trName, err)
+	}
+
+	t.Logf("Verifying TaskRun %s has no start time and no pod while pending", trName)
+	taskRun, err := c.V1TaskRunClient.Get(ctx, trName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting TaskRun %s: %s", trName, err)
+	}
+	if taskRun.Status.StartTime != nil {
+		t.Fatalf("Expected start time to be nil while pending, got: %s", taskRun.Status.StartTime)
+	}
+
+	pods, err := c.KubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "tekton.dev/taskRun=" + trName,
+	})
+	if err != nil {
+		t.Fatalf("Error listing pods for TaskRun %s: %s", trName, err)
+	}
+	if len(pods.Items) != 0 {
+		t.Fatalf("Expected no pods while TaskRun is pending, got %d", len(pods.Items))
+	}
+
+	t.Logf("Clearing pending status on TaskRun %s", trName)
+	taskRun.Spec.Status = ""
+	if _, err := c.V1TaskRunClient.Update(ctx, taskRun, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Error clearing pending status on TaskRun %s: %s", trName, err)
+	}
+
+	t.Logf("Waiting for TaskRun %s in namespace %s to complete", trName, namespace)
+	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSuccess", v1Version); err != nil {
+		t.Fatalf("Error waiting for TaskRun %s to finish: %s", trName, err)
+	}
+}

--- a/test/wait.go
+++ b/test/wait.go
@@ -50,7 +50,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.opentelemetry.io/otel"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -316,6 +316,31 @@ func TaskRunFailed(name string) ConditionAccessorFn {
 	return Failed(name)
 }
 
+// TaskRunPending provides a poll condition function that checks if the TaskRun
+// has been marked pending by the Tekton controller. If the TaskRun starts
+// running before we observe the pending state, an error is returned.
+func TaskRunPending(name string) ConditionAccessorFn {
+	running := Running(name)
+
+	return func(ca apis.ConditionAccessor) (bool, error) {
+		c := ca.GetCondition(apis.ConditionSucceeded)
+		if c != nil {
+			if c.Status == corev1.ConditionUnknown && c.Reason == string(v1.TaskRunReasonPending) {
+				return true, nil
+			}
+		}
+		status, err := running(ca)
+		if status {
+			reason := ""
+			if c != nil {
+				reason = c.Reason
+			}
+			return false, fmt.Errorf("status should be %s, but it is %s", v1.TaskRunReasonPending, reason)
+		}
+		return status, err
+	}
+}
+
 // PipelineRunSucceed provides a poll condition function that checks if the PipelineRun
 // has successfully completed.
 func PipelineRunSucceed(name string) ConditionAccessorFn {
@@ -336,7 +361,7 @@ func PipelineRunPending(name string) ConditionAccessorFn {
 	return func(ca apis.ConditionAccessor) (bool, error) {
 		c := ca.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
-			if c.Status == corev1.ConditionUnknown && c.Reason == string(v1beta1.PipelineRunReasonPending) {
+			if c.Status == corev1.ConditionUnknown && c.Reason == string(v1.PipelineRunReasonPending) {
 				return true, nil
 			}
 		}
@@ -347,7 +372,7 @@ func PipelineRunPending(name string) ConditionAccessorFn {
 			if c != nil {
 				reason = c.Reason
 			}
-			return false, fmt.Errorf("status should be %s, but it is %s", v1beta1.PipelineRunReasonPending, reason)
+			return false, fmt.Errorf("status should be %s, but it is %s", v1.PipelineRunReasonPending, reason)
 		}
 		return status, err
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add `TestTaskRunPending` e2e test that mirrors the existing `TestPipelineRunPending`
test for PipelineRun (#9464). The test verifies the full lifecycle:

1. Creates a TaskRun with `status: TaskRunPending`
2. Verifies it enters the Pending state with no StartTime set
3. Clears the pending status
4. Verifies the TaskRun completes successfully

Also adds `TaskRunPending` condition function to `test/wait.go` for polling.

/kind feature

# Submitter Checklist

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [x] Has a kind label
- [x] Release notes block below has been updated

# Release Notes

```release-note
NONE
```