### PR TITLE
fix: end root tracing span at reconciliation completion

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -184,7 +184,8 @@ var (
 // resource with the current status of the resource.
 func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
-	ctx = initTracing(ctx, c.tracerProvider, pr)
+	ctx, rootSpan := initTracing(ctx, c.tracerProvider, pr)
+	defer rootSpan.End()
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "PipelineRun:ReconcileKind")
 	defer span.End()
 

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -190,7 +190,8 @@ var (
 // resource with the current status of the resource.
 func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
-	ctx = initTracing(ctx, c.tracerProvider, pr)
+	ctx, rootSpan := initTracing(ctx, c.tracerProvider, pr)
+	defer rootSpan.End()
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "PipelineRun:ReconcileKind")
 	defer span.End()
 

--- a/pkg/reconciler/pipelinerun/tracing.go
+++ b/pkg/reconciler/pipelinerun/tracing.go
@@ -39,15 +39,17 @@ const (
 	TaskRunSpanContextAnnotation = "tekton.dev/taskrunSpanContext"
 )
 
-// initialize tracing by creating the root span and injecting the
-// spanContext is propagated through annotations in the CR
-func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, pr *v1.PipelineRun) context.Context {
+// initTracing initializes tracing by creating or restoring the root span.
+// It persists the span context in status and restores parent context propagated
+// through annotations. The caller is responsible for ending the returned span.
+func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, pr *v1.PipelineRun) (context.Context, trace.Span) {
 	logger := logging.FromContext(ctx)
 	pro := otel.GetTextMapPropagator()
+	noopSpan := trace.SpanFromContext(context.Background())
 
 	// SpanContext was created already
 	if len(pr.Status.SpanContext) > 0 {
-		return pro.Extract(ctx, propagation.MapCarrier(pr.Status.SpanContext))
+		return pro.Extract(ctx, propagation.MapCarrier(pr.Status.SpanContext)), noopSpan
 	}
 
 	spanContext := make(map[string]string)
@@ -60,12 +62,11 @@ func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, pr *v
 		}
 
 		pr.Status.SpanContext = spanContext
-		return pro.Extract(ctx, propagation.MapCarrier(pr.Status.SpanContext))
+		return pro.Extract(ctx, propagation.MapCarrier(pr.Status.SpanContext)), noopSpan
 	}
 
 	// Create a new root span since there was no parent spanContext provided through annotations
 	ctxWithTrace, span := tracerProvider.Tracer(TracerName).Start(ctx, "PipelineRun:Reconciler")
-	defer span.End()
 	span.SetAttributes(attribute.String("pipelinerun", pr.Name), attribute.String("namespace", pr.Namespace))
 
 	pro.Inject(ctxWithTrace, propagation.MapCarrier(spanContext))
@@ -73,12 +74,13 @@ func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, pr *v
 	logger.Debug("got tracing carrier", spanContext)
 	if len(spanContext) == 0 {
 		logger.Debug("tracerProvider doesn't provide a traceId, tracing is disabled")
-		return ctx
+		span.End()
+		return ctx, noopSpan
 	}
 
 	span.AddEvent("updating PipelineRun status with SpanContext")
 	pr.Status.SpanContext = spanContext
-	return ctxWithTrace
+	return ctxWithTrace, span
 }
 
 // Extract spanContext from the context and return it as json encoded string

--- a/pkg/reconciler/pipelinerun/tracing.go
+++ b/pkg/reconciler/pipelinerun/tracing.go
@@ -39,15 +39,17 @@ const (
 	TaskRunSpanContextAnnotation = "tekton.dev/taskrunSpanContext"
 )
 
-// initialize tracing by creating the root span and injecting the
-// spanContext is propagated through annotations in the CR
-func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, pr *v1.PipelineRun) context.Context {
+// initTracing initializes tracing by creating or restoring the root span.
+// It persists the span context in status and restores parent context propagated
+// through annotations. The caller is responsible for ending the returned span.
+func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, pr *v1.PipelineRun) (context.Context, trace.Span) {
 	logger := logging.FromContext(ctx)
 	pro := otel.GetTextMapPropagator()
+	noopSpan := trace.SpanFromContext(ctx)
 
 	// SpanContext was created already
 	if len(pr.Status.SpanContext) > 0 {
-		return pro.Extract(ctx, propagation.MapCarrier(pr.Status.SpanContext))
+		return pro.Extract(ctx, propagation.MapCarrier(pr.Status.SpanContext)), noopSpan
 	}
 
 	spanContext := make(map[string]string)
@@ -60,12 +62,11 @@ func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, pr *v
 		}
 
 		pr.Status.SpanContext = spanContext
-		return pro.Extract(ctx, propagation.MapCarrier(pr.Status.SpanContext))
+		return pro.Extract(ctx, propagation.MapCarrier(pr.Status.SpanContext)), noopSpan
 	}
 
 	// Create a new root span since there was no parent spanContext provided through annotations
 	ctxWithTrace, span := tracerProvider.Tracer(TracerName).Start(ctx, "PipelineRun:Reconciler")
-	defer span.End()
 	span.SetAttributes(attribute.String("pipelinerun", pr.Name), attribute.String("namespace", pr.Namespace))
 
 	pro.Inject(ctxWithTrace, propagation.MapCarrier(spanContext))
@@ -73,12 +74,13 @@ func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, pr *v
 	logger.Debug("got tracing carrier", spanContext)
 	if len(spanContext) == 0 {
 		logger.Debug("tracerProvider doesn't provide a traceId, tracing is disabled")
-		return ctx
+		span.End()
+		return ctx, noopSpan
 	}
 
 	span.AddEvent("updating PipelineRun status with SpanContext")
 	pr.Status.SpanContext = spanContext
-	return ctxWithTrace
+	return ctxWithTrace, span
 }
 
 // Extract spanContext from the context and return it as json encoded string

--- a/pkg/reconciler/pipelinerun/tracing.go
+++ b/pkg/reconciler/pipelinerun/tracing.go
@@ -45,7 +45,7 @@ const (
 func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, pr *v1.PipelineRun) (context.Context, trace.Span) {
 	logger := logging.FromContext(ctx)
 	pro := otel.GetTextMapPropagator()
-	noopSpan := trace.SpanFromContext(ctx)
+	noopSpan := trace.SpanFromContext(context.Background())
 
 	// SpanContext was created already
 	if len(pr.Status.SpanContext) > 0 {

--- a/pkg/reconciler/pipelinerun/tracing_test.go
+++ b/pkg/reconciler/pipelinerun/tracing_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 func TestInitTracing(t *testing.T) {
+	oldPropagator := otel.GetTextMapPropagator()
 	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(oldPropagator) })
 
 	testcases := []struct {
 		name                    string
@@ -121,7 +123,10 @@ func TestInitTracing(t *testing.T) {
 }
 
 func TestInitTracingRootSpanLifecycle(t *testing.T) {
+	oldPropagator := otel.GetTextMapPropagator()
 	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(oldPropagator) })
+
 	exporter := tracetest.NewInMemoryExporter()
 	tracerProvider := tracesdk.NewTracerProvider(tracesdk.WithSyncer(exporter))
 	defer func() { _ = tracerProvider.Shutdown(t.Context()) }()

--- a/pkg/reconciler/pipelinerun/tracing_test.go
+++ b/pkg/reconciler/pipelinerun/tracing_test.go
@@ -124,7 +124,7 @@ func TestInitTracingRootSpanLifecycle(t *testing.T) {
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 	exporter := tracetest.NewInMemoryExporter()
 	tracerProvider := tracesdk.NewTracerProvider(tracesdk.WithSyncer(exporter))
-	defer tracerProvider.Shutdown(t.Context())
+	defer func() { _ = tracerProvider.Shutdown(t.Context()) }()
 
 	pr := &v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "testns"}}
 	_, span := initTracing(t.Context(), tracerProvider, pr)

--- a/pkg/reconciler/pipelinerun/tracing_test.go
+++ b/pkg/reconciler/pipelinerun/tracing_test.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -90,7 +91,8 @@ func TestInitTracing(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			pr := tc.pipelineRun
-			ctx := initTracing(t.Context(), tc.tracerProvider, pr)
+			ctx, span := initTracing(t.Context(), tc.tracerProvider, pr)
+			defer span.End()
 
 			if ctx == nil {
 				t.Fatalf("returned nil context from initTracing")
@@ -115,5 +117,28 @@ func TestInitTracing(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestInitTracingRootSpanLifecycle(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	exporter := tracetest.NewInMemoryExporter()
+	tracerProvider := tracesdk.NewTracerProvider(tracesdk.WithSyncer(exporter))
+	defer tracerProvider.Shutdown(t.Context())
+
+	pr := &v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "testns"}}
+	_, span := initTracing(t.Context(), tracerProvider, pr)
+
+	if got := exporter.GetSpans(); len(got) != 0 {
+		t.Fatalf("root span exported before caller ended it: got %d spans", len(got))
+	}
+
+	span.End()
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("exported spans = %d, want 1", len(spans))
+	}
+	if spans[0].Name != "PipelineRun:Reconciler" {
+		t.Fatalf("exported span name = %q, want PipelineRun:Reconciler", spans[0].Name)
 	}
 }

--- a/pkg/reconciler/pipelinerun/tracing_test.go
+++ b/pkg/reconciler/pipelinerun/tracing_test.go
@@ -20,17 +20,25 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestInitTracing(t *testing.T) {
+	oldPropagator := otel.GetTextMapPropagator()
 	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(oldPropagator) })
+
+	exporter := tracetest.NewInMemoryExporter()
+	tracerProvider := tracesdk.NewTracerProvider(tracesdk.WithSyncer(exporter))
+	defer func() { _ = tracerProvider.Shutdown(t.Context()) }()
 
 	testcases := []struct {
 		name                    string
 		pipelineRun             *v1.PipelineRun
 		tracerProvider          trace.TracerProvider
+		exporter                *tracetest.InMemoryExporter
 		expectSpanContextStatus bool
 		expectValidSpanContext  bool
 		parentTraceID           string
@@ -42,7 +50,8 @@ func TestInitTracing(t *testing.T) {
 				Namespace: "testns",
 			},
 		},
-		tracerProvider:          tracesdk.NewTracerProvider(),
+		tracerProvider:          tracerProvider,
+		exporter:                exporter,
 		expectSpanContextStatus: true,
 		expectValidSpanContext:  true,
 	}, {
@@ -90,7 +99,24 @@ func TestInitTracing(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			pr := tc.pipelineRun
-			ctx := initTracing(t.Context(), tc.tracerProvider, pr)
+			ctx, span := initTracing(t.Context(), tc.tracerProvider, pr)
+
+			if tc.exporter != nil {
+				if got := tc.exporter.GetSpans(); len(got) != 0 {
+					t.Fatalf("root span exported before caller ended it: got %d spans", len(got))
+				}
+			}
+
+			span.End()
+			if tc.exporter != nil {
+				spans := tc.exporter.GetSpans()
+				if len(spans) != 1 {
+					t.Fatalf("exported spans = %d, want 1", len(spans))
+				}
+				if spans[0].Name != "PipelineRun:Reconciler" {
+					t.Fatalf("exported span name = %q, want PipelineRun:Reconciler", spans[0].Name)
+				}
+			}
 
 			if ctx == nil {
 				t.Fatalf("returned nil context from initTracing")

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -131,7 +131,8 @@ var (
 // resource with the current status of the resource.
 func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
-	ctx = initTracing(ctx, c.tracerProvider, tr)
+	ctx, rootSpan := initTracing(ctx, c.tracerProvider, tr)
+	defer rootSpan.End()
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "TaskRun:ReconcileKind")
 	defer span.End()
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -136,7 +136,8 @@ var (
 // resource with the current status of the resource.
 func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
-	ctx = initTracing(ctx, c.tracerProvider, tr)
+	ctx, rootSpan := initTracing(ctx, c.tracerProvider, tr)
+	defer rootSpan.End()
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "TaskRun:ReconcileKind")
 	defer span.End()
 

--- a/pkg/reconciler/taskrun/tracing.go
+++ b/pkg/reconciler/taskrun/tracing.go
@@ -41,7 +41,7 @@ const (
 func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, tr *v1.TaskRun) (context.Context, trace.Span) {
 	logger := logging.FromContext(ctx)
 	pro := otel.GetTextMapPropagator()
-	noopSpan := trace.SpanFromContext(ctx)
+	noopSpan := trace.SpanFromContext(context.Background())
 
 	// SpanContext was created already
 	if len(tr.Status.SpanContext) > 0 {

--- a/pkg/reconciler/taskrun/tracing.go
+++ b/pkg/reconciler/taskrun/tracing.go
@@ -35,15 +35,17 @@ const (
 	SpanContextAnnotation = "tekton.dev/taskrunSpanContext"
 )
 
-// initialize tracing by creating the root span and injecting the
-// spanContext is propogated through annotations in the CR
-func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, tr *v1.TaskRun) context.Context {
+// initTracing initializes tracing by creating or restoring the root span.
+// It persists the span context in status and restores parent context propagated
+// through annotations. The caller is responsible for ending the returned span.
+func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, tr *v1.TaskRun) (context.Context, trace.Span) {
 	logger := logging.FromContext(ctx)
 	pro := otel.GetTextMapPropagator()
+	noopSpan := trace.SpanFromContext(ctx)
 
 	// SpanContext was created already
 	if len(tr.Status.SpanContext) > 0 {
-		return pro.Extract(ctx, propagation.MapCarrier(tr.Status.SpanContext))
+		return pro.Extract(ctx, propagation.MapCarrier(tr.Status.SpanContext)), noopSpan
 	}
 
 	spanContext := make(map[string]string)
@@ -56,12 +58,11 @@ func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, tr *v
 		}
 
 		tr.Status.SpanContext = spanContext
-		return pro.Extract(ctx, propagation.MapCarrier(tr.Status.SpanContext))
+		return pro.Extract(ctx, propagation.MapCarrier(tr.Status.SpanContext)), noopSpan
 	}
 
 	// Create a new root span since there was no parent spanContext provided through annotations
 	ctxWithTrace, span := tracerProvider.Tracer(TracerName).Start(ctx, "TaskRun:Reconciler")
-	defer span.End()
 	span.SetAttributes(attribute.String("taskrun", tr.Name), attribute.String("namespace", tr.Namespace))
 
 	pro.Inject(ctxWithTrace, propagation.MapCarrier(spanContext))
@@ -69,10 +70,11 @@ func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, tr *v
 	logger.Debug("got tracing carrier", spanContext)
 	if len(spanContext) == 0 {
 		logger.Debug("tracerProvider doesn't provide a traceId, tracing is disabled")
-		return ctx
+		span.End()
+		return ctx, noopSpan
 	}
 
 	span.AddEvent("updating TaskRun status with SpanContext")
 	tr.Status.SpanContext = spanContext
-	return ctxWithTrace
+	return ctxWithTrace, span
 }

--- a/pkg/reconciler/taskrun/tracing.go
+++ b/pkg/reconciler/taskrun/tracing.go
@@ -35,15 +35,17 @@ const (
 	SpanContextAnnotation = "tekton.dev/taskrunSpanContext"
 )
 
-// initialize tracing by creating the root span and injecting the
-// spanContext is propogated through annotations in the CR
-func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, tr *v1.TaskRun) context.Context {
+// initTracing initializes tracing by creating or restoring the root span.
+// It persists the span context in status and restores parent context propagated
+// through annotations. The caller is responsible for ending the returned span.
+func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, tr *v1.TaskRun) (context.Context, trace.Span) {
 	logger := logging.FromContext(ctx)
 	pro := otel.GetTextMapPropagator()
+	noopSpan := trace.SpanFromContext(context.Background())
 
 	// SpanContext was created already
 	if len(tr.Status.SpanContext) > 0 {
-		return pro.Extract(ctx, propagation.MapCarrier(tr.Status.SpanContext))
+		return pro.Extract(ctx, propagation.MapCarrier(tr.Status.SpanContext)), noopSpan
 	}
 
 	spanContext := make(map[string]string)
@@ -56,12 +58,11 @@ func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, tr *v
 		}
 
 		tr.Status.SpanContext = spanContext
-		return pro.Extract(ctx, propagation.MapCarrier(tr.Status.SpanContext))
+		return pro.Extract(ctx, propagation.MapCarrier(tr.Status.SpanContext)), noopSpan
 	}
 
 	// Create a new root span since there was no parent spanContext provided through annotations
 	ctxWithTrace, span := tracerProvider.Tracer(TracerName).Start(ctx, "TaskRun:Reconciler")
-	defer span.End()
 	span.SetAttributes(attribute.String("taskrun", tr.Name), attribute.String("namespace", tr.Namespace))
 
 	pro.Inject(ctxWithTrace, propagation.MapCarrier(spanContext))
@@ -69,10 +70,11 @@ func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, tr *v
 	logger.Debug("got tracing carrier", spanContext)
 	if len(spanContext) == 0 {
 		logger.Debug("tracerProvider doesn't provide a traceId, tracing is disabled")
-		return ctx
+		span.End()
+		return ctx, noopSpan
 	}
 
 	span.AddEvent("updating TaskRun status with SpanContext")
 	tr.Status.SpanContext = spanContext
-	return ctxWithTrace
+	return ctxWithTrace, span
 }

--- a/pkg/reconciler/taskrun/tracing_test.go
+++ b/pkg/reconciler/taskrun/tracing_test.go
@@ -128,7 +128,7 @@ func TestInitTracingRootSpanLifecycle(t *testing.T) {
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 	exporter := tracetest.NewInMemoryExporter()
 	tracerProvider := tracesdk.NewTracerProvider(tracesdk.WithSyncer(exporter))
-	defer tracerProvider.Shutdown(t.Context())
+	defer func() { _ = tracerProvider.Shutdown(t.Context()) }()
 
 	tr := &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "testns"}}
 	_, span := initTracing(t.Context(), tracerProvider, tr)

--- a/pkg/reconciler/taskrun/tracing_test.go
+++ b/pkg/reconciler/taskrun/tracing_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 func TestInitTracing(t *testing.T) {
+	oldPropagator := otel.GetTextMapPropagator()
 	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(oldPropagator) })
 
 	testcases := []struct {
 		name                    string
@@ -125,7 +127,10 @@ func TestInitTracing(t *testing.T) {
 }
 
 func TestInitTracingRootSpanLifecycle(t *testing.T) {
+	oldPropagator := otel.GetTextMapPropagator()
 	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(oldPropagator) })
+
 	exporter := tracetest.NewInMemoryExporter()
 	tracerProvider := tracesdk.NewTracerProvider(tracesdk.WithSyncer(exporter))
 	defer func() { _ = tracerProvider.Shutdown(t.Context()) }()

--- a/pkg/reconciler/taskrun/tracing_test.go
+++ b/pkg/reconciler/taskrun/tracing_test.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -90,7 +91,8 @@ func TestInitTracing(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			tr := tc.taskRun
-			ctx := initTracing(t.Context(), tc.tracerProvider, tr)
+			ctx, span := initTracing(t.Context(), tc.tracerProvider, tr)
+			defer span.End()
 
 			if ctx == nil {
 				t.Fatalf("returned nil context from initTracing")
@@ -119,5 +121,28 @@ func TestInitTracing(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestInitTracingRootSpanLifecycle(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	exporter := tracetest.NewInMemoryExporter()
+	tracerProvider := tracesdk.NewTracerProvider(tracesdk.WithSyncer(exporter))
+	defer tracerProvider.Shutdown(t.Context())
+
+	tr := &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "testns"}}
+	_, span := initTracing(t.Context(), tracerProvider, tr)
+
+	if got := exporter.GetSpans(); len(got) != 0 {
+		t.Fatalf("root span exported before caller ended it: got %d spans", len(got))
+	}
+
+	span.End()
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("exported spans = %d, want 1", len(spans))
+	}
+	if spans[0].Name != "TaskRun:Reconciler" {
+		t.Fatalf("exported span name = %q, want TaskRun:Reconciler", spans[0].Name)
 	}
 }

--- a/pkg/reconciler/taskrun/tracing_test.go
+++ b/pkg/reconciler/taskrun/tracing_test.go
@@ -30,12 +30,19 @@ import (
 )
 
 func TestInitTracing(t *testing.T) {
+	oldPropagator := otel.GetTextMapPropagator()
 	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(oldPropagator) })
+
+	exporter := tracetest.NewInMemoryExporter()
+	tracerProvider := tracesdk.NewTracerProvider(tracesdk.WithSyncer(exporter))
+	defer func() { _ = tracerProvider.Shutdown(t.Context()) }()
 
 	testcases := []struct {
 		name                    string
 		taskRun                 *v1.TaskRun
 		tracerProvider          trace.TracerProvider
+		exporter                *tracetest.InMemoryExporter
 		expectSpanContextStatus bool
 		expectValidSpanContext  bool
 		parentTraceID           string
@@ -47,7 +54,8 @@ func TestInitTracing(t *testing.T) {
 				Namespace: "testns",
 			},
 		},
-		tracerProvider:          tracesdk.NewTracerProvider(),
+		tracerProvider:          tracerProvider,
+		exporter:                exporter,
 		expectSpanContextStatus: true,
 		expectValidSpanContext:  true,
 	}, {
@@ -95,7 +103,24 @@ func TestInitTracing(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			tr := tc.taskRun
-			ctx := initTracing(t.Context(), tc.tracerProvider, tr)
+			ctx, span := initTracing(t.Context(), tc.tracerProvider, tr)
+
+			if tc.exporter != nil {
+				if got := tc.exporter.GetSpans(); len(got) != 0 {
+					t.Fatalf("root span exported before caller ended it: got %d spans", len(got))
+				}
+			}
+
+			span.End()
+			if tc.exporter != nil {
+				spans := tc.exporter.GetSpans()
+				if len(spans) != 1 {
+					t.Fatalf("exported spans = %d, want 1", len(spans))
+				}
+				if spans[0].Name != "TaskRun:Reconciler" {
+					t.Fatalf("exported span name = %q, want TaskRun:Reconciler", spans[0].Name)
+				}
+			}
 
 			if ctx == nil {
 				t.Fatalf("returned nil context from initTracing")


### PR DESCRIPTION
# Changes

The root span created in `initTracing()` was immediately ended via `defer span.End()` inside the function itself. Since `initTracing` returns right after creating the span, this resulted in near-zero duration root spans that did not represent the actual reconciliation lifecycle.

## What was changed

- Changed `initTracing` in both `pkg/reconciler/taskrun/tracing.go` and `pkg/reconciler/pipelinerun/tracing.go` to return `(context.Context, trace.Span)` instead of just `context.Context`
- Removed `defer span.End()` from inside `initTracing`
- Added `defer rootSpan.End()` in `ReconcileKind` (both TaskRun and PipelineRun reconcilers) so the root span covers the full reconciliation cycle
- Updated tests to handle the new return signature

## Why

With `defer span.End()` inside `initTracing()`, the root span ended as soon as `initTracing` returned -- giving it near-zero duration. The root span should represent the entire reconciliation lifecycle, which means it must be ended when `ReconcileKind` completes.

For early-return paths (existing SpanContext, annotation-propagated context, disabled tracing), a no-op span is returned so the caller's `defer span.End()` is safe.

/kind bug

## Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user-facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests)
- [x] Conforms to the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

## Release Notes

```release-note
Fix root tracing span lifecycle in TaskRun and PipelineRun reconcilers to cover the full reconciliation cycle instead of ending immediately after initialization.
```