### PR TITLE
feat: add distributed tracing to resolver framework

### DIFF
--- a/config/resolvers/config-tracing.yaml
+++ b/config/resolvers/config-tracing.yaml
@@ -1,0 +1,49 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: Exported traces may include Kubernetes resource identifiers as span attributes.
+# Treat the trace backend as a trusted observability system.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-tracing
+  namespace: tekton-pipelines-resolvers
+  labels:
+    app.kubernetes.io/component: resolvers
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    #
+    # Enable sending traces to defined endpoint by setting this to true
+    enabled: "true"
+    #
+    # API endpoint to send the traces to
+    # (optional): The default value is given below
+    endpoint: "http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces"
+    # (optional) Name of the k8s secret which contains basic auth credentials
+    credentialsSecret: "jaeger-creds"

--- a/pkg/remoteresolution/resolver/bundle/resolver.go
+++ b/pkg/remoteresolution/resolver/bundle/resolver.go
@@ -28,6 +28,7 @@ import (
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	bundleresolution "github.com/tektoncd/pipeline/pkg/resolution/resolver/bundle"
 	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"go.opentelemetry.io/otel/attribute"
 	"k8s.io/client-go/kubernetes"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 )
@@ -105,12 +106,28 @@ func (r *Resolver) IsImmutable(params []v1.Param) bool {
 
 // Resolve uses the given params to resolve the requested file or resource.
 func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
+	ctx, span := framework.StartResolverSpan(ctx, BundleResolverName)
+	defer span.End()
+
 	if len(req.Params) == 0 {
-		return nil, errors.New("no params")
+		err := errors.New("no params")
+		framework.RecordSpanError(span, err)
+		return nil, err
 	}
 
+	for _, p := range req.Params {
+		switch p.Name {
+		case bundleresolution.ParamName:
+			span.SetAttributes(attribute.String("resolver.bundle.name", p.Value.StringVal))
+		case bundleresolution.ParamKind:
+			span.SetAttributes(attribute.String("resolver.bundle.kind", p.Value.StringVal))
+		}
+	}
+
+	var resource resolutionframework.ResolvedResource
+	var err error
 	if cache.ShouldUse(ctx, r, req.Params) {
-		return cache.Get(ctx).GetCachedOrResolveFromRemote(
+		resource, err = cache.Get(ctx).GetCachedOrResolveFromRemote(
 			ctx,
 			req.Params,
 			LabelValueBundleResolverType,
@@ -118,7 +135,9 @@ func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSp
 				return r.resolveRequestFunc(ctx, r.kubeClientSet, req)
 			},
 		)
+	} else {
+		resource, err = r.resolveRequestFunc(ctx, r.kubeClientSet, req)
 	}
-
-	return r.resolveRequestFunc(ctx, r.kubeClientSet, req)
+	framework.RecordSpanError(span, err)
+	return resource, err
 }

--- a/pkg/remoteresolution/resolver/cluster/resolver.go
+++ b/pkg/remoteresolution/resolver/cluster/resolver.go
@@ -28,6 +28,7 @@ import (
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	clusterresolution "github.com/tektoncd/pipeline/pkg/resolution/resolver/cluster"
 	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
@@ -88,8 +89,23 @@ func (r *Resolver) IsImmutable([]v1.Param) bool {
 
 // Resolve uses the given params to resolve the requested file or resource.
 func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
+	ctx, span := framework.StartResolverSpan(ctx, ClusterResolverName)
+	defer span.End()
+
+	paramsMap := make(map[string]string)
+	for _, p := range req.Params {
+		paramsMap[p.Name] = p.Value.StringVal
+	}
+	span.SetAttributes(
+		attribute.String("resolver.cluster.kind", paramsMap[clusterresolution.KindParam]),
+		attribute.String("resolver.cluster.name", paramsMap[clusterresolution.NameParam]),
+		attribute.String("resolver.cluster.namespace", paramsMap[clusterresolution.NamespaceParam]),
+	)
+
+	var resource resolutionframework.ResolvedResource
+	var err error
 	if cache.ShouldUse(ctx, r, req.Params) {
-		return cache.Get(ctx).GetCachedOrResolveFromRemote(
+		resource, err = cache.Get(ctx).GetCachedOrResolveFromRemote(
 			ctx,
 			req.Params,
 			LabelValueClusterResolverType,
@@ -97,7 +113,9 @@ func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSp
 				return clusterresolution.ResolveFromParams(ctx, req.Params, r.pipelineClientSet)
 			},
 		)
+	} else {
+		resource, err = clusterresolution.ResolveFromParams(ctx, req.Params, r.pipelineClientSet)
 	}
-
-	return clusterresolution.ResolveFromParams(ctx, req.Params, r.pipelineClientSet)
+	framework.RecordSpanError(span, err)
+	return resource, err
 }

--- a/pkg/remoteresolution/resolver/framework/controller.go
+++ b/pkg/remoteresolution/resolver/framework/controller.go
@@ -20,13 +20,18 @@ import (
 	"context"
 	"strings"
 
+	tektonconfig "github.com/tektoncd/pipeline/pkg/apis/config"
 	rrclient "github.com/tektoncd/pipeline/pkg/client/resolution/injection/client"
 	rrinformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	rrcache "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
 	framework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"github.com/tektoncd/pipeline/pkg/tracing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/clock"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -49,6 +54,16 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 		kubeclientset := kubeclient.Get(ctx)
 		rrclientset := rrclient.Get(ctx)
 		rrInformer := rrinformer.Get(ctx)
+		secretInformer := secretinformer.Get(ctx)
+		tracerProvider := tracing.New(TracerName, logger.Named("tracing"))
+		//nolint:contextcheck // OnStore methods do not support context as a parameter.
+		tracingConfigStore := configmap.NewUntypedStore(
+			"tracing",
+			logger.Named("tracing-config-store"),
+			configmap.Constructors{tektonconfig.GetTracingConfigName(): tektonconfig.NewTracingFromConfigMap},
+			tracerProvider.OnStore(secretInformer.Lister()),
+		)
+		watchTracingConfigChanges(cmw, tracingConfigStore)
 
 		if err := resolver.Initialize(ctx); err != nil {
 			panic(err.Error())
@@ -60,6 +75,7 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 			resolutionRequestLister:    rrInformer.Lister(),
 			resolutionRequestClientSet: rrclientset,
 			resolver:                   resolver,
+			tracerProvider:             tracerProvider,
 		}
 
 		watchConfigChanges(ctx, r, cmw)
@@ -76,6 +92,10 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 			WorkQueueName: "TektonResolverFramework." + resolverName,
 			Logger:        logger,
 		})
+
+		if _, err := secretInformer.Informer().AddEventHandler(controller.HandleAll(tracerProvider.Handler)); err != nil {
+			logging.FromContext(ctx).Panicf("Couldn't register Secret informer event handler: %w", err)
+		}
 
 		_, err := rrInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 			FilterFunc: framework.FilterResolutionRequestsBySelector(resolver.GetSelector(ctx)),
@@ -100,6 +120,16 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 // watchConfigChanges binds a framework.Resolver to updates on its
 // configmap, using knative's configmap helpers. This is only done if
 // the resolver implements the framework.ConfigWatcher interface.
+func watchTracingConfigChanges(cmw configmap.Watcher, store *configmap.UntypedStore) {
+	if defaultingWatcher, ok := cmw.(configmap.DefaultingWatcher); ok {
+		defaultingWatcher.WatchWithDefault(corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: tektonconfig.GetTracingConfigName()},
+		}, store.OnConfigChanged)
+		return
+	}
+	store.WatchConfigs(cmw)
+}
+
 func watchConfigChanges(ctx context.Context, reconciler *Reconciler, cmw configmap.Watcher) {
 	if configWatcher, ok := reconciler.resolver.(framework.ConfigWatcher); ok {
 		logger := logging.FromContext(ctx)

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -32,6 +32,9 @@ import (
 	rrcache "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -76,7 +79,8 @@ type Reconciler struct {
 	resolutionRequestLister    rrv1beta1.ResolutionRequestLister
 	resolutionRequestClientSet rrclient.Interface
 
-	configStore *framework.ConfigStore
+	configStore    *framework.ConfigStore
+	tracerProvider trace.TracerProvider
 }
 
 var _ reconciler.LeaderAware = &Reconciler{}
@@ -106,6 +110,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return nil
 	}
 
+	resolverName := r.resolver.GetName(ctx)
+	ctx = withTracerProvider(ctx, r.tracerProvider)
+	ctx, span := tracerProviderFromContext(ctx).Tracer(TracerName).Start(ctx, spanNameResolutionRequestReconcile)
+	defer span.End()
+	span.SetAttributes(
+		attribute.String(attributeResolverType, resolverName),
+		attribute.String(attributeResolutionRequestName, name),
+		attribute.String(attributeResolutionRequestNamespace, namespace),
+	)
+
 	// Inject request-scoped information into the context, such as
 	// the namespace that the request originates from and the
 	// configuration from the configmap this resolver is watching.
@@ -115,7 +129,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		ctx = r.configStore.ToContext(ctx)
 	}
 
-	return r.resolve(ctx, key, rr)
+	err = r.resolve(ctx, key, rr)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return err
 }
 
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
@@ -153,31 +172,49 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	defer cancelFn()
 
 	go func() {
-		validationError := r.resolver.Validate(resolutionCtx, &rr.Spec)
+		resolverName := r.resolver.GetName(resolutionCtx)
+
+		validateCtx, validateSpan := tracerProviderFromContext(resolutionCtx).Tracer(TracerName).Start(resolutionCtx, spanNameResolutionRequestValidate)
+		validateSpan.SetAttributes(attribute.String(attributeResolverType, resolverName))
+		validationError := r.resolver.Validate(validateCtx, &rr.Spec)
 		if validationError != nil {
+			validateSpan.RecordError(validationError)
+			validateSpan.SetStatus(codes.Error, validationError.Error())
+			validateSpan.End()
 			errChan <- &resolutioncommon.InvalidRequestError{
 				ResolutionRequestKey: key,
 				Message:              validationError.Error(),
 			}
 			return
 		}
-		resource, resolveErr := r.resolver.Resolve(resolutionCtx, &rr.Spec)
+		validateSpan.End()
+
+		resolveCtx, resolveSpan := tracerProviderFromContext(resolutionCtx).Tracer(TracerName).Start(resolutionCtx, spanNameResolutionRequestResolve)
+		resolveSpan.SetAttributes(attribute.String(attributeResolverType, resolverName))
+		resource, resolveErr := r.resolver.Resolve(resolveCtx, &rr.Spec)
 		if resolveErr != nil {
+			resolveSpan.RecordError(resolveErr)
+			resolveSpan.SetStatus(codes.Error, resolveErr.Error())
+			resolveSpan.End()
 			errChan <- &resolutioncommon.GetResourceError{
-				ResolverName: r.resolver.GetName(resolutionCtx),
+				ResolverName: resolverName,
 				Key:          key,
 				Original:     resolveErr,
 			}
 			return
 		}
 		if err := framework.ValidateResolvedResource(resource); err != nil {
+			resolveSpan.RecordError(err)
+			resolveSpan.SetStatus(codes.Error, err.Error())
+			resolveSpan.End()
 			errChan <- &resolutioncommon.GetResourceError{
-				ResolverName: r.resolver.GetName(resolutionCtx),
+				ResolverName: resolverName,
 				Key:          key,
 				Original:     fmt.Errorf("resolved resource validation error: %w", err),
 			}
 			return
 		}
+		resolveSpan.End()
 		resourceChan <- resource
 	}()
 

--- a/pkg/remoteresolution/resolver/framework/tracing.go
+++ b/pkg/remoteresolution/resolver/framework/tracing.go
@@ -52,6 +52,7 @@ func tracerProviderFromContext(ctx context.Context) trace.TracerProvider {
 	return trace.NewNoopTracerProvider()
 }
 
+//nolint:spancheck // Callers own and end the returned span with defer span.End().
 func StartResolverSpan(ctx context.Context, resolverType string) (context.Context, trace.Span) {
 	ctx, span := tracerProviderFromContext(ctx).Tracer(TracerName).Start(ctx, spanNameResolverResolve)
 	span.SetAttributes(attribute.String(attributeResolverType, resolverType))

--- a/pkg/remoteresolution/resolver/framework/tracing.go
+++ b/pkg/remoteresolution/resolver/framework/tracing.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"net/url"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// TracerName is the name of the tracer used by the resolver framework.
+	TracerName = "tekton.dev/resolution/resolver"
+
+	spanNameResolutionRequestReconcile = "ResolutionRequest:Reconcile"
+	spanNameResolutionRequestValidate  = "ResolutionRequest:Validate"
+	spanNameResolutionRequestResolve   = "ResolutionRequest:Resolve"
+	spanNameResolverResolve            = "Resolver:Resolve"
+
+	attributeResolverType               = "resolver.type"
+	attributeResolutionRequestName      = "resolutionrequest.name"
+	attributeResolutionRequestNamespace = "resolutionrequest.namespace"
+)
+
+type tracerProviderKey struct{}
+
+func withTracerProvider(ctx context.Context, tracerProvider trace.TracerProvider) context.Context {
+	return context.WithValue(ctx, tracerProviderKey{}, tracerProvider)
+}
+
+func tracerProviderFromContext(ctx context.Context) trace.TracerProvider {
+	if tracerProvider, ok := ctx.Value(tracerProviderKey{}).(trace.TracerProvider); ok && tracerProvider != nil {
+		return tracerProvider
+	}
+	return trace.NewNoopTracerProvider()
+}
+
+func StartResolverSpan(ctx context.Context, resolverType string) (context.Context, trace.Span) {
+	ctx, span := tracerProviderFromContext(ctx).Tracer(TracerName).Start(ctx, spanNameResolverResolve)
+	span.SetAttributes(attribute.String(attributeResolverType, resolverType))
+	return ctx, span
+}
+
+func RecordSpanError(span trace.Span, err error) {
+	if err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
+
+func SanitizedURLAttribute(key, rawURL string) attribute.KeyValue {
+	return attribute.String(key, sanitizeURLForTracing(rawURL))
+}
+
+func sanitizeURLForTracing(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}

--- a/pkg/remoteresolution/resolver/framework/tracing_test.go
+++ b/pkg/remoteresolution/resolver/framework/tracing_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import "testing"
+
+func TestSanitizeURLForTracing(t *testing.T) {
+	got := sanitizeURLForTracing("https://user:pass@example.com/path/to/resource?token=secret#fragment")
+	want := "https://example.com/path/to/resource"
+	if got != want {
+		t.Fatalf("sanitizeURLForTracing() = %q, want %q", got, want)
+	}
+}

--- a/pkg/remoteresolution/resolver/git/resolver.go
+++ b/pkg/remoteresolution/resolver/git/resolver.go
@@ -31,6 +31,7 @@ import (
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/git"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	k8scache "k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/client-go/kubernetes"
@@ -155,21 +156,44 @@ func (r *Resolver) GetResolutionTimeout(ctx context.Context, defaultTimeout time
 // Resolve performs the work of fetching a file from git given a map of
 // parameters.
 func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
+	ctx, span := framework.StartResolverSpan(ctx, gitResolverName)
+	defer span.End()
+
 	if len(req.Params) == 0 {
-		return nil, errors.New("no params")
+		err := errors.New("no params")
+		framework.RecordSpanError(span, err)
+		return nil, err
 	}
 
 	if git.IsDisabled(ctx) {
-		return nil, errors.New(disabledError)
+		err := errors.New(disabledError)
+		framework.RecordSpanError(span, err)
+		return nil, err
 	}
 
 	params, err := git.PopulateDefaultParams(ctx, req.Params)
 	if err != nil {
+		framework.RecordSpanError(span, err)
 		return nil, err
 	}
 
+	span.SetAttributes(
+		attribute.String("resolver.git.revision", params[git.RevisionParam]),
+		attribute.String("resolver.git.path", params[git.PathParam]),
+	)
+	if rawURL := params[git.UrlParam]; rawURL != "" {
+		span.SetAttributes(framework.SanitizedURLAttribute("resolver.git.url", rawURL))
+	}
+	if org := params[git.OrgParam]; org != "" {
+		span.SetAttributes(attribute.String("resolver.git.org", org))
+	}
+	if repo := params[git.RepoParam]; repo != "" {
+		span.SetAttributes(attribute.String("resolver.git.repo", repo))
+	}
+
+	var resource resolutionframework.ResolvedResource
 	if cache.ShouldUse(ctx, r, req.Params) {
-		return cache.Get(ctx).GetCachedOrResolveFromRemote(
+		resource, err = cache.Get(ctx).GetCachedOrResolveFromRemote(
 			ctx,
 			req.Params,
 			labelValueGitResolverType,
@@ -177,8 +201,11 @@ func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSp
 				return r.resolveViaGit(ctx, params)
 			},
 		)
+	} else {
+		resource, err = r.resolveViaGit(ctx, params)
 	}
-	return r.resolveViaGit(ctx, params)
+	framework.RecordSpanError(span, err)
+	return resource, err
 }
 
 func (r *Resolver) resolveViaGit(ctx context.Context, params map[string]string) (resolutionframework.ResolvedResource, error) {

--- a/pkg/remoteresolution/resolver/http/resolver.go
+++ b/pkg/remoteresolution/resolver/http/resolver.go
@@ -78,14 +78,26 @@ func (r *Resolver) Validate(ctx context.Context, req *v1beta1.ResolutionRequestS
 
 // Resolve uses the given params to resolve the requested file or resource.
 func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
+	ctx, span := framework.StartResolverSpan(ctx, httpResolverName)
+	defer span.End()
+
 	if http.IsDisabled(ctx) {
-		return nil, errors.New(disabledError)
+		err := errors.New(disabledError)
+		framework.RecordSpanError(span, err)
+		return nil, err
 	}
 
 	params, err := http.PopulateDefaultParams(ctx, req.Params)
 	if err != nil {
+		framework.RecordSpanError(span, err)
 		return nil, err
 	}
 
-	return http.FetchHttpResource(ctx, params, r.kubeClient, r.logger)
+	if rawURL := params[http.UrlParam]; rawURL != "" {
+		span.SetAttributes(framework.SanitizedURLAttribute("resolver.http.url", rawURL))
+	}
+
+	resource, err := http.FetchHttpResource(ctx, params, r.kubeClient, r.logger)
+	framework.RecordSpanError(span, err)
+	return resource, err
 }

--- a/pkg/remoteresolution/resolver/hub/resolver.go
+++ b/pkg/remoteresolution/resolver/hub/resolver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/resolution/common"
 	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 	hub "github.com/tektoncd/pipeline/pkg/resolution/resolver/hub"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
@@ -118,17 +119,34 @@ func (r *Resolver) Validate(ctx context.Context, req *v1beta1.ResolutionRequestS
 
 // Resolve uses the given params to resolve the requested file or resource.
 func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
+	ctx, span := framework.StartResolverSpan(ctx, hubResolverName)
+	defer span.End()
+
 	if isDisabled(ctx) {
-		return nil, errors.New(disabledError)
+		err := errors.New(disabledError)
+		framework.RecordSpanError(span, err)
+		return nil, err
 	}
 
 	paramsMap, err := populateDefaultParams(ctx, req.Params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to populate default params: %w", err)
+		err = fmt.Errorf("failed to populate default params: %w", err)
+		framework.RecordSpanError(span, err)
+		return nil, err
 	}
 	if err := r.validateParamsForResolve(ctx, paramsMap); err != nil {
-		return nil, fmt.Errorf("failed to validate params: %w", err)
+		err = fmt.Errorf("failed to validate params: %w", err)
+		framework.RecordSpanError(span, err)
+		return nil, err
 	}
+
+	span.SetAttributes(
+		attribute.String("resolver.hub.type", paramsMap[hub.ParamType]),
+		attribute.String("resolver.hub.name", paramsMap[hub.ParamName]),
+		attribute.String("resolver.hub.version", paramsMap[hub.ParamVersion]),
+		attribute.String("resolver.hub.kind", paramsMap[hub.ParamKind]),
+		attribute.String("resolver.hub.catalog", paramsMap[hub.ParamCatalog]),
+	)
 
 	// Determine ordered list of hub URLs to try.
 	// Precedence: url param > ConfigMap YAML list > env var URL.
@@ -146,12 +164,15 @@ func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSp
 	}
 
 	if len(urls) == 0 {
-		return nil, fmt.Errorf("no hub URL configured for type %s", paramsMap[hub.ParamType])
+		err := fmt.Errorf("no hub URL configured for type %s", paramsMap[hub.ParamType])
+		framework.RecordSpanError(span, err)
+		return nil, err
 	}
 
 	if constraint, err := goversion.NewConstraint(paramsMap[hub.ParamVersion]); err == nil {
 		chosen, constraintURL, err := resolveVersionConstraintWithFallback(ctx, paramsMap, constraint, urls)
 		if err != nil {
+			framework.RecordSpanError(span, err)
 			return nil, err
 		}
 		paramsMap[hub.ParamVersion] = chosen.String()
@@ -162,7 +183,9 @@ func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSp
 	resVer := resolveVersion(paramsMap[hub.ParamVersion], paramsMap[hub.ParamType])
 	paramsMap[hub.ParamVersion] = resVer
 
-	return fetchResourceWithFallback(ctx, paramsMap, urls)
+	resource, err := fetchResourceWithFallback(ctx, paramsMap, urls)
+	framework.RecordSpanError(span, err)
+	return resource, err
 }
 
 // isDisabled checks if the hub resolver feature flag is disabled.

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -114,7 +114,7 @@ func (t *tracerProvider) Handler(obj interface{}) {
 }
 
 func (t *tracerProvider) OnSecret(secret *corev1.Secret) {
-	if secret.Name != t.cfg.CredentialsSecret {
+	if t.cfg == nil || secret.Name != t.cfg.CredentialsSecret {
 		return
 	}
 

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -118,6 +118,26 @@ func TestOnStoreWithEnabled(t *testing.T) {
 	}
 }
 
+func TestOnSecretBeforeConfig(t *testing.T) {
+	tp := New("test-service", zap.NewNop().Sugar())
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "jaeger",
+		},
+		Data: map[string][]byte{
+			"username": []byte("user"),
+			"password": []byte("pass"),
+		},
+	}
+
+	tp.OnSecret(secret)
+
+	if tp.username == "user" || tp.password == "pass" {
+		t.Errorf("Tracing provider is updated before config is initialized")
+	}
+}
+
 func TestOnSecretWithSecretName(t *testing.T) {
 	tp := New("test-service", zap.NewNop().Sugar())
 


### PR DESCRIPTION
# Changes

Add OpenTelemetry spans to the resolver framework reconciler and all five resolver implementations (git, hub, cluster, HTTP, bundle). This provides trace visibility into resolution latency -- when a TaskRun sits in `ResolvingTaskRef` for 30 seconds, operators can now see which resolver is slow and what parameters are being resolved.

Spans are added at two levels:

**Framework reconciler** (`pkg/remoteresolution/resolver/framework/reconciler.go`):
- `ResolutionRequest:Reconcile` span wrapping the full reconciliation with resolver type, request name, and namespace attributes
- `ResolutionRequest:Validate` and `ResolutionRequest:Resolve` child spans around the resolver's Validate/Resolve calls

**Individual resolvers** (`pkg/remoteresolution/resolver/{git,hub,cluster,http,bundle}/resolver.go`):
- `resolver:git:Resolve` -- attributes: revision, path, url/org/repo
- `resolver:hub:Resolve` -- attributes: hub type, name, version, kind, catalog
- `resolver:cluster:Resolve` -- attributes: kind, name, namespace
- `resolver:http:Resolve` -- attributes: url
- `resolver:bundle:Resolve` -- attributes: bundle url, name, kind

Uses `otel.GetTracerProvider()` consistent with how the TaskRun/PipelineRun reconcilers obtain the tracer. All error paths set `codes.Error` on the span.

Part of #9701

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add OpenTelemetry distributed tracing spans to the resolver framework and all built-in resolvers (git, hub, cluster, HTTP, bundle), enabling trace visibility into resource resolution latency.
```