### PR TITLE
fix: allow finally tasks to run when tasks timeout is exceeded

### DIFF
--- a/docs/pipeline-api.md
+++ b/docs/pipeline-api.md
@@ -2301,6 +2301,10 @@ pipeline will stop once all running tasks complete their work</p>
 </tr><tr><td><p>&#34;PipelineRunTimeout&#34;</p></td>
 <td><p>PipelineRunReasonTimedOut is the reason set when the PipelineRun has timed out</p>
 </td>
+</tr><tr><td><p>&#34;PipelineRunTimeoutRunningFinally&#34;</p></td>
+<td><p>PipelineRunReasonTimedOutRunningFinally indicates that the tasks timeout has been exceeded
+and no new DAG tasks will be scheduled, but final tasks are now running</p>
+</td>
 </tr></tbody>
 </table>
 <h3 id="tekton.dev/v1.PipelineRunResult">PipelineRunResult

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -366,6 +366,9 @@ const (
 	// PipelineRunReasonStopping indicates that no new Tasks will be scheduled by the controller, and the
 	// pipeline will stop once all running tasks complete their work
 	PipelineRunReasonStopping PipelineRunReason = "PipelineRunStopping"
+	// PipelineRunReasonTimedOutRunningFinally indicates that the tasks timeout has been exceeded
+	// and no new DAG tasks will be scheduled, but final tasks are now running
+	PipelineRunReasonTimedOutRunningFinally PipelineRunReason = "PipelineRunTimeoutRunningFinally"
 	// PipelineRunReasonCancelledRunningFinally indicates that pipeline has been gracefully cancelled
 	// and no new Tasks will be scheduled by the controller, but final tasks are now running
 	PipelineRunReasonCancelledRunningFinally PipelineRunReason = "CancelledRunningFinally"

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -545,12 +545,18 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, p
 	}
 
 	if pr.HaveTasksTimedOut(ctx, c) {
-		return &apis.Condition{
-			Type:    apis.ConditionSucceeded,
-			Status:  corev1.ConditionFalse,
-			Reason:  v1.PipelineRunReasonTimedOut.String(),
-			Message: fmt.Sprintf("PipelineRun %q failed due to tasks failed to finish within %q", pr.Name, pr.TasksTimeout().Duration.String()),
+		// If there are finally tasks that haven't completed yet, allow the pipeline to keep
+		// running so that finally tasks can execute. Only fail immediately if there are no
+		// finally tasks or all finally tasks have already completed.
+		if !facts.hasFinalTasks() || facts.checkFinalTasksDone() {
+			return &apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionFalse,
+				Reason:  v1.PipelineRunReasonTimedOut.String(),
+				Message: fmt.Sprintf("PipelineRun %q failed due to tasks failed to finish within %q", pr.Name, pr.TasksTimeout().Duration.String()),
+			}
 		}
+		logger.Infof("Tasks in PipelineRun %q have timed out but final tasks are not yet done", pr.Name)
 	}
 
 	// report the count in PipelineRun Status
@@ -613,8 +619,11 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, p
 		}
 	}
 
-	// Hasn't timed out; not all tasks have finished.... Must keep running then....
+	// Not all tasks (regular + finally) have finished.... Must keep running then....
 	switch {
+	case pr.HaveTasksTimedOut(ctx, c) && facts.hasFinalTasks() && !facts.checkFinalTasksDone():
+		// Tasks have timed out but finally tasks are still running
+		reason = v1.PipelineRunReasonTimedOutRunningFinally.String()
 	case pr.IsGracefullyCancelled():
 		// Transition pipeline into running finally state, when graceful cancel is in progress
 		reason = v1.PipelineRunReasonCancelledRunningFinally.String()
@@ -788,6 +797,11 @@ func (facts *PipelineRunFacts) checkDAGTasksDone() bool {
 // check if all finally tasks done executing (succeeded or failed)
 func (facts *PipelineRunFacts) checkFinalTasksDone() bool {
 	return facts.checkTasksDone(facts.FinalTasksGraph)
+}
+
+// hasFinalTasks returns true if the Pipeline has any finally tasks defined
+func (facts *PipelineRunFacts) hasFinalTasks() bool {
+	return facts.FinalTasksGraph.Nodes != nil && len(facts.FinalTasksGraph.Nodes) > 0
 }
 
 // getPipelineTasksCount returns the count of successful tasks, failed tasks, cancelled tasks, skipped task, and incomplete tasks

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2387,6 +2387,163 @@ func TestGetPipelineConditionStatus_PipelineTasksTimeouts(t *testing.T) {
 	}
 }
 
+func TestGetPipelineConditionStatus_TasksTimedOutRunningFinally(t *testing.T) {
+	// DAG task that is running (will be timed out)
+	dagRunning := PipelineRunState{{
+		TaskRunNames: []string{"task0taskrun"},
+		PipelineTask: &pts[0],
+		TaskRuns:     []*v1.TaskRun{makeStarted(trs[0])},
+	}}
+
+	// DAG task that has timed out (cancelled) and finally task not started
+	dagTimedOutFinalNotStarted := PipelineRunState{{
+		TaskRunNames: []string{"task0taskrun"},
+		PipelineTask: &pts[0],
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+	}, {
+		TaskRunNames: []string{"finaltask"},
+		PipelineTask: &pts[1],
+		TaskRuns:     nil,
+	}}
+
+	// DAG task that has timed out (cancelled) and finally task succeeded
+	dagTimedOutFinalDone := PipelineRunState{{
+		TaskRunNames: []string{"task0taskrun"},
+		PipelineTask: &pts[0],
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+	}, {
+		TaskRunNames: []string{"finaltask"},
+		PipelineTask: &pts[1],
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[1])},
+	}}
+
+	tcs := []struct {
+		name           string
+		state          PipelineRunState
+		dagTasks       []v1.PipelineTask
+		finalTasks     []v1.PipelineTask
+		expectedStatus corev1.ConditionStatus
+		expectedReason string
+	}{{
+		name:           "tasks timed out with finally tasks not started - should keep running",
+		state:          dagTimedOutFinalNotStarted,
+		dagTasks:       []v1.PipelineTask{pts[0]},
+		finalTasks:     []v1.PipelineTask{pts[1]},
+		expectedStatus: corev1.ConditionUnknown,
+		expectedReason: v1.PipelineRunReasonTimedOutRunningFinally.String(),
+	}, {
+		name:           "tasks timed out with finally tasks completed - should fail",
+		state:          dagTimedOutFinalDone,
+		dagTasks:       []v1.PipelineTask{pts[0]},
+		finalTasks:     []v1.PipelineTask{pts[1]},
+		expectedStatus: corev1.ConditionFalse,
+		expectedReason: v1.PipelineRunReasonTimedOut.String(),
+	}, {
+		name:           "tasks timed out with no finally tasks - should fail",
+		state:          dagRunning,
+		dagTasks:       []v1.PipelineTask{pts[0]},
+		finalTasks:     []v1.PipelineTask{},
+		expectedStatus: corev1.ConditionFalse,
+		expectedReason: v1.PipelineRunReasonTimedOut.String(),
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-tasks-timeout-finally"},
+				Spec: v1.PipelineRunSpec{
+					Timeouts: &v1.TimeoutFields{
+						Pipeline: &metav1.Duration{Duration: 2 * time.Minute},
+						Finally:  &metav1.Duration{Duration: 1 * time.Minute},
+						// tasks timeout is calculated: pipeline - finally = 1 minute
+					},
+				},
+				Status: v1.PipelineRunStatus{
+					PipelineRunStatusFields: v1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: now.Add(-90 * time.Second)},
+					},
+				},
+			}
+			d, err := dag.Build(v1.PipelineTaskList(tc.dagTasks), v1.PipelineTaskList(tc.dagTasks).Deps())
+			if err != nil {
+				t.Fatalf("Unexpected error while building graph for DAG tasks %v: %v", tc.dagTasks, err)
+			}
+			df, err := dag.Build(v1.PipelineTaskList(tc.finalTasks), map[string][]string{})
+			if err != nil {
+				t.Fatalf("Unexpected error while building graph for final tasks %v: %v", tc.finalTasks, err)
+			}
+			facts := PipelineRunFacts{
+				State:           tc.state,
+				TasksGraph:      d,
+				FinalTasksGraph: df,
+				TimeoutsState: PipelineRunTimeoutsState{
+					Clock: testClock,
+				},
+			}
+			c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
+			if c.Status != tc.expectedStatus {
+				t.Errorf("Expected status %s but got %s for test %s", tc.expectedStatus, c.Status, tc.name)
+			}
+			if c.Reason != tc.expectedReason {
+				t.Errorf("Expected reason %s but got %s for test %s", tc.expectedReason, c.Reason, tc.name)
+			}
+		})
+	}
+}
+
+func TestGetPipelineConditionStatus_TasksTimedOutExplicitWithFinally(t *testing.T) {
+	// Same as above but with explicit tasks timeout instead of calculated
+	dagTimedOutFinalNotStarted := PipelineRunState{{
+		TaskRunNames: []string{"task0taskrun"},
+		PipelineTask: &pts[0],
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+	}, {
+		TaskRunNames: []string{"finaltask"},
+		PipelineTask: &pts[1],
+		TaskRuns:     nil,
+	}}
+
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-explicit-tasks-timeout-finally"},
+		Spec: v1.PipelineRunSpec{
+			Timeouts: &v1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: 2 * time.Minute},
+				Tasks:    &metav1.Duration{Duration: 1 * time.Minute},
+			},
+		},
+		Status: v1.PipelineRunStatus{
+			PipelineRunStatusFields: v1.PipelineRunStatusFields{
+				StartTime: &metav1.Time{Time: now.Add(-90 * time.Second)},
+			},
+		},
+	}
+
+	d, err := dag.Build(v1.PipelineTaskList([]v1.PipelineTask{pts[0]}), v1.PipelineTaskList([]v1.PipelineTask{pts[0]}).Deps())
+	if err != nil {
+		t.Fatalf("Unexpected error while building graph for DAG tasks: %v", err)
+	}
+	df, err := dag.Build(v1.PipelineTaskList([]v1.PipelineTask{pts[1]}), map[string][]string{})
+	if err != nil {
+		t.Fatalf("Unexpected error while building graph for final tasks: %v", err)
+	}
+
+	facts := PipelineRunFacts{
+		State:           dagTimedOutFinalNotStarted,
+		TasksGraph:      d,
+		FinalTasksGraph: df,
+		TimeoutsState: PipelineRunTimeoutsState{
+			Clock: testClock,
+		},
+	}
+	c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
+	if c.Status != corev1.ConditionUnknown {
+		t.Errorf("Expected status %s but got %s", corev1.ConditionUnknown, c.Status)
+	}
+	if c.Reason != v1.PipelineRunReasonTimedOutRunningFinally.String() {
+		t.Errorf("Expected reason %s but got %s", v1.PipelineRunReasonTimedOutRunningFinally.String(), c.Reason)
+	}
+}
+
 func TestGetPipelineConditionStatus_OnError(t *testing.T) {
 	var oneFailedStateOnError = PipelineRunState{{
 		PipelineTask: &v1.PipelineTask{


### PR DESCRIPTION
# Changes

Fixes #6794

When `HaveTasksTimedOut()` returns true, `GetPipelineConditionStatus` was
immediately returning `ConditionFalse` (Failed), preventing finally tasks
from ever being scheduled.

This change makes `GetPipelineConditionStatus` return `ConditionUnknown`
(keep running) when tasks have timed out but there are pending finally
tasks, similar to how graceful cancellation (`CancelledRunningFinally`)
works. The pipeline will continue running until finally tasks complete,
then fail with the timeout reason.

This applies to both calculated tasks timeout (`pipeline - finally`) and
explicit `tasks` timeout.

### What was changed

- **`pkg/apis/pipeline/v1/pipelinerun_types.go`**: Add `PipelineRunReasonTimedOutRunningFinally` reason constant (mirrors the existing `CancelledRunningFinally` / `StoppedRunningFinally` pattern)
- **`pkg/reconciler/pipelinerun/resources/pipelinerunstate.go`**: Modify `GetPipelineConditionStatus` so that when `HaveTasksTimedOut` is true but finally tasks still need to run, return `ConditionUnknown` instead of `ConditionFalse`; add `hasFinalTasks()` helper
- **`pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go`**: Add tests for both calculated and explicit tasks timeout with finally tasks

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix a bug where finally tasks were not executed when the tasks timeout
(either explicit via `timeouts.tasks` or calculated as `timeouts.pipeline -
timeouts.finally`) was exceeded. The PipelineRun was immediately marked as
Failed without giving finally tasks a chance to run. Now the pipeline
continues running with reason `PipelineRunTimeoutRunningFinally` until
finally tasks complete.
```