### PR TITLE
Prevent auto-cleanup-pvc annotation from propagating to child PipelineRuns

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1784,8 +1784,9 @@ func createChildResourceAnnotations(pr *v1.PipelineRun) map[string]string {
 	for key, val := range pr.ObjectMeta.Annotations {
 		annotations[key] = val
 	}
-	return kmap.Filter(annotations, func(s string) bool {
-		return filterReservedAnnotationRegexp.MatchString(s)
+	// Filter out reserved annotations and annotations that should not propagate to child resources
+	return kmap.Filter(annotations, func(key string) bool {
+		return filterReservedAnnotationRegexp.MatchString(key) || key == AutoCleanupPVCAnnotation
 	})
 }
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -19755,3 +19755,68 @@ status:
 		t.Errorf("Expected PipelineRun to be marked Failed for generic failed TaskRun, got status %s reason %s", condition.Status, condition.Reason)
 	}
 }
+
+func TestCreateChildResourceAnnotations_FiltersAutoCleanupPVC(t *testing.T) {
+	tcs := []struct {
+		name        string
+		annotations map[string]string
+		expected    map[string]string
+	}{
+		{
+			name: "auto-cleanup-pvc annotation is filtered out",
+			annotations: map[string]string{
+				AutoCleanupPVCAnnotation: "true",
+				"user-annotation":        "val",
+			},
+			expected: map[string]string{
+				"user-annotation": "val",
+			},
+		},
+		{
+			name: "chains annotations are still filtered out",
+			annotations: map[string]string{
+				"chains.tekton.dev/signed": "true",
+				AutoCleanupPVCAnnotation:   "true",
+				"user-annotation":          "val",
+			},
+			expected: map[string]string{
+				"user-annotation": "val",
+			},
+		},
+		{
+			name: "other tekton annotations are preserved",
+			annotations: map[string]string{
+				"tekton.dev/some-other": "value",
+				"user-annotation":       "val",
+			},
+			expected: map[string]string{
+				"tekton.dev/some-other": "value",
+				"user-annotation":       "val",
+			},
+		},
+		{
+			name: "only auto-cleanup-pvc annotation results in empty map",
+			annotations: map[string]string{
+				AutoCleanupPVCAnnotation: "true",
+			},
+			expected: map[string]string{},
+		},
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    map[string]string{},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := &v1.PipelineRun{}
+			pr.ObjectMeta.Annotations = tc.annotations
+
+			got := createChildResourceAnnotations(pr)
+			if d := cmp.Diff(tc.expected, got); d != "" {
+				t.Errorf("createChildResourceAnnotations() mismatch (-want +got):\n%s", d)
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
When a parent PipelineRun has the `tekton.dev/auto-cleanup-pvc` annotation set, it was unintentionally propagated to child PipelineRuns created via Pipeline-in-Pipeline. This caused child PipelineRun VolumeClaimTemplate PVCs to be unexpectedly auto-deleted on completion.

Fixes #9679

/kind bug
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
