### PR TITLE
docs: document Operator performance config for controller HA

### DIFF
--- a/docs/enabling-ha.md
+++ b/docs/enabling-ha.md
@@ -49,6 +49,8 @@ Leader election can be configured in [config-leader-election.yaml](./../config/c
 
 _Note_: The maximum value of `data.buckets` at this time is 10.
 
+When the controller is installed through the [Tekton Operator](https://github.com/tektoncd/operator), configure these high-availability settings through the `TektonConfig` `spec.pipeline.performance` field instead of editing the controller or the ConfigMap directly. That field exposes `replicas`, `buckets`, `disable-ha`, `threads-per-controller`, and `statefulset-ordinals`, the last of which runs the controller as a StatefulSet with the load spread evenly across replicas. See the Operator's [performance properties](https://github.com/tektoncd/operator/blob/main/docs/TektonPipeline.md#performance-properties) and the [Performance Configuration](./tekton-controller-performance-configuration.md) guide for details.
+
 ### Disabling Controller HA
 
 If HA is not required, you can disable it by scaling the deployment back to one replica. You can also modify the [controller deployment](./../config/controller.yaml), by specifying in the `tekton-pipelines-controller` container the `disable-ha` flag. For example:


### PR DESCRIPTION
# Changes

Document horizontal controller scaling via Knative's bucket-based leader election in `docs/enabling-ha.md`, including the StatefulSet approach for environments without the Tekton Operator as discussed with @vdemeester.

Covers:
- How bucket-based leader election distributes reconciliation work
- Scaling with a Deployment (buckets + replicas config)
- Scaling with a StatefulSet without the Tekton Operator
- Bucket-to-replica ratio guidelines
- Rebalancing behavior and caveats
- Same mechanism for webhook and events controllers

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [x] Has a kind label (`/kind documentation`)
- [x] Release notes block below has been updated
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

Fixes #9670