### PR TITLE
refactor: decouple metadata sync from event emission in reconcilers

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -21,8 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -196,6 +196,16 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 		ctx = logging.WithLogger(ctx, logger)
 	}
 
+	// Sync metadata (labels/annotations) at the end of every reconciliation.
+	// This is deferred to ensure it runs on every exit path.
+	// Knative's generated reconciler only calls UpdateStatus(), never writes .metadata,
+	// so we must persist label/annotation changes ourselves.
+	defer func() {
+		if err := c.syncMetadata(ctx, pr); err != nil {
+			logger.Warn("Failed to sync PipelineRun metadata", zap.Error(err))
+		}
+	}()
+
 	// Read the initial condition
 	before := pr.Status.GetCondition(apis.ConditionSucceeded)
 
@@ -210,7 +220,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 		if err := timeoutPipelineRun(ctx, logger, pr, c.PipelineClientSet); err != nil {
 			return err
 		}
-		if err := c.finishReconcileUpdateEmitEvents(ctx, pr, before, nil); err != nil {
+		if err := c.emitReconcileEvents(ctx, pr, before, nil); err != nil {
 			return err
 		}
 		return controller.NewPermanentError(errors.New("PipelineRun has timed out for a long time"))
@@ -225,7 +235,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 		if err != nil {
 			logger.Errorf("Failed to delete StatefulSet or PVC for PipelineRun %s: %v", pr.Name, err)
 		}
-		return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
+		return c.emitReconcileEvents(ctx, pr, before, err)
 	}
 
 	if !pr.HasStarted() && !pr.IsPending() {
@@ -257,13 +267,13 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 
 	if err := propagatePipelineNameLabelToPipelineRun(pr); err != nil {
 		logger.Errorf("Failed to propagate pipeline name label to pipelinerun %s: %v", pr.Name, err)
-		return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
+		return c.emitReconcileEvents(ctx, pr, before, err)
 	}
 
 	// If the pipelinerun is cancelled, cancel tasks and update status
 	if pr.IsCancelled() {
 		err := cancelPipelineRun(ctx, logger, pr, c.PipelineClientSet)
-		return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
+		return c.emitReconcileEvents(ctx, pr, before, err)
 	}
 
 	// Make sure that the PipelineRun status is in sync with the actual TaskRuns
@@ -271,7 +281,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 	if err != nil {
 		// This should not fail. Return the error so we can re-try later.
 		logger.Errorf("Error while syncing the pipelinerun status: %v", err.Error())
-		return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
+		return c.emitReconcileEvents(ctx, pr, before, err)
 	}
 
 	// Reconcile this copy of the pipelinerun and then write back any status or label
@@ -289,7 +299,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 		}
 	}
 
-	if err = c.finishReconcileUpdateEmitEvents(ctx, pr, before, err); err != nil {
+	if err = c.emitReconcileEvents(ctx, pr, before, err); err != nil {
 		return err
 	}
 
@@ -353,35 +363,17 @@ func (c *Reconciler) durationAndCountMetrics(ctx context.Context, pr *v1.Pipelin
 	}
 }
 
-func (c *Reconciler) finishReconcileUpdateEmitEvents(ctx context.Context, pr *v1.PipelineRun, beforeCondition *apis.Condition, previousError error) error {
-	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "finishReconcileUpdateEmitEvents")
+func (c *Reconciler) emitReconcileEvents(ctx context.Context, pr *v1.PipelineRun, beforeCondition *apis.Condition, previousError error) error {
+	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "emitReconcileEvents")
 	defer span.End()
-	logger := logging.FromContext(ctx)
 
 	afterCondition := pr.Status.GetCondition(apis.ConditionSucceeded)
 	events.Emit(ctx, beforeCondition, afterCondition, pr)
 
-	errs := []error{previousError}
-
-	// If the PipelineRun was already completed before and remains completed,
-	// there is no need to update labels and annotations — they can't have
-	// changed. This avoids an unnecessary API read+write on every resync of
-	// a done PipelineRun (ported from the TaskRun reconciler).
-	skipUpdateLabelsAndAnnotations := !afterCondition.IsUnknown() && !beforeCondition.IsUnknown()
-	if !skipUpdateLabelsAndAnnotations {
-		_, err := c.updateLabelsAndAnnotations(ctx, pr)
-		if err != nil {
-			logger.Warn("Failed to update PipelineRun labels/annotations", zap.Error(err))
-			events.EmitError(controller.GetEventRecorder(ctx), err, pr)
-			errs = append(errs, err)
-		}
-	}
-
-	joinedErr := errors.Join(errs...)
 	if controller.IsPermanentError(previousError) {
-		return controller.NewPermanentError(joinedErr)
+		return controller.NewPermanentError(previousError)
 	}
-	return joinedErr
+	return previousError
 }
 
 // resolvePipelineState will attempt to resolve each referenced pipeline task in the pipeline's spec and all of the resources
@@ -1922,24 +1914,32 @@ func addMetadataByPrecedence(metadata map[string]string, addedMetadata map[strin
 	}
 }
 
-func (c *Reconciler) updateLabelsAndAnnotations(ctx context.Context, pr *v1.PipelineRun) (*v1.PipelineRun, error) {
-	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "updateLabelsAndAnnotations")
+// syncMetadata persists label and annotation changes made during reconciliation.
+// Knative's generated reconciler only calls UpdateStatus() after ReconcileKind returns,
+// so metadata changes must be persisted separately. This is called via defer in
+// ReconcileKind to ensure it runs on every exit path.
+func (c *Reconciler) syncMetadata(ctx context.Context, pr *v1.PipelineRun) error {
+	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "syncMetadata")
 	defer span.End()
-	newPr, err := c.pipelineRunLister.PipelineRuns(pr.Namespace).Get(pr.Name)
+
+	existing, err := c.pipelineRunLister.PipelineRuns(pr.Namespace).Get(pr.Name)
 	if err != nil {
-		return nil, fmt.Errorf("error getting PipelineRun %s when updating labels/annotations: %w", pr.Name, err)
+		return fmt.Errorf("error getting PipelineRun %s when syncing metadata: %w", pr.Name, err)
 	}
-	if !maps.Equal(pr.ObjectMeta.Labels, newPr.ObjectMeta.Labels) || !maps.Equal(pr.ObjectMeta.Annotations, newPr.ObjectMeta.Annotations) {
-		// Note that this uses Update vs. Patch because the former is significantly easier to test.
-		// If we want to switch this to Patch, then we will need to teach the utilities in test/controller.go
-		// to deal with Patch (setting resourceVersion, and optimistic concurrency checks).
-		newPr = newPr.DeepCopy()
-		// Properly merge labels and annotations, as the labels *might* have changed during the reconciliation
-		newPr.Labels = kmap.Union(newPr.Labels, pr.Labels)
-		newPr.Annotations = kmap.Union(newPr.Annotations, pr.Annotations)
-		return c.PipelineClientSet.TektonV1().PipelineRuns(pr.Namespace).Update(ctx, newPr, metav1.UpdateOptions{})
+
+	// Merge labels and annotations: existing values are preserved, reconciled values take precedence
+	mergedLabels := kmap.Union(existing.Labels, pr.Labels)
+	mergedAnnotations := kmap.Union(existing.Annotations, pr.Annotations)
+
+	if reflect.DeepEqual(mergedLabels, existing.ObjectMeta.Labels) && reflect.DeepEqual(mergedAnnotations, existing.ObjectMeta.Annotations) {
+		return nil
 	}
-	return newPr, nil
+
+	updated := existing.DeepCopy()
+	updated.Labels = mergedLabels
+	updated.Annotations = mergedAnnotations
+	_, err = c.PipelineClientSet.TektonV1().PipelineRuns(pr.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	return err
 }
 
 func storePipelineSpecAndMergeMeta(ctx context.Context, pr *v1.PipelineRun, ps *v1.PipelineSpec, meta *resolutionutil.ResolvedObjectMeta) error {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -21,8 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -182,7 +182,7 @@ var (
 // ReconcileKind compares the actual state with the desired, and attempts to
 // converge the two. It then updates the Status block of the Pipeline Run
 // resource with the current status of the resource.
-func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgreconciler.Event {
+func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) (reconcileErr pkgreconciler.Event) {
 	logger := logging.FromContext(ctx)
 	ctx = initTracing(ctx, c.tracerProvider, pr)
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "PipelineRun:ReconcileKind")
@@ -203,6 +203,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 	defer func() {
 		if err := c.syncMetadata(ctx, pr); err != nil {
 			logger.Warn("Failed to sync PipelineRun metadata", zap.Error(err))
+			events.EmitError(controller.GetEventRecorder(ctx), err, pr)
+			reconcileErr = errors.Join(reconcileErr, err)
 		}
 	}()
 
@@ -1931,7 +1933,7 @@ func (c *Reconciler) syncMetadata(ctx context.Context, pr *v1.PipelineRun) error
 	mergedLabels := kmap.Union(existing.Labels, pr.Labels)
 	mergedAnnotations := kmap.Union(existing.Annotations, pr.Annotations)
 
-	if reflect.DeepEqual(mergedLabels, existing.ObjectMeta.Labels) && reflect.DeepEqual(mergedAnnotations, existing.ObjectMeta.Annotations) {
+	if maps.Equal(mergedLabels, existing.ObjectMeta.Labels) && maps.Equal(mergedAnnotations, existing.ObjectMeta.Annotations) {
 		return nil
 	}
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -3817,6 +3817,77 @@ spec:
 	}
 }
 
+// TestReconcile_SyncMetadataFailure verifies that when the deferred syncMetadata
+// call fails (metadata Update returns an error), the error is propagated back
+// from ReconcileKind and an error event is emitted.
+func TestReconcile_SyncMetadataFailure(t *testing.T) {
+	pipelineRun := parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: test-pr-sync-fail
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+status:
+  conditions:
+  - reason: Running
+    status: Unknown
+    type: Succeeded
+  startTime: "2024-01-23T09:55:17Z"
+`)
+	pipeline := parse.MustParseV1Pipeline(t, `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+  - name: unit-test
+    taskRef:
+      name: unit-test-task
+`)
+
+	d := test.Data{
+		PipelineRuns: []*v1.PipelineRun{pipelineRun},
+		Pipelines:    []*v1.Pipeline{pipeline},
+	}
+	testAssets, cancel := getPipelineRunController(t, d)
+	defer cancel()
+
+	// Make metadata Update fail.
+	updateErr := errors.New("injected metadata update failure")
+	testAssets.Clients.Pipeline.PrependReactor("update", "pipelineruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		// Only fail the metadata update (not status updates).
+		if action.GetSubresource() == "" {
+			ua := action.(ktesting.UpdateAction)
+			return true, ua.GetObject(), updateErr
+		}
+		return false, nil, nil
+	})
+
+	err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, "foo/test-pr-sync-fail")
+	if err == nil {
+		t.Fatal("Expected error from Reconcile when syncMetadata fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "injected metadata update failure") {
+		t.Errorf("Expected error to contain syncMetadata failure, got: %v", err)
+	}
+
+	// Verify an error event was emitted by draining the recorder channel.
+	foundErrorEvent := false
+	for range 10 {
+		select {
+		case event := <-testAssets.Recorder.Events:
+			if strings.Contains(event, "Warning") && strings.Contains(event, "injected metadata update failure") {
+				foundErrorEvent = true
+			}
+		default:
+		}
+	}
+	if !foundErrorEvent {
+		t.Error("Expected a Warning error event from syncMetadata failure, but none was found")
+	}
+}
+
 func TestReconcilePropagateLabelsAndAnnotations(t *testing.T) {
 	names.TestingSeed()
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -129,7 +129,7 @@ var (
 // ReconcileKind compares the actual state with the desired, and attempts to
 // converge the two. It then updates the Status block of the Task Run
 // resource with the current status of the resource.
-func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgreconciler.Event {
+func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) (reconcileErr pkgreconciler.Event) {
 	logger := logging.FromContext(ctx)
 	ctx = initTracing(ctx, c.tracerProvider, tr)
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "TaskRun:ReconcileKind")
@@ -142,10 +142,14 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	}
 
 	// Set the release annotation early so it's available throughout reconciliation.
-	if tr.Annotations == nil {
-		tr.Annotations = make(map[string]string, 1)
+	// Only set for TaskRuns that haven't completed yet, to avoid overwriting
+	// the annotation with the current controller version on resyncs of done runs.
+	if !tr.IsDone() {
+		if tr.Annotations == nil {
+			tr.Annotations = make(map[string]string, 1)
+		}
+		tr.Annotations[podconvert.ReleaseAnnotation] = changeset.Get()
 	}
-	tr.Annotations[podconvert.ReleaseAnnotation] = changeset.Get()
 
 	// Sync metadata (labels/annotations) at the end of every reconciliation.
 	// This is deferred to ensure it runs on every exit path.
@@ -154,6 +158,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	defer func() {
 		if err := c.syncMetadata(ctx, tr); err != nil {
 			logger.Warn("Failed to sync TaskRun metadata", zap.Error(err))
+			events.EmitError(controller.GetEventRecorder(ctx), err, tr)
+			reconcileErr = errors.Join(reconcileErr, err)
 		}
 	}()
 	// Read the initial condition
@@ -869,7 +875,7 @@ func (c *Reconciler) syncMetadata(ctx context.Context, tr *v1.TaskRun) (err erro
 		tr.Annotations,
 	)
 
-	if reflect.DeepEqual(mergedLabels, existing.ObjectMeta.Labels) && reflect.DeepEqual(mergedAnnotations, existing.ObjectMeta.Annotations) {
+	if maps.Equal(mergedLabels, existing.ObjectMeta.Labels) && maps.Equal(mergedAnnotations, existing.ObjectMeta.Annotations) {
 		return nil
 	}
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -140,6 +140,22 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 		logger = logger.With(zap.String("traceID", spanCtx.TraceID().String()), zap.String("spanID", spanCtx.SpanID().String()))
 		ctx = logging.WithLogger(ctx, logger)
 	}
+
+	// Set the release annotation early so it's available throughout reconciliation.
+	if tr.Annotations == nil {
+		tr.Annotations = make(map[string]string, 1)
+	}
+	tr.Annotations[podconvert.ReleaseAnnotation] = changeset.Get()
+
+	// Sync metadata (labels/annotations) at the end of every reconciliation.
+	// This is deferred to ensure it runs on every exit path.
+	// Knative's generated reconciler only calls UpdateStatus(), never writes .metadata,
+	// so we must persist label/annotation changes ourselves.
+	defer func() {
+		if err := c.syncMetadata(ctx, tr); err != nil {
+			logger.Warn("Failed to sync TaskRun metadata", zap.Error(err))
+		}
+	}()
 	// Read the initial condition
 	before := tr.Status.GetCondition(apis.ConditionSucceeded)
 
@@ -182,7 +198,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 			}
 		}
 
-		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, nil)
+		return c.emitReconcileEvents(ctx, tr, before, nil)
 	}
 
 	// If the TaskRun is cancelled, kill resources and update status
@@ -190,13 +206,13 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 		message := fmt.Sprintf("TaskRun %q was cancelled. %s", tr.Name, tr.Spec.StatusMessage)
 		message = appendPreviousConditionContext(before, message)
 		err := c.failTaskRun(ctx, tr, v1.TaskRunReasonCancelled, message)
-		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, err)
+		return c.emitReconcileEvents(ctx, tr, before, err)
 	}
 
 	// When TaskRun is pending, do not create a Pod. Set condition and return.
 	if tr.IsPending() {
 		tr.Status.MarkResourceOngoing(v1.TaskRunReasonPending, fmt.Sprintf("TaskRun %q is pending", tr.Name))
-		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, nil)
+		return c.emitReconcileEvents(ctx, tr, before, nil)
 	}
 
 	// Check if the TaskRun has timed out; if it is, this will set its status
@@ -210,7 +226,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 		message := fmt.Sprintf("TaskRun %q failed to finish within %q", tr.Name, tr.GetTimeout(ctx))
 		message = appendPreviousConditionContext(before, message)
 		err := c.failTaskRun(ctx, tr, v1.TaskRunReasonTimedOut, message)
-		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, err)
+		return c.emitReconcileEvents(ctx, tr, before, err)
 	}
 
 	// Check for Pod Failures
@@ -219,7 +235,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	// from the current pod state (e.g., ImagePullBackOff, CreateContainerConfigError).
 	if failed, reason, message := c.checkPodFailed(ctx, tr); failed {
 		err := c.failTaskRun(ctx, tr, reason, message)
-		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, err)
+		return c.emitReconcileEvents(ctx, tr, before, err)
 	}
 
 	// prepare fetches all required resources, validates them together with the
@@ -231,7 +247,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 		// reconcile an invalid TaskRun anymore
 		span.SetStatus(codes.Error, "taskrun prepare error")
 		span.RecordError(err)
-		return c.finishReconcileUpdateEmitEvents(ctx, tr, nil, err)
+		return c.emitReconcileEvents(ctx, tr, nil, err)
 	}
 
 	// Store the condition before reconcile
@@ -244,12 +260,12 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 		if errors.Is(err, sidecarlogresults.ErrSizeExceeded) {
 			message := fmt.Sprintf("%s TaskRun \"%q\" failed: %s", pipelineErrors.UserErrorLabel, tr.Name, err.Error())
 			err := c.failTaskRun(ctx, tr, v1.TaskRunReasonResultLargerThanAllowedLimit, message)
-			return c.finishReconcileUpdateEmitEvents(ctx, tr, before, err)
+			return c.emitReconcileEvents(ctx, tr, before, err)
 		}
 	}
 
 	// Emit events (only when ConditionSucceeded was changed)
-	if err = c.finishReconcileUpdateEmitEvents(ctx, tr, before, err); err != nil {
+	if err = c.emitReconcileEvents(ctx, tr, before, err); err != nil {
 		return err
 	}
 
@@ -454,10 +470,9 @@ func (c *Reconciler) stopSidecars(ctx context.Context, tr *v1.TaskRun) error {
 	return nil
 }
 
-func (c *Reconciler) finishReconcileUpdateEmitEvents(ctx context.Context, tr *v1.TaskRun, beforeCondition *apis.Condition, previousError error) error {
-	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "finishReconcileUpdateEmitEvents")
+func (c *Reconciler) emitReconcileEvents(ctx context.Context, tr *v1.TaskRun, beforeCondition *apis.Condition, previousError error) error {
+	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "emitReconcileEvents")
 	defer span.End()
-	logger := logging.FromContext(ctx)
 
 	afterCondition := tr.Status.GetCondition(apis.ConditionSucceeded)
 	if afterCondition.IsFalse() && !tr.IsCancelled() && tr.IsRetriable() {
@@ -466,24 +481,10 @@ func (c *Reconciler) finishReconcileUpdateEmitEvents(ctx context.Context, tr *v1
 	}
 	events.Emit(ctx, beforeCondition, afterCondition, tr)
 
-	errs := []error{previousError}
-
-	// If the Run has been completed before and remains so at present,
-	// no need to update the labels and annotations
-	skipUpdateLabelsAndAnnotations := !afterCondition.IsUnknown() && !beforeCondition.IsUnknown()
-	if !skipUpdateLabelsAndAnnotations {
-		_, err := c.updateLabelsAndAnnotations(ctx, tr)
-		if err != nil {
-			logger.Warn("Failed to update TaskRun labels/annotations", zap.Error(err))
-			events.EmitError(controller.GetEventRecorder(ctx), err, tr)
-			errs = append(errs, err)
-		}
-	}
-	joinedErr := errors.Join(errs...)
 	if controller.IsPermanentError(previousError) {
-		return controller.NewPermanentError(joinedErr)
+		return controller.NewPermanentError(previousError)
 	}
-	return joinedErr
+	return previousError
 }
 
 // `prepare` fetches resources the taskrun depends on, runs validation and conversion
@@ -842,8 +843,12 @@ func (c *Reconciler) updateTaskRunWithDefaultWorkspaces(ctx context.Context, tr 
 	return nil
 }
 
-func (c *Reconciler) updateLabelsAndAnnotations(ctx context.Context, tr *v1.TaskRun) (_ *v1.TaskRun, err error) {
-	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "updateLabelsAndAnnotations")
+// syncMetadata persists label and annotation changes made during reconciliation.
+// Knative's generated reconciler only calls UpdateStatus() after ReconcileKind returns,
+// so metadata changes must be persisted separately. This is called via defer in
+// ReconcileKind to ensure it runs on every exit path.
+func (c *Reconciler) syncMetadata(ctx context.Context, tr *v1.TaskRun) (err error) {
+	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "syncMetadata")
 	defer span.End()
 	defer func() {
 		if err != nil {
@@ -851,26 +856,28 @@ func (c *Reconciler) updateLabelsAndAnnotations(ctx context.Context, tr *v1.Task
 			span.RecordError(err)
 		}
 	}()
-	// Ensure the TaskRun is properly decorated with the version of the Tekton controller processing it.
-	if tr.Annotations == nil {
-		tr.Annotations = make(map[string]string, 1)
-	}
-	tr.Annotations[podconvert.ReleaseAnnotation] = changeset.Get()
 
-	newTr, err := c.taskRunLister.TaskRuns(tr.Namespace).Get(tr.Name)
+	existing, err := c.taskRunLister.TaskRuns(tr.Namespace).Get(tr.Name)
 	if err != nil {
-		return nil, fmt.Errorf("error getting TaskRun %s when updating labels/annotations: %w", tr.Name, err)
+		return fmt.Errorf("error getting TaskRun %s when syncing metadata: %w", tr.Name, err)
 	}
-	if !maps.Equal(tr.ObjectMeta.Labels, newTr.ObjectMeta.Labels) || !maps.Equal(tr.ObjectMeta.Annotations, newTr.ObjectMeta.Annotations) {
-		// Note that this uses Update vs. Patch because the former is significantly easier to test.
-		// If we want to switch this to Patch, then we will need to teach the utilities in test/controller.go
-		// to deal with Patch (setting resourceVersion, and optimistic concurrency checks).
-		newTr = newTr.DeepCopy()
-		newTr.Labels = kmap.Union(newTr.Labels, tr.Labels)
-		newTr.Annotations = kmap.Union(kmap.ExcludeKeys(newTr.Annotations, tknreconciler.KubectlLastAppliedAnnotationKey), tr.Annotations)
-		return c.PipelineClientSet.TektonV1().TaskRuns(tr.Namespace).Update(ctx, newTr, metav1.UpdateOptions{})
+
+	// Merge labels and annotations: existing values are preserved, reconciled values take precedence
+	mergedLabels := kmap.Union(existing.Labels, tr.Labels)
+	mergedAnnotations := kmap.Union(
+		kmap.ExcludeKeys(existing.Annotations, tknreconciler.KubectlLastAppliedAnnotationKey),
+		tr.Annotations,
+	)
+
+	if reflect.DeepEqual(mergedLabels, existing.ObjectMeta.Labels) && reflect.DeepEqual(mergedAnnotations, existing.ObjectMeta.Annotations) {
+		return nil
 	}
-	return newTr, nil
+
+	updated := existing.DeepCopy()
+	updated.Labels = mergedLabels
+	updated.Annotations = mergedAnnotations
+	_, err = c.PipelineClientSet.TektonV1().TaskRuns(tr.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	return err
 }
 
 func (c *Reconciler) handlePodCreationError(tr *v1.TaskRun, err error) error {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -7843,8 +7843,9 @@ status:
 		name:    "completed",
 		taskRun: taskRunCompleted,
 		wantAnnotations: map[string]string{
-			// annotation always reflects the controller version that processed the run
-			"pipeline.tekton.dev/release": fakeVersion,
+			// annotation not updated: the run is already terminal on entry, so the
+			// release annotation is left frozen at its existing value
+			"pipeline.tekton.dev/release": "release-sha",
 		},
 	}, {
 		name:    "cancelled",

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -7843,15 +7843,15 @@ status:
 		name:    "completed",
 		taskRun: taskRunCompleted,
 		wantAnnotations: map[string]string{
-			// annotation not updated
-			"pipeline.tekton.dev/release": "release-sha",
+			// annotation always reflects the controller version that processed the run
+			"pipeline.tekton.dev/release": fakeVersion,
 		},
 	}, {
 		name:    "cancelled",
 		taskRun: taskRunCancelled,
 		wantAnnotations: map[string]string{
-			// annotation updated
-			"pipeline.tekton.dev/release": "unknown",
+			// annotation always reflects the controller version that processed the run
+			"pipeline.tekton.dev/release": fakeVersion,
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -7843,8 +7843,9 @@ status:
 		name:    "completed",
 		taskRun: taskRunCompleted,
 		wantAnnotations: map[string]string{
-			// annotation always reflects the controller version that processed the run
-			"pipeline.tekton.dev/release": fakeVersion,
+			// annotation not updated: the run is already terminal on entry, so the
+			// release annotation is left frozen at its existing value
+			"pipeline.tekton.dev/release": "release-sha",
 		},
 	}, {
 		name:    "cancelled",
@@ -7874,6 +7875,69 @@ status:
 				t.Errorf("TaskRun annotations doesn't match %s", diff.PrintWantGot(d))
 			}
 		})
+	}
+}
+
+// TestReconcile_SyncMetadataFailure verifies that when the deferred syncMetadata
+// call fails (metadata Update returns an error), the error is propagated back
+// from ReconcileKind and an error event is emitted.
+func TestReconcile_SyncMetadataFailure(t *testing.T) {
+	// Use a cancelled TaskRun so reconciliation is short but still mutates
+	// metadata (release annotation is set for non-done runs).
+	taskRun := parse.MustParseV1TaskRun(t, `
+metadata:
+  name: test-taskrun-sync-fail
+  namespace: foo
+spec:
+  status: TaskRunCancelled
+  taskRef:
+    name: test-task
+status:
+  conditions:
+  - reason: Pending
+    status: Unknown
+    type: Succeeded
+`)
+	d := test.Data{
+		TaskRuns: []*v1.TaskRun{taskRun},
+		Tasks:    []*v1.Task{simpleTask},
+	}
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+
+	// Make metadata Update fail.
+	updateErr := errors.New("injected metadata update failure")
+	testAssets.Clients.Pipeline.PrependReactor("update", "taskruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		ua := action.(ktesting.UpdateAction)
+		obj := ua.GetObject()
+		// Only fail the metadata update (not status updates).
+		if action.GetSubresource() == "" {
+			return true, obj, updateErr
+		}
+		return false, nil, nil
+	})
+
+	err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRunName(taskRun))
+	if err == nil {
+		t.Fatal("Expected error from Reconcile when syncMetadata fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "injected metadata update failure") {
+		t.Errorf("Expected error to contain syncMetadata failure, got: %v", err)
+	}
+
+	// Verify an error event was emitted by draining the recorder channel.
+	foundErrorEvent := false
+	for range 10 {
+		select {
+		case event := <-testAssets.Recorder.Events:
+			if strings.Contains(event, "Warning") && strings.Contains(event, "injected metadata update failure") {
+				foundErrorEvent = true
+			}
+		default:
+		}
+	}
+	if !foundErrorEvent {
+		t.Error("Expected a Warning error event from syncMetadata failure, but none was found")
 	}
 }
 


### PR DESCRIPTION
# Changes

The TaskRun and PipelineRun reconcilers call `Update()` on their own objects
inside `ReconcileKind` via `updateLabelsAndAnnotations`, which is coupled to
event emission in `finishReconcileUpdateEmitEvents`. This is unexpected in
Knative's reconciler model (where the framework handles writes after
`ReconcileKind` returns) and makes the reconciliation flow harder to follow.

**Root cause:** Knative's generated reconciler only calls `UpdateStatus()` —
it never writes `.metadata`. So label/annotation changes *must* be persisted
by Tekton separately. But the current implementation couples this with event
emission, and relies on manual calls at each return point.

This PR:

- **Decouples metadata sync from event emission** — `syncMetadata` is a
  standalone function called via `defer` in `ReconcileKind`, ensuring it runs
  on every exit path without manual wiring
- **Renames `finishReconcileUpdateEmitEvents` → `emitReconcileEvents`** since
  it no longer handles metadata persistence
- **Moves `ReleaseAnnotation`** (TaskRun) from `updateLabelsAndAnnotations` to
  early in `ReconcileKind` so it's set consistently regardless of exit path

No user-facing behavior change — same labels/annotations end up on objects.

Fixes #5146

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```