### PR TITLE
feat: add sampling-ratio configuration for distributed tracing

### DIFF
--- a/config/config-tracing.yaml
+++ b/config/config-tracing.yaml
@@ -44,3 +44,8 @@ data:
     endpoint: "http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces"
     # (optional) Name of the k8s secret which contains basic auth credentials
     credentialsSecret: "jaeger-creds"
+    #
+    # (optional) Sampling ratio for traces, between 0.0 and 1.0.
+    # 1.0 samples every trace (default), 0.0 samples none,
+    # 0.5 samples approximately half.
+    sampling-ratio: "1.0"

--- a/pkg/apis/config/tracing.go
+++ b/pkg/apis/config/tracing.go
@@ -33,8 +33,14 @@ const (
 	// tracingCredentialsSecretKey is the name of the secret which contains credentials for tracing endpoint
 	tracingCredentialsSecretKey = "credentialsSecret"
 
+	// tracingSamplingRatioKey is the configmap key for trace sampling ratio
+	tracingSamplingRatioKey = "sampling-ratio"
+
 	// DefaultEndpoint is the default destination for sending traces
 	DefaultEndpoint = "http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces"
+
+	// DefaultSamplingRatio is the default trace sampling ratio (1.0 = sample everything)
+	DefaultSamplingRatio = 1.0
 )
 
 // DefaultTracing holds all the default configurations for tracing
@@ -46,6 +52,7 @@ type Tracing struct {
 	Enabled           bool
 	Endpoint          string
 	CredentialsSecret string
+	SamplingRatio     float64
 }
 
 // Equals returns true if two Configs are identical
@@ -60,7 +67,8 @@ func (cfg *Tracing) Equals(other *Tracing) bool {
 
 	return other.Enabled == cfg.Enabled &&
 		other.Endpoint == cfg.Endpoint &&
-		other.CredentialsSecret == cfg.CredentialsSecret
+		other.CredentialsSecret == cfg.CredentialsSecret &&
+		other.SamplingRatio == cfg.SamplingRatio
 }
 
 // GetTracingConfigName returns the name of the configmap containing all
@@ -75,8 +83,9 @@ func GetTracingConfigName() string {
 // newTracingFromMap returns a Config given a map from ConfigMap
 func newTracingFromMap(config map[string]string) (*Tracing, error) {
 	t := Tracing{
-		Enabled:  false,
-		Endpoint: DefaultEndpoint,
+		Enabled:       false,
+		Endpoint:      DefaultEndpoint,
+		SamplingRatio: DefaultSamplingRatio,
 	}
 
 	if endpoint, ok := config[tracingEndpointKey]; ok {
@@ -94,6 +103,18 @@ func newTracingFromMap(config map[string]string) (*Tracing, error) {
 		}
 		t.Enabled = e
 	}
+
+	if ratio, ok := config[tracingSamplingRatioKey]; ok {
+		r, err := strconv.ParseFloat(ratio, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing tracing sampling-ratio %q: %w", ratio, err)
+		}
+		if r < 0 || r > 1 {
+			return nil, fmt.Errorf("sampling-ratio %v must be between 0.0 and 1.0", r)
+		}
+		t.SamplingRatio = r
+	}
+
 	return &t, nil
 }
 

--- a/pkg/apis/config/tracing_test.go
+++ b/pkg/apis/config/tracing_test.go
@@ -34,16 +34,18 @@ func TestNewTracingFromConfigMap(t *testing.T) {
 		{
 			name: "empty",
 			want: &config.Tracing{
-				Enabled:  false,
-				Endpoint: "http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces",
+				Enabled:       false,
+				Endpoint:      "http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces",
+				SamplingRatio: 1.0,
 			},
 			fileName: "config-tracing-empty",
 		},
 		{
 			name: "enabled with endpoint",
 			want: &config.Tracing{
-				Enabled:  true,
-				Endpoint: "http://jaeger-test",
+				Enabled:       true,
+				Endpoint:      "http://jaeger-test",
+				SamplingRatio: 1.0,
 			},
 			fileName: "config-tracing-enabled",
 		},
@@ -123,16 +125,28 @@ func TestTracingEquals(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "different samplingRatio",
+			left: &config.Tracing{
+				SamplingRatio: 0.5,
+			},
+			right: &config.Tracing{
+				SamplingRatio: 1.0,
+			},
+			expected: false,
+		},
+		{
 			name: "same all fields",
 			left: &config.Tracing{
 				Enabled:           true,
 				Endpoint:          "a",
 				CredentialsSecret: "b",
+				SamplingRatio:     0.5,
 			},
 			right: &config.Tracing{
 				Enabled:           true,
 				Endpoint:          "a",
 				CredentialsSecret: "b",
+				SamplingRatio:     0.5,
 			},
 			expected: true,
 		},

--- a/pkg/apis/config/tracing_test.go
+++ b/pkg/apis/config/tracing_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	test "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test/diff"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestNewTracingFromConfigMap(t *testing.T) {
@@ -58,6 +59,65 @@ func TestNewTracingFromConfigMap(t *testing.T) {
 				}
 			} else {
 				t.Errorf("NewTracingFromConfigMap(actual) = %v", err)
+			}
+		})
+	}
+}
+
+func TestNewTracingFromConfigMapSamplingRatio(t *testing.T) {
+	testCases := []struct {
+		name    string
+		value   string
+		want    float64
+		wantErr bool
+	}{
+		{
+			name:  "zero",
+			value: "0.0",
+			want:  0.0,
+		},
+		{
+			name:  "one",
+			value: "1.0",
+			want:  1.0,
+		},
+		{
+			name:  "half",
+			value: "0.5",
+			want:  0.5,
+		},
+		{
+			name:    "negative",
+			value:   "-0.1",
+			wantErr: true,
+		},
+		{
+			name:    "greater than one",
+			value:   "1.1",
+			wantErr: true,
+		},
+		{
+			name:    "not a number",
+			value:   "abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cm := &corev1.ConfigMap{Data: map[string]string{"sampling-ratio": tc.value}}
+			got, err := config.NewTracingFromConfigMap(cm)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("NewTracingFromConfigMap() expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewTracingFromConfigMap() = %v", err)
+			}
+			if got.SamplingRatio != tc.want {
+				t.Fatalf("SamplingRatio = %v, want %v", got.SamplingRatio, tc.want)
 			}
 		})
 	}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -184,6 +184,7 @@ func createTracerProvider(service string, cfg *config.Tracing, user, pass string
 	// Initialize tracerProvider with the jaeger exporter
 	tp := tracesdk.NewTracerProvider(
 		tracesdk.WithBatcher(exp),
+		tracesdk.WithSampler(tracesdk.TraceIDRatioBased(cfg.SamplingRatio)),
 		// Record information about the service in a Resource.
 		tracesdk.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -184,7 +184,7 @@ func createTracerProvider(service string, cfg *config.Tracing, user, pass string
 	// Initialize tracerProvider with the jaeger exporter
 	tp := tracesdk.NewTracerProvider(
 		tracesdk.WithBatcher(exp),
-		tracesdk.WithSampler(tracesdk.TraceIDRatioBased(cfg.SamplingRatio)),
+		tracesdk.WithSampler(tracesdk.ParentBased(tracesdk.TraceIDRatioBased(cfg.SamplingRatio))),
 		// Record information about the service in a Resource.
 		tracesdk.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -70,6 +70,7 @@ func TestOnStoreWithSecret(t *testing.T) {
 	cfg := &config.Tracing{
 		Enabled:           true,
 		CredentialsSecret: "tracing-sec",
+		SamplingRatio:     1.0,
 	}
 
 	client := fakekubeclient.Get(ctx)
@@ -80,7 +81,7 @@ func TestOnStoreWithSecret(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "tracing-sec",
-			// system.Namespace() will return `knative-testing`
+			// system.Namespace() will return 'knative-testing'
 			// Set inside the imported knative testing package
 			Namespace: "knative-testing",
 		},
@@ -104,8 +105,9 @@ func TestOnStoreWithEnabled(t *testing.T) {
 	tp := New("test-service", zap.NewNop().Sugar())
 
 	cfg := &config.Tracing{
-		Enabled:  true,
-		Endpoint: "test-endpoint",
+		Enabled:       true,
+		Endpoint:      "test-endpoint",
+		SamplingRatio: 1.0,
 	}
 
 	tp.OnStore(nil)("config-tracing", cfg)
@@ -124,6 +126,7 @@ func TestOnSecretWithSecretName(t *testing.T) {
 	cfg := &config.Tracing{
 		Enabled:           true,
 		CredentialsSecret: "jaeger",
+		SamplingRatio:     1.0,
 	}
 
 	tp.OnStore(nil)("config-tracing", cfg)
@@ -152,6 +155,7 @@ func TestOnSecretWithSameCreds(t *testing.T) {
 	cfg := &config.Tracing{
 		Enabled:           true,
 		CredentialsSecret: "jaeger",
+		SamplingRatio:     1.0,
 	}
 
 	tp.OnStore(nil)("config-tracing", cfg)
@@ -183,6 +187,7 @@ func TestOnSecretWithWrongName(t *testing.T) {
 	cfg := &config.Tracing{
 		Enabled:           true,
 		CredentialsSecret: "jaeger",
+		SamplingRatio:     1.0,
 	}
 
 	tp.OnStore(nil)("config-tracing", cfg)
@@ -210,6 +215,7 @@ func TestHandlerSecretUpdate(t *testing.T) {
 	cfg := &config.Tracing{
 		Enabled:           true,
 		CredentialsSecret: "jaeger",
+		SamplingRatio:     1.0,
 	}
 
 	tp.OnStore(nil)("config-tracing", cfg)

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package tracing
 
 import (
+	"context"
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +43,41 @@ func TestNewTracerProvider(t *testing.T) {
 	if span.IsRecording() {
 		t.Fatalf("Span is recording before configuration")
 	}
+}
+
+func TestCreateTracerProviderSamplingRatio(t *testing.T) {
+	cfg := &config.Tracing{
+		Enabled:       true,
+		Endpoint:      "http://localhost:4318/v1/traces",
+		SamplingRatio: 0.0,
+	}
+
+	tp, err := createTracerProvider("test-service", cfg, "", "")
+	if err != nil {
+		t.Fatalf("createTracerProvider() = %v", err)
+	}
+	if shutdown, ok := tp.(interface{ Shutdown(context.Context) error }); ok {
+		defer shutdown.Shutdown(context.Background())
+	}
+
+	_, root := tp.Tracer("tracer").Start(t.Context(), "root")
+	if root.IsRecording() {
+		t.Fatalf("root span is recording with sampling-ratio 0.0")
+	}
+	root.End()
+
+	sampledParent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{1},
+		SpanID:     trace.SpanID{2},
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	ctx := trace.ContextWithRemoteSpanContext(t.Context(), sampledParent)
+	_, child := tp.Tracer("tracer").Start(ctx, "child")
+	if !child.IsRecording() {
+		t.Fatalf("child span with sampled parent is not recording")
+	}
+	child.End()
 }
 
 func TestOnStore(t *testing.T) {

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -56,8 +56,10 @@ func TestCreateTracerProviderSamplingRatio(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createTracerProvider() = %v", err)
 	}
-	if shutdown, ok := tp.(interface{ Shutdown(context.Context) error }); ok {
-		defer shutdown.Shutdown(context.Background())
+	if shutdown, ok := tp.(interface {
+		Shutdown(ctx context.Context) error
+	}); ok {
+		defer func() { _ = shutdown.Shutdown(context.Background()) }()
 	}
 
 	_, root := tp.Tracer("tracer").Start(t.Context(), "root")


### PR DESCRIPTION
# Changes

Adds a `sampling-ratio` configuration key to the `config-tracing` ConfigMap, allowing operators to control what fraction of traces are sampled.

## Problem

`tracesdk.NewTracerProvider` was created with no sampler option, which defaults to `AlwaysSample`. Production deployments would either drown in traces or have to disable tracing entirely -- there was no middle ground.

## Solution

- Add `sampling-ratio` key to `config-tracing` ConfigMap (float between 0.0 and 1.0, default `1.0` for backward compatibility)
- Parse and validate the ratio in `newTracingFromMap` (rejects values outside [0.0, 1.0])
- Pass `tracesdk.WithSampler(tracesdk.TraceIDRatioBased(ratio))` when creating the `TracerProvider`
- Add `SamplingRatio` field to the `Tracing` config struct with equality comparison
- Update all tests to set `SamplingRatio: 1.0` on enabled configs (required since `TraceIDRatioBased(0.0)` drops all traces)

## Files changed

- `config/config-tracing.yaml` -- documented new key in example block
- `pkg/apis/config/tracing.go` -- new field, constant, parsing, validation, equality
- `pkg/apis/config/tracing_test.go` -- updated expected defaults, added `samplingRatio` equality test
- `pkg/tracing/tracing.go` -- added `WithSampler` to `NewTracerProvider`
- `pkg/tracing/tracing_test.go` -- set `SamplingRatio: 1.0` on all enabled configs

## Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes to behavior or new features
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) for new/changed functionality
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [x] Release notes block below has been updated with relevant changes

```release-note
Add `sampling-ratio` configuration to `config-tracing` ConfigMap for controlling trace sampling ratio (0.0-1.0, default 1.0).
```