### PR TITLE
ci: Skip most e2e tests on draft PRs to save CI resources

### DIFF
--- a/.github/e2e-matrix-draft.json
+++ b/.github/e2e-matrix-draft.json
@@ -1,0 +1,8 @@
+{
+  "os": ["ubuntu-latest"],
+  "k8s-name": ["k8s-latest"],
+  "feature-flags": ["stable"],
+  "include": [
+    {"k8s-name": "k8s-latest", "k8s-version": "v1.34.x"}
+  ]
+}

--- a/.github/e2e-matrix-full.json
+++ b/.github/e2e-matrix-full.json
@@ -1,0 +1,14 @@
+{
+  "os": ["ubuntu-latest", "ubuntu-24.04-arm"],
+  "k8s-name": ["k8s-oldest", "k8s-latest"],
+  "feature-flags": ["stable", "beta", "alpha"],
+  "include": [
+    {"k8s-name": "k8s-oldest", "k8s-version": "v1.28.x"},
+    {"k8s-name": "k8s-latest", "k8s-version": "v1.34.x"}
+  ],
+  "exclude": [
+    {"k8s-name": "k8s-oldest", "os": "ubuntu-24.04-arm"},
+    {"k8s-name": "k8s-latest", "os": "ubuntu-24.04-arm", "feature-flags": "beta"},
+    {"k8s-name": "k8s-latest", "os": "ubuntu-24.04-arm", "feature-flags": "alpha"}
+  ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: ci
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull-request.number || github.ref }}
@@ -188,6 +190,8 @@ jobs:
   e2e-tests:
     needs: [build]
     uses: ./.github/workflows/e2e-matrix.yml
+    with:
+      is-draft: ${{ github.event.pull_request.draft }}
 
   ci-summary:
     name: CI summary
@@ -195,7 +199,16 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
+    - name: Block merge for draft PRs
+      if: ${{ github.event.pull_request.draft == true }}
+      run: |
+        echo "::warning::Draft PR — only minimal e2e tests were run (amd64, k8s-latest, stable)"
+        echo "Mark as 'Ready for Review' to run the full CI matrix."
+        exit 1
+      env:
+        IS_DRAFT: ${{ github.event.pull_request.draft }}
     - name: Check CI results
+      if: ${{ github.event.pull_request.draft == false }}
       run: |
         results=(
           "build=${NEEDS_BUILD_RESULT}"

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -1,7 +1,14 @@
 name: Tekton Integration
 # Adapted from https://github.com/mattmoor/mink/blob/master/.github/workflows/minkind.yaml
 
-on: [workflow_call]
+on:
+  workflow_call:
+    inputs:
+      is-draft:
+        description: 'Whether the PR is a draft'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -11,7 +18,31 @@ defaults:
     shell: bash
 
 jobs:
+  compute-matrix:
+    name: compute e2e matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        sparse-checkout: .github
+        persist-credentials: false
+    - name: Select matrix
+      id: matrix
+      run: |
+        if [ "${IS_DRAFT}" = "true" ]; then
+          echo "Using draft matrix (amd64, k8s-latest, stable)"
+          echo "matrix=$(jq -c . .github/e2e-matrix-draft.json)" >> $GITHUB_OUTPUT
+        else
+          echo "Using full matrix"
+          echo "matrix=$(jq -c . .github/e2e-matrix-full.json)" >> $GITHUB_OUTPUT
+        fi
+      env:
+        IS_DRAFT: ${{ inputs.is-draft }}
+
   e2e-tests:
+    needs: [compute-matrix]
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.k8s-name }}-${{ matrix.feature-flags }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
@@ -19,36 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # Keep running if one leg fails.
-      matrix:
-        os:
-        - ubuntu-latest     # amd64
-        - ubuntu-24.04-arm  # arm64
-
-        k8s-name:
-        - k8s-oldest             # 1.28
-        - k8s-latest             # 1.34
-
-        feature-flags:
-        - stable
-        - beta
-        - alpha
-
-        include:
-        - k8s-name: k8s-oldest
-          k8s-version: v1.28.x
-        - k8s-name: k8s-latest
-          k8s-version: v1.34.x
-
-        # Limit arm64: only run k8s-latest on arm64 (alpha and beta), skip oldest on arm64
-        exclude:
-        - k8s-name: k8s-oldest
-          os: ubuntu-24.04-arm
-        - k8s-name: k8s-latest
-          os: ubuntu-24.04-arm
-          feature-flags: beta
-        - k8s-name: k8s-latest
-          os: ubuntu-24.04-arm
-          feature-flags: alpha
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.matrix) }}
     env:
       KO_DOCKER_REPO: registry.local:5000/tekton
       CLUSTER_DOMAIN: c${{ github.run_id }}.local


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

# Changes

Draft PRs currently run the full e2e matrix (7 jobs), which is expensive and
unnecessary during early development. This PR reduces draft PR CI to a single
e2e job while keeping the full matrix for non-draft PRs.

**`ci.yaml`:**
- Add `ready_for_review` to PR event types so the full matrix triggers when a
  draft PR is marked ready
- Pass `is-draft` input to the e2e reusable workflow
- CI summary explicitly **fails** on draft PRs with a warning, preventing
  accidental merges

**`e2e-matrix.yml`:**
- Accept `is-draft` boolean input
- New `compute-matrix` job selects the appropriate matrix JSON file:
  - **Draft PRs**: `.github/e2e-matrix-draft.json` — 1 job (`ubuntu-latest`/amd64, `k8s-latest`, `stable`)
  - **Non-draft PRs**: `.github/e2e-matrix-full.json` — full 7-job matrix (unchanged from current behavior)

**`.github/e2e-matrix-draft.json` / `.github/e2e-matrix-full.json`:**
- Matrix definitions extracted into standalone JSON files for easy maintenance
- Bumping k8s versions or adding architectures only requires editing these files

| PR State | e2e Jobs | CI Summary | Mergeable? |
|----------|----------|------------|------------|
| Draft | 1 (amd64, k8s-latest, stable) | ❌ Fails with warning | No |
| Ready for Review | 7 (full matrix) | ✅ Normal check | Yes (if all pass) |
| Draft → Ready | Full matrix re-runs | ✅ Normal check | Yes (if all pass) |

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```