### PR TITLE
Validate workspace variable references in Tasks

### DIFF
--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -66,6 +66,10 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 	// When a Task is created directly, instead of declared inline in a TaskRun or PipelineRun,
 	// we do not support propagated parameters. Validate that all params it uses are declared.
 	errs = errs.Also(ValidateUsageOfDeclaredParameters(ctx, t.Spec.Steps, t.Spec.Params).ViaField("spec"))
+	// When a Task is created directly, instead of declared inline in a TaskRun or PipelineRun,
+	// we do not support propagated workspaces. Validate that all workspace variable references
+	// (e.g. $(workspaces.foo.path)) refer to declared workspaces with valid properties.
+	errs = errs.Also(ValidateUsageOfDeclaredWorkspaces(ctx, t.Spec.Steps, t.Spec.Sidecars, t.Spec.Workspaces).ViaField("spec"))
 	return errs
 }
 
@@ -155,6 +159,27 @@ func validateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step,
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("workspace mount path %q must be unique", mountPath), "mountpath").ViaIndex(idx))
 		}
 		mountPaths[mountPath] = struct{}{}
+	}
+	return errs
+}
+
+// ValidateUsageOfDeclaredWorkspaces validates that all workspace variable references
+// (e.g. $(workspaces.foo.path)) in Steps and Sidecars refer to workspaces declared in the Task
+// and use valid workspace properties (path, bound, claim, volume).
+func ValidateUsageOfDeclaredWorkspaces(ctx context.Context, steps []Step, sidecars []Sidecar, workspaces []WorkspaceDeclaration) *apis.FieldError {
+	var errs *apis.FieldError
+	wsNames := sets.NewString()
+	for _, w := range workspaces {
+		wsNames.Insert(w.Name)
+	}
+	// Validate that workspace variable references refer to declared workspaces
+	errs = errs.Also(validateVariables(ctx, steps, "workspaces", wsNames))
+	errs = errs.Also(validateSidecarVariables(ctx, sidecars, "workspaces", wsNames))
+	// Validate that workspace properties are valid (path, bound, claim, volume)
+	wsProperties := sets.NewString("path", "bound", "claim", "volume")
+	for _, w := range workspaces {
+		errs = errs.Also(validateVariables(ctx, steps, "workspaces\\."+w.Name, wsProperties))
+		errs = errs.Also(validateSidecarVariables(ctx, sidecars, "workspaces\\."+w.Name, wsProperties))
 	}
 	return errs
 }
@@ -447,6 +472,37 @@ func validateStepArrayUsage(step Step, prefix string, arrayParamNames sets.Strin
 func validateVariables(ctx context.Context, steps []Step, prefix string, vars sets.String) (errs *apis.FieldError) {
 	for idx, step := range steps {
 		errs = errs.Also(validateStepVariables(ctx, step, prefix, vars).ViaFieldIndex("steps", idx))
+	}
+	return errs
+}
+
+// validateSidecarVariables returns an error if the Sidecars contain references to any unknown variables
+func validateSidecarVariables(ctx context.Context, sidecars []Sidecar, prefix string, vars sets.String) (errs *apis.FieldError) {
+	for idx, sidecar := range sidecars {
+		errs = errs.Also(validateSidecarContainerVariables(ctx, sidecar, prefix, vars).ViaFieldIndex("sidecars", idx))
+	}
+	return errs
+}
+
+// validateSidecarContainerVariables validates variable references in a single Sidecar
+func validateSidecarContainerVariables(ctx context.Context, sidecar Sidecar, prefix string, vars sets.String) *apis.FieldError {
+	errs := substitution.ValidateNoReferencesToUnknownVariables(sidecar.Name, prefix, vars).ViaField("name")
+	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(sidecar.Image, prefix, vars).ViaField("image"))
+	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(sidecar.WorkingDir, prefix, vars).ViaField("workingDir"))
+	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(sidecar.Script, prefix, vars).ViaField("script"))
+	for i, cmd := range sidecar.Command {
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(cmd, prefix, vars).ViaFieldIndex("command", i))
+	}
+	for i, arg := range sidecar.Args {
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(arg, prefix, vars).ViaFieldIndex("args", i))
+	}
+	for _, env := range sidecar.Env {
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
+	}
+	for i, v := range sidecar.VolumeMounts {
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.Name, prefix, vars).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.MountPath, prefix, vars).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.SubPath, prefix, vars).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -57,6 +57,13 @@ func (t *Task) SupportedVerbs() []admissionregistrationv1.OperationType {
 var (
 	stringAndArrayVariableNameFormatRegex = regexp.MustCompile(stringAndArrayVariableNameFormat)
 	objectVariableNameFormatRegex         = regexp.MustCompile(objectVariableNameFormat)
+
+	// workspaceVariableRegex matches workspace variable references, capturing the workspace name
+	// and, when present, the property, e.g. $(workspaces.myws.path).
+	workspaceVariableRegex = regexp.MustCompile(`\$\(workspaces\.([^.)]*)(?:\.([^)]*))?\)`)
+
+	// validWorkspaceProperties are the workspace properties substituted at runtime.
+	validWorkspaceProperties = sets.NewString("path", "bound", "claim", "volume")
 )
 
 // Validate implements apis.Validatable
@@ -66,6 +73,10 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 	// When a Task is created directly, instead of declared inline in a TaskRun or PipelineRun,
 	// we do not support propagated parameters. Validate that all params it uses are declared.
 	errs = errs.Also(ValidateUsageOfDeclaredParameters(ctx, t.Spec.Steps, t.Spec.Params).ViaField("spec"))
+	// When a Task is created directly, instead of declared inline in a TaskRun or PipelineRun,
+	// we do not support propagated workspaces. Validate that all workspace variable references
+	// (e.g. $(workspaces.foo.path)) refer to declared workspaces with valid properties.
+	errs = errs.Also(ValidateUsageOfDeclaredWorkspaces(t.Spec.Steps, t.Spec.Sidecars, t.Spec.Workspaces).ViaField("spec"))
 	return errs
 }
 
@@ -157,6 +168,43 @@ func validateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step,
 		mountPaths[mountPath] = struct{}{}
 	}
 	return errs
+}
+
+// ValidateUsageOfDeclaredWorkspaces validates that all workspace variable references
+// (e.g. $(workspaces.foo.path)) in Steps and Sidecars refer to workspaces declared in the Task
+// and use one of the valid workspace properties (path, bound, claim, volume).
+func ValidateUsageOfDeclaredWorkspaces(steps []Step, sidecars []Sidecar, workspaces []WorkspaceDeclaration) *apis.FieldError {
+	var errs *apis.FieldError
+	wsNames := sets.NewString()
+	for _, w := range workspaces {
+		wsNames.Insert(w.Name)
+	}
+	check := func(value string, _ bool) *apis.FieldError {
+		return validateWorkspaceVariableReferences(value, wsNames)
+	}
+	for idx, step := range steps {
+		errs = errs.Also(walkStepVariableFields(step, check).ViaFieldIndex("steps", idx))
+	}
+	for idx, sidecar := range sidecars {
+		errs = errs.Also(walkSidecarVariableFields(sidecar, check).ViaFieldIndex("sidecars", idx))
+	}
+	return errs
+}
+
+// validateWorkspaceVariableReferences returns an error if value references a workspace that is
+// not in wsNames, or uses a property that is not substituted at runtime. Bare references such as
+// $(workspaces.myws) are rejected: only $(workspaces.myws.<property>) is substituted.
+func validateWorkspaceVariableReferences(value string, wsNames sets.String) *apis.FieldError {
+	for _, match := range workspaceVariableRegex.FindAllStringSubmatch(value, -1) {
+		if !wsNames.Has(match[1]) || !validWorkspaceProperties.Has(match[2]) {
+			return &apis.FieldError{
+				Message: fmt.Sprintf("non-existent variable in %q", value),
+				// Empty path is required to make the `ViaField`, … work
+				Paths: []string{""},
+			}
+		}
+	}
+	return nil
 }
 
 // validateWorkspaceUsages checks that all WorkspaceUsage objects in Steps
@@ -465,6 +513,31 @@ func validateVariables(ctx context.Context, steps []Step, prefix string, vars se
 	return errs
 }
 
+// walkSidecarVariableFields calls check on every Sidecar field that supports variable
+// substitution, attaching the path of the field to any error returned. check is called with
+// isScript set to true for the script field, which some callers report with more detail.
+func walkSidecarVariableFields(sidecar Sidecar, check func(value string, isScript bool) *apis.FieldError) *apis.FieldError {
+	errs := check(sidecar.Name, false).ViaField("name")
+	errs = errs.Also(check(sidecar.Image, false).ViaField("image"))
+	errs = errs.Also(check(sidecar.WorkingDir, false).ViaField("workingDir"))
+	errs = errs.Also(check(sidecar.Script, true).ViaField("script"))
+	for i, cmd := range sidecar.Command {
+		errs = errs.Also(check(cmd, false).ViaFieldIndex("command", i))
+	}
+	for i, arg := range sidecar.Args {
+		errs = errs.Also(check(arg, false).ViaFieldIndex("args", i))
+	}
+	for _, env := range sidecar.Env {
+		errs = errs.Also(check(env.Value, false).ViaFieldKey("env", env.Name))
+	}
+	for i, v := range sidecar.VolumeMounts {
+		errs = errs.Also(check(v.Name, false).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(check(v.MountPath, false).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(check(v.SubPath, false).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
+	}
+	return errs
+}
+
 // ValidateNameFormat validates that the name format of all param types follows the rules
 func ValidateNameFormat(stringAndArrayParams sets.String, objectParams []ParamSpec) (errs *apis.FieldError) {
 	// checking string or array name format
@@ -516,25 +589,40 @@ func ValidateNameFormat(stringAndArrayParams sets.String, objectParams []ParamSp
 
 // validateStepVariables returns an error if the Step contains references to any unknown variables
 func validateStepVariables(ctx context.Context, step Step, prefix string, vars sets.String) *apis.FieldError {
-	errs := substitution.ValidateNoReferencesToUnknownVariables(step.Name, prefix, vars).ViaField("name")
-	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(step.Image, prefix, vars).ViaField("image"))
-	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(step.WorkingDir, prefix, vars).ViaField("workingDir"))
-	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(step.Script, prefix, vars).ViaField("script"))
+	return walkStepVariableFields(step, func(value string, _ bool) *apis.FieldError {
+		return substitution.ValidateNoReferencesToUnknownVariables(value, prefix, vars)
+	})
+}
+
+// walkStepVariableFields calls check on every Step field that supports variable substitution,
+// attaching the path of the field to any error returned. check is called with isScript set to
+// true for the script field, which some callers report with more detail.
+func walkStepVariableFields(step Step, check func(value string, isScript bool) *apis.FieldError) *apis.FieldError {
+	errs := check(step.Name, false).ViaField("name")
+	errs = errs.Also(check(step.Image, false).ViaField("image"))
+	errs = errs.Also(check(step.WorkingDir, false).ViaField("workingDir"))
+	errs = errs.Also(check(step.Script, true).ViaField("script"))
 	for i, cmd := range step.Command {
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(cmd, prefix, vars).ViaFieldIndex("command", i))
+		errs = errs.Also(check(cmd, false).ViaFieldIndex("command", i))
 	}
 	for i, arg := range step.Args {
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(arg, prefix, vars).ViaFieldIndex("args", i))
+		errs = errs.Also(check(arg, false).ViaFieldIndex("args", i))
 	}
 	for _, env := range step.Env {
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
+		errs = errs.Also(check(env.Value, false).ViaFieldKey("env", env.Name))
 	}
 	for i, v := range step.VolumeMounts {
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.Name, prefix, vars).ViaField("name").ViaFieldIndex("volumeMount", i))
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.MountPath, prefix, vars).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.SubPath, prefix, vars).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(check(v.Name, false).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(check(v.MountPath, false).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(check(v.SubPath, false).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
 	}
-	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(string(step.OnError), prefix, vars).ViaField("onError"))
+	if step.StdoutConfig != nil {
+		errs = errs.Also(check(step.StdoutConfig.Path, false).ViaField("path").ViaField("stdoutConfig"))
+	}
+	if step.StderrConfig != nil {
+		errs = errs.Also(check(step.StderrConfig.Path, false).ViaField("path").ViaField("stderrConfig"))
+	}
+	errs = errs.Also(check(string(step.OnError), false).ViaField("onError"))
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -810,6 +810,331 @@ func TestTaskValidateError(t *testing.T) {
 	}
 }
 
+func TestTaskValidateWorkspaceVariableReferences(t *testing.T) {
+	tests := []struct {
+		name       string
+		workspaces []v1.WorkspaceDeclaration
+		steps      []v1.Step
+	}{{ // Valid cases
+		name: "valid workspace variable in script",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.path)",
+		}},
+	}, {
+		name: "valid workspace variable bound in args",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Args:  []string{"$(workspaces.myws.bound)"},
+		}},
+	}, {
+		name: "valid workspace variable claim in env",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Env: []corev1.EnvVar{{
+				Name:  "CLAIM",
+				Value: "$(workspaces.myws.claim)",
+			}},
+		}},
+	}, {
+		name: "valid workspace variable volume in command",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:    "step1",
+			Image:   "my-image",
+			Command: []string{"echo", "$(workspaces.myws.volume)"},
+		}},
+	}, {
+		name: "valid multiple workspaces referenced",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "source",
+		}, {
+			Name: "output",
+		}},
+		steps: []v1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "cp $(workspaces.source.path)/file $(workspaces.output.path)/file",
+		}},
+	}, {
+		name: "valid workspace variable in stdoutConfig path",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:         "step1",
+			Image:        "my-image",
+			StdoutConfig: &v1.StepOutputConfig{Path: "$(workspaces.myws.path)/stdout.txt"},
+		}},
+	}, {
+		name: "no workspace references is valid",
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Args:  []string{"hello"},
+		}},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &v1.Task{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1.TaskSpec{
+					Workspaces: tt.workspaces,
+					Steps:      tt.steps,
+				},
+			}
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
+			task.SetDefaults(ctx)
+			err := task.Validate(ctx)
+			if err != nil {
+				t.Errorf("Task.Validate() returned error for valid Task: %v", err)
+			}
+		})
+	}
+}
+
+func TestTaskValidateWorkspaceVariableReferencesError(t *testing.T) {
+	tests := []struct {
+		name          string
+		workspaces    []v1.WorkspaceDeclaration
+		steps         []v1.Step
+		sidecars      []v1.Sidecar
+		expectedError apis.FieldError
+	}{{
+		name: "undeclared workspace in script",
+		steps: []v1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.undeclared.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "echo $(workspaces.undeclared.path)"`,
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "undeclared workspace in args",
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Args:  []string{"--path=$(workspaces.missing.path)"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "--path=$(workspaces.missing.path)"`,
+			Paths:   []string{"spec.steps[0].args[0]"},
+		},
+	}, {
+		name: "undeclared workspace in env",
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Env: []corev1.EnvVar{{
+				Name:  "WS_PATH",
+				Value: "$(workspaces.absent.path)",
+			}},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.absent.path)"`,
+			Paths:   []string{"spec.steps[0].env[WS_PATH]"},
+		},
+	}, {
+		name: "undeclared workspace in command",
+		steps: []v1.Step{{
+			Name:    "step1",
+			Image:   "my-image",
+			Command: []string{"$(workspaces.nonexistent.path)"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.nonexistent.path)"`,
+			Paths:   []string{"spec.steps[0].command[0]"},
+		},
+	}, {
+		name: "undeclared workspace in image",
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "$(workspaces.nonexistent.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.nonexistent.path)"`,
+			Paths:   []string{"spec.steps[0].image"},
+		},
+	}, {
+		name: "invalid workspace property",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.invalid)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "echo $(workspaces.myws.invalid)"`,
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "one declared and one undeclared workspace",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "exists",
+		}},
+		steps: []v1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.exists.path) $(workspaces.missing.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "echo $(workspaces.exists.path) $(workspaces.missing.path)"`,
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "workspace reference in working dir",
+		steps: []v1.Step{{
+			Name:       "step1",
+			Image:      "my-image",
+			WorkingDir: "$(workspaces.nonexistent.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.nonexistent.path)"`,
+			Paths:   []string{"spec.steps[0].workingDir"},
+		},
+	}, {
+		name: "undeclared workspace in sidecar script",
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+		}},
+		sidecars: []v1.Sidecar{{
+			Name:   "sidecar1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.undeclared.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "echo $(workspaces.undeclared.path)"`,
+			Paths:   []string{"spec.sidecars[0].script"},
+		},
+	}, {
+		name: "invalid workspace property in sidecar",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+		}},
+		sidecars: []v1.Sidecar{{
+			Name:   "sidecar1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.invalid)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "echo $(workspaces.myws.invalid)"`,
+			Paths:   []string{"spec.sidecars[0].script"},
+		},
+	}, {
+		name: "bare workspace reference without property",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "echo $(workspaces.myws)"`,
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "bare workspace reference in sidecar args",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+		}},
+		sidecars: []v1.Sidecar{{
+			Name:  "sidecar1",
+			Image: "my-image",
+			Args:  []string{"$(workspaces.myws)"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.myws)"`,
+			Paths:   []string{"spec.sidecars[0].args[0]"},
+		},
+	}, {
+		name: "undeclared workspace in sidecar image",
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+		}},
+		sidecars: []v1.Sidecar{{
+			Name:  "sidecar1",
+			Image: "$(workspaces.missing.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.missing.path)"`,
+			Paths:   []string{"spec.sidecars[0].image"},
+		},
+	}, {
+		name: "undeclared workspace in stdoutConfig path",
+		steps: []v1.Step{{
+			Name:         "step1",
+			Image:        "my-image",
+			StdoutConfig: &v1.StepOutputConfig{Path: "$(workspaces.missing.path)/stdout.txt"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.missing.path)/stdout.txt"`,
+			Paths:   []string{"spec.steps[0].stdoutConfig.path"},
+		},
+	}, {
+		name: "undeclared workspace in stderrConfig path",
+		steps: []v1.Step{{
+			Name:         "step1",
+			Image:        "my-image",
+			StderrConfig: &v1.StepOutputConfig{Path: "$(workspaces.missing.path)/stderr.txt"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.missing.path)/stderr.txt"`,
+			Paths:   []string{"spec.steps[0].stderrConfig.path"},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &v1.Task{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1.TaskSpec{
+					Workspaces: tt.workspaces,
+					Steps:      tt.steps,
+					Sidecars:   tt.sidecars,
+				},
+			}
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
+			task.SetDefaults(ctx)
+			err := task.Validate(ctx)
+			if err == nil {
+				t.Fatalf("Expected an error, got nothing for %v", task)
+			}
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("Task.Validate() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
 func TestTaskSpecValidateError(t *testing.T) {
 	type fields struct {
 		Params       []v1.ParamSpec

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -790,6 +790,253 @@ func TestTaskValidateError(t *testing.T) {
 	}
 }
 
+func TestTaskValidateWorkspaceVariableReferences(t *testing.T) {
+	tests := []struct {
+		name       string
+		workspaces []v1.WorkspaceDeclaration
+		steps      []v1.Step
+	}{{ // Valid cases
+		name: "valid workspace variable in script",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.path)",
+		}},
+	}, {
+		name: "valid workspace variable bound in args",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Args:  []string{"$(workspaces.myws.bound)"},
+		}},
+	}, {
+		name: "valid workspace variable claim in env",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Env: []corev1.EnvVar{{
+				Name:  "CLAIM",
+				Value: "$(workspaces.myws.claim)",
+			}},
+		}},
+	}, {
+		name: "valid workspace variable volume in command",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:    "step1",
+			Image:   "my-image",
+			Command: []string{"echo", "$(workspaces.myws.volume)"},
+		}},
+	}, {
+		name: "valid multiple workspaces referenced",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "source",
+		}, {
+			Name: "output",
+		}},
+		steps: []v1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "cp $(workspaces.source.path)/file $(workspaces.output.path)/file",
+		}},
+	}, {
+		name: "no workspace references is valid",
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Args:  []string{"hello"},
+		}},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &v1.Task{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1.TaskSpec{
+					Workspaces: tt.workspaces,
+					Steps:      tt.steps,
+				},
+			}
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
+			task.SetDefaults(ctx)
+			err := task.Validate(ctx)
+			if err != nil {
+				t.Errorf("Task.Validate() returned error for valid Task: %v", err)
+			}
+		})
+	}
+}
+
+func TestTaskValidateWorkspaceVariableReferencesError(t *testing.T) {
+	tests := []struct {
+		name          string
+		workspaces    []v1.WorkspaceDeclaration
+		steps         []v1.Step
+		sidecars      []v1.Sidecar
+		expectedError apis.FieldError
+	}{{
+		name: "undeclared workspace in script",
+		steps: []v1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.undeclared.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "echo $(workspaces.undeclared.path)"`,
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "undeclared workspace in args",
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Args:  []string{"--path=$(workspaces.missing.path)"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "--path=$(workspaces.missing.path)"`,
+			Paths:   []string{"spec.steps[0].args[0]"},
+		},
+	}, {
+		name: "undeclared workspace in env",
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Env: []corev1.EnvVar{{
+				Name:  "WS_PATH",
+				Value: "$(workspaces.absent.path)",
+			}},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.absent.path)"`,
+			Paths:   []string{"spec.steps[0].env[WS_PATH]"},
+		},
+	}, {
+		name: "undeclared workspace in command",
+		steps: []v1.Step{{
+			Name:    "step1",
+			Image:   "my-image",
+			Command: []string{"$(workspaces.nonexistent.path)"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.nonexistent.path)"`,
+			Paths:   []string{"spec.steps[0].command[0]"},
+		},
+	}, {
+		name: "undeclared workspace in image",
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "$(workspaces.nonexistent.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.nonexistent.path)"`,
+			Paths:   []string{"spec.steps[0].image"},
+		},
+	}, {
+		name: "invalid workspace property",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.invalid)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "echo $(workspaces.myws.invalid)"`,
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "one declared and one undeclared workspace",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "exists",
+		}},
+		steps: []v1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.exists.path) $(workspaces.missing.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "echo $(workspaces.exists.path) $(workspaces.missing.path)"`,
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "workspace reference in working dir",
+		steps: []v1.Step{{
+			Name:       "step1",
+			Image:      "my-image",
+			WorkingDir: "$(workspaces.nonexistent.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.nonexistent.path)"`,
+			Paths:   []string{"spec.steps[0].workingDir"},
+		},
+	}, {
+		name: "undeclared workspace in sidecar script",
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+		}},
+		sidecars: []v1.Sidecar{{
+			Name:   "sidecar1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.undeclared.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "echo $(workspaces.undeclared.path)"`,
+			Paths:   []string{"spec.sidecars[0].script"},
+		},
+	}, {
+		name: "invalid workspace property in sidecar",
+		workspaces: []v1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+		}},
+		sidecars: []v1.Sidecar{{
+			Name:   "sidecar1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.invalid)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "echo $(workspaces.myws.invalid)"`,
+			Paths:   []string{"spec.sidecars[0].script"},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &v1.Task{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1.TaskSpec{
+					Workspaces: tt.workspaces,
+					Steps:      tt.steps,
+					Sidecars:   tt.sidecars,
+				},
+			}
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
+			task.SetDefaults(ctx)
+			err := task.Validate(ctx)
+			if err == nil {
+				t.Fatalf("Expected an error, got nothing for %v", task)
+			}
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("Task.Validate() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
 func TestTaskSpecValidateError(t *testing.T) {
 	type fields struct {
 		Params       []v1.ParamSpec

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -65,6 +65,13 @@ func (t *Task) SupportedVerbs() []admissionregistrationv1.OperationType {
 var (
 	stringAndArrayVariableNameFormatRegex = regexp.MustCompile(stringAndArrayVariableNameFormat)
 	objectVariableNameFormatRegex         = regexp.MustCompile(objectVariableNameFormat)
+
+	// workspaceVariableRegex matches workspace variable references, capturing the workspace name
+	// and, when present, the property, e.g. $(workspaces.myws.path).
+	workspaceVariableRegex = regexp.MustCompile(`\$\(workspaces\.([^.)]*)(?:\.([^)]*))?\)`)
+
+	// validWorkspaceProperties are the workspace properties substituted at runtime.
+	validWorkspaceProperties = sets.NewString("path", "bound", "claim", "volume")
 )
 
 // Validate implements apis.Validatable
@@ -73,7 +80,12 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 	errs = errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 	// When a Task is created directly, instead of declared inline in a TaskRun or PipelineRun,
 	// we do not support propagated parameters. Validate that all params it uses are declared.
-	return errs.Also(ValidateUsageOfDeclaredParameters(ctx, t.Spec.Steps, t.Spec.Params).ViaField("spec"))
+	errs = errs.Also(ValidateUsageOfDeclaredParameters(ctx, t.Spec.Steps, t.Spec.Params).ViaField("spec"))
+	// When a Task is created directly, instead of declared inline in a TaskRun or PipelineRun,
+	// we do not support propagated workspaces. Validate that all workspace variable references
+	// (e.g. $(workspaces.foo.path)) refer to declared workspaces with valid properties.
+	errs = errs.Also(ValidateUsageOfDeclaredWorkspaces(t.Spec.Steps, t.Spec.Sidecars, t.Spec.Workspaces).ViaField("spec"))
+	return errs
 }
 
 // Validate implements apis.Validatable
@@ -179,6 +191,57 @@ func validateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step,
 		mountPaths[mountPath] = struct{}{}
 	}
 	return errs
+}
+
+// ValidateUsageOfDeclaredWorkspaces validates that all workspace variable references
+// (e.g. $(workspaces.foo.path)) in Steps and Sidecars refer to workspaces declared in the Task
+// and use one of the valid workspace properties (path, bound, claim, volume).
+func ValidateUsageOfDeclaredWorkspaces(steps []Step, sidecars []Sidecar, workspaces []WorkspaceDeclaration) *apis.FieldError {
+	var errs *apis.FieldError
+	wsNames := sets.NewString()
+	for _, w := range workspaces {
+		wsNames.Insert(w.Name)
+	}
+	check := func(value string, isScript bool) *apis.FieldError {
+		return validateWorkspaceVariableReferences(value, wsNames, isScript)
+	}
+	for idx, step := range steps {
+		errs = errs.Also(walkStepVariableFields(step, check).ViaFieldIndex("steps", idx))
+	}
+	for idx, sidecar := range sidecars {
+		errs = errs.Also(walkSidecarVariableFields(sidecar, check).ViaFieldIndex("sidecars", idx))
+	}
+	return errs
+}
+
+// validateWorkspaceVariableReferences returns an error if value references a workspace that is
+// not in wsNames, or uses a property that is not substituted at runtime. Bare references such as
+// $(workspaces.myws) are rejected: only $(workspaces.myws.<property>) is substituted.
+// When withDetail is set, the offending reference is named in the error message.
+func validateWorkspaceVariableReferences(value string, wsNames sets.String, withDetail bool) *apis.FieldError {
+	for _, match := range workspaceVariableRegex.FindAllStringSubmatch(value, -1) {
+		if !wsNames.Has(match[1]) || !validWorkspaceProperties.Has(match[2]) {
+			msg := fmt.Sprintf("non-existent variable in %q", value)
+			if withDetail {
+				invalid := match[1]
+				switch {
+				case !wsNames.Has(invalid):
+				case match[2] != "":
+					invalid = match[2]
+				default:
+					// bare reference, e.g. $(workspaces.myws)
+					invalid = match[0]
+				}
+				msg = fmt.Sprintf("non-existent variable `%s` in %q", invalid, value)
+			}
+			return &apis.FieldError{
+				Message: msg,
+				// Empty path is required to make the `ViaField`, … work
+				Paths: []string{""},
+			}
+		}
+	}
+	return nil
 }
 
 // validateWorkspaceUsages checks that all WorkspaceUsage objects in Steps
@@ -687,6 +750,31 @@ func validateVariables(ctx context.Context, steps []Step, prefix string, vars se
 	return errs
 }
 
+// walkSidecarVariableFields calls check on every Sidecar field that supports variable
+// substitution, attaching the path of the field to any error returned. check is called with
+// isScript set to true for the script field, which some callers report with more detail.
+func walkSidecarVariableFields(sidecar Sidecar, check func(value string, isScript bool) *apis.FieldError) *apis.FieldError {
+	errs := check(sidecar.Name, false).ViaField("name")
+	errs = errs.Also(check(sidecar.Image, false).ViaField("image"))
+	errs = errs.Also(check(sidecar.WorkingDir, false).ViaField("workingDir"))
+	errs = errs.Also(check(sidecar.Script, true).ViaField("script"))
+	for i, cmd := range sidecar.Command {
+		errs = errs.Also(check(cmd, false).ViaFieldIndex("command", i))
+	}
+	for i, arg := range sidecar.Args {
+		errs = errs.Also(check(arg, false).ViaFieldIndex("args", i))
+	}
+	for _, env := range sidecar.Env {
+		errs = errs.Also(check(env.Value, false).ViaFieldKey("env", env.Name))
+	}
+	for i, v := range sidecar.VolumeMounts {
+		errs = errs.Also(check(v.Name, false).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(check(v.MountPath, false).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(check(v.SubPath, false).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
+	}
+	return errs
+}
+
 // validateNameFormat validates that the name format of all param types follows the rules
 func validateNameFormat(stringAndArrayParams sets.String, objectParams []ParamSpec) (errs *apis.FieldError) {
 	// checking string or array name format
@@ -738,25 +826,43 @@ func validateNameFormat(stringAndArrayParams sets.String, objectParams []ParamSp
 
 // validateStepVariables returns an error if the Step contains references to any unknown variables
 func validateStepVariables(ctx context.Context, step Step, prefix string, vars sets.String) *apis.FieldError {
-	errs := substitution.ValidateNoReferencesToUnknownVariables(step.Name, prefix, vars).ViaField("name")
-	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(step.Image, prefix, vars).ViaField("image"))
-	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(step.WorkingDir, prefix, vars).ViaField("workingDir"))
-	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariablesWithDetail(step.Script, prefix, vars).ViaField("script"))
+	return walkStepVariableFields(step, func(value string, isScript bool) *apis.FieldError {
+		if isScript {
+			return substitution.ValidateNoReferencesToUnknownVariablesWithDetail(value, prefix, vars)
+		}
+		return substitution.ValidateNoReferencesToUnknownVariables(value, prefix, vars)
+	})
+}
+
+// walkStepVariableFields calls check on every Step field that supports variable substitution,
+// attaching the path of the field to any error returned. check is called with isScript set to
+// true for the script field, which some callers report with more detail.
+func walkStepVariableFields(step Step, check func(value string, isScript bool) *apis.FieldError) *apis.FieldError {
+	errs := check(step.Name, false).ViaField("name")
+	errs = errs.Also(check(step.Image, false).ViaField("image"))
+	errs = errs.Also(check(step.WorkingDir, false).ViaField("workingDir"))
+	errs = errs.Also(check(step.Script, true).ViaField("script"))
 	for i, cmd := range step.Command {
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(cmd, prefix, vars).ViaFieldIndex("command", i))
+		errs = errs.Also(check(cmd, false).ViaFieldIndex("command", i))
 	}
 	for i, arg := range step.Args {
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(arg, prefix, vars).ViaFieldIndex("args", i))
+		errs = errs.Also(check(arg, false).ViaFieldIndex("args", i))
 	}
 	for _, env := range step.Env {
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
+		errs = errs.Also(check(env.Value, false).ViaFieldKey("env", env.Name))
 	}
 	for i, v := range step.VolumeMounts {
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.Name, prefix, vars).ViaField("name").ViaFieldIndex("volumeMount", i))
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.MountPath, prefix, vars).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
-		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.SubPath, prefix, vars).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(check(v.Name, false).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(check(v.MountPath, false).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(check(v.SubPath, false).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
 	}
-	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(string(step.OnError), prefix, vars).ViaField("onError"))
+	if step.StdoutConfig != nil {
+		errs = errs.Also(check(step.StdoutConfig.Path, false).ViaField("path").ViaField("stdoutConfig"))
+	}
+	if step.StderrConfig != nil {
+		errs = errs.Also(check(step.StderrConfig.Path, false).ViaField("path").ViaField("stderrConfig"))
+	}
+	errs = errs.Also(check(string(step.OnError), false).ViaField("onError"))
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -73,7 +73,12 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 	errs = errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 	// When a Task is created directly, instead of declared inline in a TaskRun or PipelineRun,
 	// we do not support propagated parameters. Validate that all params it uses are declared.
-	return errs.Also(ValidateUsageOfDeclaredParameters(ctx, t.Spec.Steps, t.Spec.Params).ViaField("spec"))
+	errs = errs.Also(ValidateUsageOfDeclaredParameters(ctx, t.Spec.Steps, t.Spec.Params).ViaField("spec"))
+	// When a Task is created directly, instead of declared inline in a TaskRun or PipelineRun,
+	// we do not support propagated workspaces. Validate that all workspace variable references
+	// (e.g. $(workspaces.foo.path)) refer to declared workspaces with valid properties.
+	errs = errs.Also(ValidateUsageOfDeclaredWorkspaces(ctx, t.Spec.Steps, t.Spec.Sidecars, t.Spec.Workspaces).ViaField("spec"))
+	return errs
 }
 
 // Validate implements apis.Validatable
@@ -177,6 +182,27 @@ func validateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step,
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("workspace mount path %q must be unique", mountPath), "mountpath").ViaIndex(idx))
 		}
 		mountPaths[mountPath] = struct{}{}
+	}
+	return errs
+}
+
+// ValidateUsageOfDeclaredWorkspaces validates that all workspace variable references
+// (e.g. $(workspaces.foo.path)) in Steps and Sidecars refer to workspaces declared in the Task
+// and use valid workspace properties (path, bound, claim, volume).
+func ValidateUsageOfDeclaredWorkspaces(ctx context.Context, steps []Step, sidecars []Sidecar, workspaces []WorkspaceDeclaration) *apis.FieldError {
+	var errs *apis.FieldError
+	wsNames := sets.NewString()
+	for _, w := range workspaces {
+		wsNames.Insert(w.Name)
+	}
+	// Validate that workspace variable references refer to declared workspaces
+	errs = errs.Also(validateVariables(ctx, steps, "workspaces", wsNames))
+	errs = errs.Also(validateSidecarVariables(ctx, sidecars, "workspaces", wsNames))
+	// Validate that workspace properties are valid (path, bound, claim, volume)
+	wsProperties := sets.NewString("path", "bound", "claim", "volume")
+	for _, w := range workspaces {
+		errs = errs.Also(validateVariables(ctx, steps, "workspaces\\."+w.Name, wsProperties))
+		errs = errs.Also(validateSidecarVariables(ctx, sidecars, "workspaces\\."+w.Name, wsProperties))
 	}
 	return errs
 }
@@ -682,6 +708,37 @@ func validateVariables(ctx context.Context, steps []Step, prefix string, vars se
 	// We've checked param name format. Now, we want to check if param names are referenced correctly in each step
 	for idx, step := range steps {
 		errs = errs.Also(validateStepVariables(ctx, step, prefix, vars).ViaFieldIndex("steps", idx))
+	}
+	return errs
+}
+
+// validateSidecarVariables returns an error if the Sidecars contain references to any unknown variables
+func validateSidecarVariables(ctx context.Context, sidecars []Sidecar, prefix string, vars sets.String) (errs *apis.FieldError) {
+	for idx, sidecar := range sidecars {
+		errs = errs.Also(validateSidecarContainerVariables(ctx, sidecar, prefix, vars).ViaFieldIndex("sidecars", idx))
+	}
+	return errs
+}
+
+// validateSidecarContainerVariables validates variable references in a single Sidecar
+func validateSidecarContainerVariables(ctx context.Context, sidecar Sidecar, prefix string, vars sets.String) *apis.FieldError {
+	errs := substitution.ValidateNoReferencesToUnknownVariables(sidecar.Name, prefix, vars).ViaField("name")
+	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(sidecar.Image, prefix, vars).ViaField("image"))
+	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(sidecar.WorkingDir, prefix, vars).ViaField("workingDir"))
+	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariablesWithDetail(sidecar.Script, prefix, vars).ViaField("script"))
+	for i, cmd := range sidecar.Command {
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(cmd, prefix, vars).ViaFieldIndex("command", i))
+	}
+	for i, arg := range sidecar.Args {
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(arg, prefix, vars).ViaFieldIndex("args", i))
+	}
+	for _, env := range sidecar.Env {
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
+	}
+	for i, v := range sidecar.VolumeMounts {
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.Name, prefix, vars).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.MountPath, prefix, vars).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(v.SubPath, prefix, vars).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -819,6 +819,134 @@ func TestTaskValidateError(t *testing.T) {
 	}
 }
 
+func TestTaskValidateWorkspaceVariableReferences(t *testing.T) {
+	tests := []struct {
+		name       string
+		workspaces []v1beta1.WorkspaceDeclaration
+		steps      []v1beta1.Step
+	}{{
+		name: "valid workspace variable in script",
+		workspaces: []v1beta1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1beta1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.path)",
+		}},
+	}, {
+		name: "valid multiple workspace properties",
+		workspaces: []v1beta1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1beta1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.path) $(workspaces.myws.bound) $(workspaces.myws.claim) $(workspaces.myws.volume)",
+		}},
+	}, {
+		name: "no workspace references is valid",
+		steps: []v1beta1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Args:  []string{"hello"},
+		}},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &v1beta1.Task{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1beta1.TaskSpec{
+					Workspaces: tt.workspaces,
+					Steps:      tt.steps,
+				},
+			}
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
+			task.SetDefaults(ctx)
+			err := task.Validate(ctx)
+			if err != nil {
+				t.Errorf("Task.Validate() returned error for valid Task: %v", err)
+			}
+		})
+	}
+}
+
+func TestTaskValidateWorkspaceVariableReferencesError(t *testing.T) {
+	tests := []struct {
+		name          string
+		workspaces    []v1beta1.WorkspaceDeclaration
+		steps         []v1beta1.Step
+		expectedError apis.FieldError
+	}{{
+		name: "undeclared workspace in script",
+		steps: []v1beta1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.undeclared.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: "non-existent variable `undeclared` in \"echo $(workspaces.undeclared.path)\"",
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "undeclared workspace in args",
+		steps: []v1beta1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Args:  []string{"--path=$(workspaces.missing.path)"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "--path=$(workspaces.missing.path)"`,
+			Paths:   []string{"spec.steps[0].args[0]"},
+		},
+	}, {
+		name: "invalid workspace property",
+		workspaces: []v1beta1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1beta1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.invalid)",
+		}},
+		expectedError: apis.FieldError{
+			Message: "non-existent variable `invalid` in \"echo $(workspaces.myws.invalid)\"",
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "workspace reference in working dir",
+		steps: []v1beta1.Step{{
+			Name:       "step1",
+			Image:      "my-image",
+			WorkingDir: "$(workspaces.nonexistent.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.nonexistent.path)"`,
+			Paths:   []string{"spec.steps[0].workingDir"},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &v1beta1.Task{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1beta1.TaskSpec{
+					Workspaces: tt.workspaces,
+					Steps:      tt.steps,
+				},
+			}
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
+			task.SetDefaults(ctx)
+			err := task.Validate(ctx)
+			if err == nil {
+				t.Fatalf("Expected an error, got nothing for %v", task)
+			}
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("Task.Validate() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
 func TestTaskSpecValidateError(t *testing.T) {
 	type fields struct {
 		Params       []v1beta1.ParamSpec

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -850,6 +850,205 @@ func TestTaskValidateError(t *testing.T) {
 	}
 }
 
+func TestTaskValidateWorkspaceVariableReferences(t *testing.T) {
+	tests := []struct {
+		name       string
+		workspaces []v1beta1.WorkspaceDeclaration
+		steps      []v1beta1.Step
+	}{{
+		name: "valid workspace variable in script",
+		workspaces: []v1beta1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1beta1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.path)",
+		}},
+	}, {
+		name: "valid multiple workspace properties",
+		workspaces: []v1beta1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1beta1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.path) $(workspaces.myws.bound) $(workspaces.myws.claim) $(workspaces.myws.volume)",
+		}},
+	}, {
+		name: "no workspace references is valid",
+		steps: []v1beta1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Args:  []string{"hello"},
+		}},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &v1beta1.Task{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1beta1.TaskSpec{
+					Workspaces: tt.workspaces,
+					Steps:      tt.steps,
+				},
+			}
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
+			task.SetDefaults(ctx)
+			err := task.Validate(ctx)
+			if err != nil {
+				t.Errorf("Task.Validate() returned error for valid Task: %v", err)
+			}
+		})
+	}
+}
+
+func TestTaskValidateWorkspaceVariableReferencesError(t *testing.T) {
+	tests := []struct {
+		name          string
+		workspaces    []v1beta1.WorkspaceDeclaration
+		steps         []v1beta1.Step
+		sidecars      []v1beta1.Sidecar
+		expectedError apis.FieldError
+	}{{
+		name: "undeclared workspace in script",
+		steps: []v1beta1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.undeclared.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: "non-existent variable `undeclared` in \"echo $(workspaces.undeclared.path)\"",
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "undeclared workspace in args",
+		steps: []v1beta1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+			Args:  []string{"--path=$(workspaces.missing.path)"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "--path=$(workspaces.missing.path)"`,
+			Paths:   []string{"spec.steps[0].args[0]"},
+		},
+	}, {
+		name: "invalid workspace property",
+		workspaces: []v1beta1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1beta1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws.invalid)",
+		}},
+		expectedError: apis.FieldError{
+			Message: "non-existent variable `invalid` in \"echo $(workspaces.myws.invalid)\"",
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "workspace reference in working dir",
+		steps: []v1beta1.Step{{
+			Name:       "step1",
+			Image:      "my-image",
+			WorkingDir: "$(workspaces.nonexistent.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.nonexistent.path)"`,
+			Paths:   []string{"spec.steps[0].workingDir"},
+		},
+	}, {
+		name: "bare workspace reference without property",
+		workspaces: []v1beta1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1beta1.Step{{
+			Name:   "step1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.myws)",
+		}},
+		expectedError: apis.FieldError{
+			Message: "non-existent variable `$(workspaces.myws)` in \"echo $(workspaces.myws)\"",
+			Paths:   []string{"spec.steps[0].script"},
+		},
+	}, {
+		name: "undeclared workspace in sidecar script",
+		steps: []v1beta1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+		}},
+		sidecars: []v1beta1.Sidecar{{
+			Name:   "sidecar1",
+			Image:  "my-image",
+			Script: "echo $(workspaces.undeclared.path)",
+		}},
+		expectedError: apis.FieldError{
+			Message: "non-existent variable `undeclared` in \"echo $(workspaces.undeclared.path)\"",
+			Paths:   []string{"spec.sidecars[0].script"},
+		},
+	}, {
+		name: "invalid workspace property in sidecar args",
+		workspaces: []v1beta1.WorkspaceDeclaration{{
+			Name: "myws",
+		}},
+		steps: []v1beta1.Step{{
+			Name:  "step1",
+			Image: "my-image",
+		}},
+		sidecars: []v1beta1.Sidecar{{
+			Name:  "sidecar1",
+			Image: "my-image",
+			Args:  []string{"$(workspaces.myws.invalid)"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.myws.invalid)"`,
+			Paths:   []string{"spec.sidecars[0].args[0]"},
+		},
+	}, {
+		name: "undeclared workspace in stdoutConfig path",
+		steps: []v1beta1.Step{{
+			Name:         "step1",
+			Image:        "my-image",
+			StdoutConfig: &v1beta1.StepOutputConfig{Path: "$(workspaces.missing.path)/stdout.txt"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.missing.path)/stdout.txt"`,
+			Paths:   []string{"spec.steps[0].stdoutConfig.path"},
+		},
+	}, {
+		name: "undeclared workspace in stderrConfig path",
+		steps: []v1beta1.Step{{
+			Name:         "step1",
+			Image:        "my-image",
+			StderrConfig: &v1beta1.StepOutputConfig{Path: "$(workspaces.missing.path)/stderr.txt"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(workspaces.missing.path)/stderr.txt"`,
+			Paths:   []string{"spec.steps[0].stderrConfig.path"},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &v1beta1.Task{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1beta1.TaskSpec{
+					Workspaces: tt.workspaces,
+					Steps:      tt.steps,
+					Sidecars:   tt.sidecars,
+				},
+			}
+			ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
+			task.SetDefaults(ctx)
+			err := task.Validate(ctx)
+			if err == nil {
+				t.Fatalf("Expected an error, got nothing for %v", task)
+			}
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("Task.Validate() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
 func TestTaskSpecValidateError(t *testing.T) {
 	type fields struct {
 		Params       []v1beta1.ParamSpec


### PR DESCRIPTION
# Changes

Previously, a Task could reference undeclared workspaces via variable
substitution (e.g. `$(workspaces.undeclared.path)`) and the webhook would
accept it without error. At runtime, these variables would not be substituted,
leading to confusing shell errors like `workspaces.abcd.path: not found`.

This PR adds webhook validation that:

1. **Rejects references to undeclared workspaces** — e.g. `$(workspaces.foo.path)`
   when `foo` is not in `spec.workspaces`
2. **Rejects invalid workspace properties** — e.g. `$(workspaces.myws.bogus)`
   where only `path`, `bound`, `claim`, `volume` are valid

This validation is only applied to standalone `Task` resources (via
`Task.Validate()`), not inline `TaskSpec` in `TaskRun`/`PipelineRun`, to
preserve workspace propagation support.

The fix follows the same pattern used for parameter validation
(`ValidateUsageOfDeclaredParameters`) and leverages the existing
`validateVariables`/`ValidateNoReferencesToUnknownVariables` infrastructure.

Applied to both `v1` and `v1beta1` API versions.

Fixes #6699

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind bug`
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Tasks that reference undeclared workspaces via variable substitution
(e.g. $(workspaces.undeclared.path)) are now rejected at admission time
with a clear error message, instead of silently failing at runtime.
```