### PR TITLE
cleanup: move shared types to remoteresolution framework

### DIFF
--- a/docs/resolver-template/cmd/resolver/main.go
+++ b/docs/resolver-template/cmd/resolver/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework"
 	"github.com/tektoncd/pipeline/pkg/resolution/common"
-	frameworkV1 "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 	filteredinformerfactory "knative.dev/pkg/client/injection/kube/informers/factory/filtered"
 	"knative.dev/pkg/injection/sharedmain"
 )
@@ -70,7 +69,7 @@ func (r *resolver) Validate(ctx context.Context, req *v1beta1.ResolutionRequestS
 }
 
 // Resolve uses the given resolution spec to resolve the requested file or resource.
-func (r *resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (frameworkV1.ResolvedResource, error) {
+func (r *resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (framework.ResolvedResource, error) {
 	return &myResolvedResource{}, nil
 }
 

--- a/pkg/remoteresolution/resolver/bundle/resolver.go
+++ b/pkg/remoteresolution/resolver/bundle/resolver.go
@@ -104,7 +104,7 @@ func (r *Resolver) IsImmutable(params []v1.Param) bool {
 }
 
 // Resolve uses the given params to resolve the requested file or resource.
-func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
+func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (framework.ResolvedResource, error) {
 	if len(req.Params) == 0 {
 		return nil, errors.New("no params")
 	}

--- a/pkg/remoteresolution/resolver/cluster/resolver.go
+++ b/pkg/remoteresolution/resolver/cluster/resolver.go
@@ -87,7 +87,7 @@ func (r *Resolver) IsImmutable([]v1.Param) bool {
 }
 
 // Resolve uses the given params to resolve the requested file or resource.
-func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
+func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (framework.ResolvedResource, error) {
 	if cache.ShouldUse(ctx, r, req.Params) {
 		return cache.Get(ctx).GetCachedOrResolveFromRemote(
 			ctx,

--- a/pkg/remoteresolution/resolver/framework/configstore.go
+++ b/pkg/remoteresolution/resolver/framework/configstore.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+
+	resolverconfig "github.com/tektoncd/pipeline/pkg/apis/config/resolver"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/configmap"
+)
+
+// resolverConfigKey is the context key associated with configuration
+// for one specific resolver, and is only used if that resolver
+// implements the optional framework.ConfigWatcher interface.
+var resolverConfigKey = struct{}{}
+
+// DataFromConfigMap returns a copy of the contents of a configmap or an
+// empty map if the configmap doesn't have any data.
+func DataFromConfigMap(config *corev1.ConfigMap) (map[string]string, error) {
+	resolverConfig := map[string]string{}
+	if config == nil {
+		return resolverConfig, nil
+	}
+	for key, value := range config.Data {
+		resolverConfig[key] = value
+	}
+	return resolverConfig, nil
+}
+
+// ConfigStore wraps a knative untyped store and provides helper methods
+// for working with a resolver's configuration data.
+type ConfigStore struct {
+	*resolverconfig.Store
+	resolverConfigName string
+	untyped            *configmap.UntypedStore
+}
+
+// NewConfigStore creates a new untyped store for the resolver's configuration and a config.Store for general Pipeline configuration.
+func NewConfigStore(resolverConfigName string, logger configmap.Logger) *ConfigStore {
+	return &ConfigStore{
+		Store:              resolverconfig.NewStore(logger),
+		resolverConfigName: resolverConfigName,
+		untyped: configmap.NewUntypedStore(
+			"resolver-config",
+			logger,
+			configmap.Constructors{
+				resolverConfigName: DataFromConfigMap,
+			},
+		),
+	}
+}
+
+// WatchConfigs uses the provided configmap.Watcher
+// to setup watches for the config names provided in the
+// Constructors map
+func (store *ConfigStore) WatchConfigs(w configmap.Watcher) {
+	store.untyped.WatchConfigs(w)
+	store.Store.WatchConfigs(w)
+}
+
+// GetResolverConfig returns a copy of the resolver's current
+// configuration or an empty map if the stored config is nil or invalid.
+func (store *ConfigStore) GetResolverConfig() map[string]string {
+	resolverConfig := map[string]string{}
+	untypedConf := store.untyped.UntypedLoad(store.resolverConfigName)
+	if conf, ok := untypedConf.(map[string]string); ok {
+		for key, val := range conf {
+			resolverConfig[key] = val
+		}
+	}
+	return resolverConfig
+}
+
+// ToContext returns a new context with the resolver's configuration
+// data stored in it.
+func (store *ConfigStore) ToContext(ctx context.Context) context.Context {
+	conf := store.GetResolverConfig()
+	return InjectResolverConfigToContext(store.Store.ToContext(ctx), conf)
+}
+
+// InjectResolverConfigToContext returns a new context with a
+// map stored in it for a resolvers config.
+func InjectResolverConfigToContext(ctx context.Context, conf map[string]string) context.Context {
+	return context.WithValue(ctx, resolverConfigKey, conf)
+}
+
+// GetResolverConfigFromContext returns any resolver-specific
+// configuration that has been stored or an empty map if none exists.
+func GetResolverConfigFromContext(ctx context.Context) map[string]string {
+	conf := map[string]string{}
+	storedConfig := ctx.Value(resolverConfigKey)
+	if resolverConfig, ok := storedConfig.(map[string]string); ok {
+		conf = resolverConfig
+	}
+	return conf
+}

--- a/pkg/remoteresolution/resolver/framework/configstore_test.go
+++ b/pkg/remoteresolution/resolver/framework/configstore_test.go
@@ -1,0 +1,86 @@
+/*
+ Copyright 2022 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package framework_test
+
+import (
+	"testing"
+
+	framework "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework"
+	corev1 "k8s.io/api/core/v1"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+// TestDataFromConfigMap checks that configmaps are correctly converted
+// into a map[string]string
+func TestDataFromConfigMap(t *testing.T) {
+	for _, tc := range []struct {
+		configMap *corev1.ConfigMap
+		expected  map[string]string
+	}{{
+		configMap: nil,
+		expected:  map[string]string{},
+	}, {
+		configMap: &corev1.ConfigMap{
+			Data: nil,
+		},
+		expected: map[string]string{},
+	}, {
+		configMap: &corev1.ConfigMap{
+			Data: map[string]string{},
+		},
+		expected: map[string]string{},
+	}, {
+		configMap: &corev1.ConfigMap{
+			Data: map[string]string{
+				"foo": "bar",
+			},
+		},
+		expected: map[string]string{
+			"foo": "bar",
+		},
+	}} {
+		out, err := framework.DataFromConfigMap(tc.configMap)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !mapsAreEqual(tc.expected, out) {
+			t.Fatalf("expected %#v received %#v", tc.expected, out)
+		}
+	}
+}
+
+func TestGetResolverConfig(t *testing.T) {
+	config := framework.NewConfigStore("test", logtesting.TestLogger(t))
+	if len(config.GetResolverConfig()) != 0 {
+		t.Fatalf("expected empty config")
+	}
+}
+
+func mapsAreEqual(m1, m2 map[string]string) bool {
+	if m1 == nil || m2 == nil {
+		return m1 == nil && m2 == nil
+	}
+	if len(m1) != len(m2) {
+		return false
+	}
+	for k, v := range m1 {
+		if m2[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/remoteresolution/resolver/framework/controller.go
+++ b/pkg/remoteresolution/resolver/framework/controller.go
@@ -18,18 +18,24 @@ package framework
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	rrclient "github.com/tektoncd/pipeline/pkg/client/resolution/injection/client"
 	rrinformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
+	rrlister "github.com/tektoncd/pipeline/pkg/client/resolution/listers/resolution/v1beta1"
 	rrcache "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
-	framework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"github.com/tektoncd/pipeline/pkg/resolution/common"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/clock"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/reconciler"
 )
 
 // ReconcilerModifier is a func that can access and modify a reconciler
@@ -41,7 +47,7 @@ type ReconcilerModifier = func(reconciler *Reconciler)
 // This sets up a lot of the boilerplate that individual resolvers
 // shouldn't need to be concerned with since it's common to all of them.
 func NewController(ctx context.Context, resolver Resolver, modifiers ...ReconcilerModifier) func(context.Context, configmap.Watcher) *controller.Impl {
-	if err := framework.ValidateResolver(ctx, resolver.GetSelector(ctx)); err != nil {
+	if err := ValidateResolver(ctx, resolver.GetSelector(ctx)); err != nil {
 		panic(err.Error())
 	}
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
@@ -55,7 +61,7 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 		}
 
 		r := &Reconciler{
-			LeaderAwareFuncs:           framework.LeaderAwareFuncs(rrInformer.Lister()),
+			LeaderAwareFuncs:           LeaderAwareFuncs(rrInformer.Lister()),
 			kubeClientSet:              kubeclientset,
 			resolutionRequestLister:    rrInformer.Lister(),
 			resolutionRequestClientSet: rrclientset,
@@ -78,7 +84,7 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 		})
 
 		_, err := rrInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: framework.FilterResolutionRequestsBySelector(resolver.GetSelector(ctx)),
+			FilterFunc: FilterResolutionRequestsBySelector(resolver.GetSelector(ctx)),
 			Handler: cache.ResourceEventHandlerFuncs{
 				AddFunc: impl.Enqueue,
 				UpdateFunc: func(oldObj, newObj interface{}) {
@@ -101,13 +107,13 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 // configmap, using knative's configmap helpers. This is only done if
 // the resolver implements the framework.ConfigWatcher interface.
 func watchConfigChanges(ctx context.Context, reconciler *Reconciler, cmw configmap.Watcher) {
-	if configWatcher, ok := reconciler.resolver.(framework.ConfigWatcher); ok {
+	if configWatcher, ok := reconciler.resolver.(ConfigWatcher); ok {
 		logger := logging.FromContext(ctx)
 		resolverConfigName := configWatcher.GetConfigName(ctx)
 		if resolverConfigName == "" {
 			panic("resolver returned empty config name")
 		}
-		reconciler.configStore = framework.NewConfigStore(resolverConfigName, logger)
+		reconciler.configStore = NewConfigStore(resolverConfigName, logger)
 		reconciler.configStore.WatchConfigs(cmw)
 	}
 }
@@ -136,4 +142,62 @@ func applyModifiersAndDefaults(ctx context.Context, r *Reconciler, modifiers []R
 	if r.Clock == nil {
 		r.Clock = clock.RealClock{}
 	}
+}
+
+func FilterResolutionRequestsBySelector(selector map[string]string) func(obj interface{}) bool {
+	return func(obj interface{}) bool {
+		rr, ok := obj.(*v1beta1.ResolutionRequest)
+		if !ok {
+			return false
+		}
+		if len(rr.ObjectMeta.Labels) == 0 {
+			return false
+		}
+		for key, val := range selector {
+			lookup, has := rr.ObjectMeta.Labels[key]
+			if !has {
+				return false
+			}
+			if lookup != val {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// TODO(sbwsg): I don't really understand the LeaderAwareness types beyond the
+// fact that the controller crashes if they're missing. It looks
+// like this is bucketing based on labels. Should we use the filter
+// selector from above in the call to lister.List here?
+func LeaderAwareFuncs(lister rrlister.ResolutionRequestLister) reconciler.LeaderAwareFuncs {
+	return reconciler.LeaderAwareFuncs{
+		PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+			all, err := lister.List(labels.Everything())
+			if err != nil {
+				return err
+			}
+			for _, elt := range all {
+				enq(bkt, types.NamespacedName{
+					Namespace: elt.GetNamespace(),
+					Name:      elt.GetName(),
+				})
+			}
+			return nil
+		},
+	}
+}
+
+// ErrMissingTypeSelector is returned when a resolver does not return
+// a selector with a type label from its GetSelector method.
+var ErrMissingTypeSelector = fmt.Errorf("invalid resolver: minimum selector must include %q", common.LabelKeyResolverType)
+
+func ValidateResolver(ctx context.Context, sel map[string]string) error {
+	if sel == nil {
+		return ErrMissingTypeSelector
+	}
+	if sel[common.LabelKeyResolverType] == "" {
+		return ErrMissingTypeSelector
+	}
+	return nil
 }

--- a/pkg/remoteresolution/resolver/framework/fakeresolver.go
+++ b/pkg/remoteresolution/resolver/framework/fakeresolver.go
@@ -18,26 +18,73 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
-	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 )
 
 const FakeUrl string = "fake://url"
 
+const (
+	// LabelValueFakeResolverType is the value to use for the
+	// resolution.tekton.dev/type label on resource requests
+	LabelValueFakeResolverType string = "fake"
+
+	// FakeResolverName is the name that the fake resolver should be
+	// associated with
+	FakeResolverName string = "Fake"
+
+	// FakeParamName is the name used for the fake resolver's single parameter.
+	FakeParamName string = "fake-key"
+)
+
 var _ Resolver = &FakeResolver{}
+
+// FakeResolvedResource is a framework.ResolvedResource implementation for use with the fake resolver.
+// If it's the value in the FakeResolver's ForParam map for the key given as the fake param value, the FakeResolver will
+// first check if it's got a value for ErrorWith. If so, that string will be returned as an error. Then, if WaitFor is
+// greater than zero, the FakeResolver will wait that long before returning. And finally, the FakeResolvedResource will
+// be returned.
+type FakeResolvedResource struct {
+	Content       string
+	AnnotationMap map[string]string
+	ContentSource *pipelinev1.RefSource
+	ErrorWith     string
+	WaitFor       time.Duration
+}
+
+// Data returns the FakeResolvedResource's Content field as bytes.
+func (f *FakeResolvedResource) Data() []byte {
+	return []byte(f.Content)
+}
+
+// Annotations returns the FakeResolvedResource's AnnotationMap field.
+func (f *FakeResolvedResource) Annotations() map[string]string {
+	return f.AnnotationMap
+}
+
+// RefSource is the source reference of the remote data that records where the remote
+// file came from including the url, digest and the entrypoint.
+func (f *FakeResolvedResource) RefSource() *pipelinev1.RefSource {
+	return f.ContentSource
+}
 
 // FakeResolver implements a framework.Resolver that can fetch pre-configured strings based on a parameter value, or return
 // resolution attempts with a configured error.
-type FakeResolver framework.FakeResolver
+type FakeResolver struct {
+	ForParam map[string]*FakeResolvedResource
+	Timeout  time.Duration
+}
 
 // Initialize performs any setup required by the fake resolver.
 func (r *FakeResolver) Initialize(ctx context.Context) error {
 	if r.ForParam == nil {
-		r.ForParam = make(map[string]*framework.FakeResolvedResource)
+		r.ForParam = make(map[string]*FakeResolvedResource)
 	}
 	return nil
 }
@@ -45,14 +92,14 @@ func (r *FakeResolver) Initialize(ctx context.Context) error {
 // GetName returns the string name that the fake resolver should be
 // associated with.
 func (r *FakeResolver) GetName(_ context.Context) string {
-	return framework.FakeResolverName
+	return FakeResolverName
 }
 
 // GetSelector returns the labels that resource requests are required to have for
 // the fake resolver to process them.
 func (r *FakeResolver) GetSelector(_ context.Context) map[string]string {
 	return map[string]string{
-		resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
+		resolutioncommon.LabelKeyResolverType: LabelValueFakeResolverType,
 	}
 }
 
@@ -60,7 +107,7 @@ func (r *FakeResolver) GetSelector(_ context.Context) map[string]string {
 // valid for a resource request targeting the fake resolver.
 func (r *FakeResolver) Validate(_ context.Context, req *v1beta1.ResolutionRequestSpec) error {
 	if len(req.Params) > 0 {
-		return framework.ValidateParams(req.Params)
+		return ValidateParams(req.Params)
 	}
 	if req.URL != FakeUrl {
 		return fmt.Errorf("Wrong url. Expected: %s,  Got: %s", FakeUrl, req.URL)
@@ -68,11 +115,38 @@ func (r *FakeResolver) Validate(_ context.Context, req *v1beta1.ResolutionReques
 	return nil
 }
 
+func ValidateParams(params []pipelinev1.Param) error {
+	paramsMap := make(map[string]pipelinev1.ParamValue)
+	for _, p := range params {
+		paramsMap[p.Name] = p.Value
+	}
+
+	required := []string{
+		FakeParamName,
+	}
+	missing := []string{}
+	if params == nil {
+		missing = required
+	} else {
+		for _, p := range required {
+			v, has := paramsMap[p]
+			if !has || v.StringVal == "" {
+				missing = append(missing, p)
+			}
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing %v", strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
 // Resolve performs the work of fetching a file from the fake resolver given a map of
 // parameters.
-func (r *FakeResolver) Resolve(_ context.Context, req *v1beta1.ResolutionRequestSpec) (framework.ResolvedResource, error) {
+func (r *FakeResolver) Resolve(_ context.Context, req *v1beta1.ResolutionRequestSpec) (ResolvedResource, error) {
 	if len(req.Params) > 0 {
-		return framework.Resolve(req.Params, r.ForParam)
+		return Resolve(req.Params, r.ForParam)
 	}
 	frr, ok := r.ForParam[req.URL]
 	if !ok {
@@ -81,9 +155,41 @@ func (r *FakeResolver) Resolve(_ context.Context, req *v1beta1.ResolutionRequest
 	return frr, nil
 }
 
-var _ framework.TimedResolution = &FakeResolver{}
+func Resolve(params []pipelinev1.Param, forParam map[string]*FakeResolvedResource) (ResolvedResource, error) {
+	paramsMap := make(map[string]pipelinev1.ParamValue)
+	for _, p := range params {
+		paramsMap[p.Name] = p.Value
+	}
+
+	paramValue := paramsMap[FakeParamName].StringVal
+
+	frr, ok := forParam[paramValue]
+	if !ok {
+		return nil, fmt.Errorf("couldn't find resource for param value %s", paramValue)
+	}
+
+	if frr.ErrorWith != "" {
+		return nil, errors.New(frr.ErrorWith)
+	}
+
+	if frr.WaitFor.Seconds() > 0 {
+		time.Sleep(frr.WaitFor)
+	}
+
+	return frr, nil
+}
+
+var _ TimedResolution = &FakeResolver{}
 
 // GetResolutionTimeout returns the configured timeout for the reconciler, or the default time.Duration if not configured.
 func (r *FakeResolver) GetResolutionTimeout(ctx context.Context, defaultTimeout time.Duration, params map[string]string) (time.Duration, error) {
-	return framework.GetResolutionTimeout(r.Timeout, defaultTimeout), nil
+	return GetResolutionTimeout(r.Timeout, defaultTimeout), nil
+}
+
+// GetResolutionTimeout returns the input timeout if set to something greater than 0 or the default time.Duration if not configured.
+func GetResolutionTimeout(timeout, defaultTimeout time.Duration) time.Duration {
+	if timeout > 0 {
+		return timeout
+	}
+	return defaultTimeout
 }

--- a/pkg/remoteresolution/resolver/framework/interface.go
+++ b/pkg/remoteresolution/resolver/framework/interface.go
@@ -18,9 +18,15 @@ package framework
 
 import (
 	"context"
+	"fmt"
+	"slices"
+	"time"
 
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
 )
 
 // Resolver is the interface to implement for type-specific resource
@@ -53,5 +59,83 @@ type Resolver interface {
 	// ResolutionRequest will not be updated with a failed status.
 	// See github.com/tektoncd/pipeline/pkg/resolution/common/errors.go for
 	// the definition of a transient error.
-	Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (framework.ResolvedResource, error)
+	//
+	// Note that the ResolvedResource returned by this function definition
+	// corresponds to remoteresolution/resolver/framework.ResolvedResource and
+	// not resolution/resolver/framework.ResolvedResource.
+	// Resolver implementations returning the old type won’t satisfy the new
+	// remoteresolution/resolver/framework.Resolver
+	Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (ResolvedResource, error)
+}
+
+// ConfigWatcher is the interface to implement if your resolver accepts
+// additional configuration from an admin. Examples of how this
+// might be used:
+// - your resolver might require an allow-list of repositories or registries
+// - your resolver might allow request timeout settings to be configured
+// - your resolver might need an API endpoint or base url to be set
+//
+// When your resolver implements this interface it will be able to
+// access configuration from the context it receives in calls to
+// ValidateParams and Resolve.
+type ConfigWatcher interface {
+	// GetConfigName should return a string name for its
+	// configuration to be referenced by. This will map to the name
+	// of a ConfigMap in the same namespace as the resolver.
+	GetConfigName(ctx context.Context) string
+}
+
+// TimedResolution is an optional interface that a resolver can
+// implement to override the default resolution request timeout.
+//
+// There are two timeouts that a resolution request adheres to: First
+// there is a global timeout that the core ResolutionRequest reconciler
+// enforces on _all_ requests. This prevents zombie requests (such as
+// those with a misconfigured `type`) sticking around in perpetuity.
+// Second there are resolver-specific timeouts that default to 1 minute.
+//
+// A resolver implementing the TimedResolution interface sets the maximum
+// duration of any single request to this resolver.
+//
+// The core ResolutionRequest reconciler's global timeout overrides any
+// resolver-specific timeout.
+type TimedResolution interface {
+	// GetResolutionTimeout receives the current request's context
+	// object, which includes any request-scoped data like
+	// resolver config and the request's originating namespace,
+	// along with a default.
+	GetResolutionTimeout(ctx context.Context, timeout time.Duration, params map[string]string) (time.Duration, error)
+}
+
+// ResolvedResource returns the data and annotations of a successful
+// resource fetch.
+//
+// This is a distinct named interface from the old
+// resolution/resolver/framework.ResolvedResource. Resolver implementations returning
+// the old type won’t satisfy the new framework.Resolver, even though the method sets are
+// identical.
+type ResolvedResource interface {
+	Data() []byte
+	Annotations() map[string]string
+	RefSource() *pipelinev1.RefSource
+}
+
+// ValidateResolvedResource validates that the ResolvedResource's data is a
+// kubernetes object and a Tekton kind. This ensures non-k8s data (e.g. tokens) or non-tekton
+// k8s objects (e.g. Secrets) are not written into the unprivileged ResolutionRequest objects.
+func ValidateResolvedResource(resource ResolvedResource) error {
+	var metadata struct {
+		APIVersion string
+		Kind       string
+	}
+	if err := yaml.Unmarshal(resource.Data(), &metadata); err != nil {
+		return fmt.Errorf("decoding error: %w", err)
+	}
+	// gv is not nil when there is an error
+	gv, _ := schema.ParseGroupVersion(metadata.APIVersion)
+
+	if gv.Group != pipelineapi.GroupName || !slices.Contains(allowedResourceKinds, metadata.Kind) {
+		return fmt.Errorf("resolved data is not of a supported type, must be of Group: %s, Kinds: %v", pipelineapi.GroupName, allowedResourceKinds)
+	}
+	return nil
 }

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
@@ -31,7 +32,6 @@ import (
 	rrv1beta1 "github.com/tektoncd/pipeline/pkg/client/resolution/listers/resolution/v1beta1"
 	rrcache "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
-	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -60,6 +60,18 @@ type statusDataPatch struct {
 	RefSource   *pipelinev1.RefSource         `json:"refSource"`
 }
 
+// allowedResourceKinds lists the kinds of resources which
+// are allowed to be resolved by resolvers
+var allowedResourceKinds = []string{
+	pipelineapi.PipelineRunControllerName,
+	pipelineapi.PipelineControllerName,
+	pipelineapi.TaskRunControllerName,
+	pipelineapi.TaskControllerName,
+	pipelineapi.RunControllerName,
+	pipelineapi.CustomRunControllerName,
+	pipelinev1beta1.StepActionKind,
+}
+
 // Reconciler handles ResolutionRequest objects, performs functionality
 // common to all resolvers and delegates resolver-specific actions
 // to its embedded type-specific Resolver object.
@@ -76,7 +88,7 @@ type Reconciler struct {
 	resolutionRequestLister    rrv1beta1.ResolutionRequestLister
 	resolutionRequestClientSet rrclient.Interface
 
-	configStore *framework.ConfigStore
+	configStore *ConfigStore
 }
 
 var _ reconciler.LeaderAware = &Reconciler{}
@@ -120,7 +132,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
 	errChan := make(chan error, 1)
-	resourceChan := make(chan framework.ResolvedResource, 1)
+	resourceChan := make(chan ResolvedResource, 1)
 
 	paramsMap := make(map[string]string)
 	for _, p := range rr.Spec.Params {
@@ -138,7 +150,7 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	}
 
 	timeoutDuration := defaultMaximumResolutionDuration
-	if timed, ok := r.resolver.(framework.TimedResolution); ok {
+	if timed, ok := r.resolver.(TimedResolution); ok {
 		var err error
 		timeoutDuration, err = timed.GetResolutionTimeout(ctx, defaultMaximumResolutionDuration, paramsMap)
 		if err != nil {
@@ -170,7 +182,7 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 			}
 			return
 		}
-		if err := framework.ValidateResolvedResource(resource); err != nil {
+		if err := ValidateResolvedResource(resource); err != nil {
 			errChan <- &resolutioncommon.GetResourceError{
 				ResolverName: r.resolver.GetName(resolutionCtx),
 				Key:          key,
@@ -236,7 +248,7 @@ func (r *Reconciler) MarkFailed(ctx context.Context, rr *v1beta1.ResolutionReque
 	return nil
 }
 
-func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.ResolutionRequest, resource framework.ResolvedResource) error {
+func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.ResolutionRequest, resource ResolvedResource) error {
 	encodedData := base64.StdEncoding.Strict().EncodeToString(resource.Data())
 	patchBytes, err := json.Marshal(map[string]statusDataPatch{
 		"status": {

--- a/pkg/remoteresolution/resolver/framework/reconciler_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_test.go
@@ -33,7 +33,6 @@ import (
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
-	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
@@ -62,7 +61,7 @@ func TestReconcile(t *testing.T) {
 	testCases := []struct {
 		name              string
 		inputRequest      *v1beta1.ResolutionRequest
-		paramMap          map[string]*resolutionframework.FakeResolvedResource
+		paramMap          map[string]*framework.FakeResolvedResource
 		reconcilerTimeout time.Duration
 		expectedStatus    *v1beta1.ResolutionRequestStatus
 		expectedErr       error
@@ -80,18 +79,18 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "foo",
 					CreationTimestamp: metav1.Time{Time: time.Now()},
 					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 					},
 				},
 				Spec: v1beta1.ResolutionRequestSpec{
 					Params: []pipelinev1.Param{{
-						Name:  resolutionframework.FakeParamName,
+						Name:  framework.FakeParamName,
 						Value: *pipelinev1.NewStructuredValues("bar"),
 					}},
 				},
 				Status: v1beta1.ResolutionRequestStatus{},
 			},
-			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+			paramMap: map[string]*framework.FakeResolvedResource{
 				"bar": {
 					Content:       "{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"Pipeline\"}",
 					AnnotationMap: map[string]string{"foo": "bar"},
@@ -140,18 +139,18 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "foo",
 					CreationTimestamp: metav1.Time{Time: time.Now()},
 					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 					},
 				},
 				Spec: v1beta1.ResolutionRequestSpec{
 					Params: []pipelinev1.Param{{
-						Name:  resolutionframework.FakeParamName,
+						Name:  framework.FakeParamName,
 						Value: *pipelinev1.NewStructuredValues("bar"),
 					}},
 				},
 				Status: v1beta1.ResolutionRequestStatus{},
 			},
-			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+			paramMap: map[string]*framework.FakeResolvedResource{
 				"bar": {
 					Content:       "foo: bar\nbax: baz",
 					AnnotationMap: map[string]string{"foo": "bar"},
@@ -177,18 +176,18 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "foo",
 					CreationTimestamp: metav1.Time{Time: time.Now()},
 					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 					},
 				},
 				Spec: v1beta1.ResolutionRequestSpec{
 					Params: []pipelinev1.Param{{
-						Name:  resolutionframework.FakeParamName,
+						Name:  framework.FakeParamName,
 						Value: *pipelinev1.NewStructuredValues("bar"),
 					}},
 				},
 				Status: v1beta1.ResolutionRequestStatus{},
 			},
-			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+			paramMap: map[string]*framework.FakeResolvedResource{
 				"bar": {
 					Content:       "{\"apiVersion\": \"other/type\", \"kind\": \"NonTekton\"}",
 					AnnotationMap: map[string]string{"foo": "bar"},
@@ -214,12 +213,12 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "foo",
 					CreationTimestamp: metav1.Time{Time: time.Now()},
 					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 					},
 				},
 				Spec: v1beta1.ResolutionRequestSpec{
 					Params: []pipelinev1.Param{{
-						Name:  resolutionframework.FakeParamName,
+						Name:  framework.FakeParamName,
 						Value: *pipelinev1.NewStructuredValues("bar"),
 					}},
 				},
@@ -238,7 +237,7 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "foo",
 					CreationTimestamp: metav1.Time{Time: time.Now()},
 					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 					},
 				},
 				Spec: v1beta1.ResolutionRequestSpec{
@@ -259,7 +258,7 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "foo",
 					CreationTimestamp: metav1.Time{Time: time.Now()},
 					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 					},
 				},
 				Spec: v1beta1.ResolutionRequestSpec{
@@ -267,7 +266,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: v1beta1.ResolutionRequestStatus{},
 			},
-			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+			paramMap: map[string]*framework.FakeResolvedResource{
 				framework.FakeUrl: {
 					Content:       "{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"Pipeline\"}",
 					AnnotationMap: map[string]string{"foo": "bar"},
@@ -316,7 +315,7 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "foo",
 					CreationTimestamp: metav1.Time{Time: time.Now()},
 					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 					},
 				},
 				Spec: v1beta1.ResolutionRequestSpec{
@@ -324,7 +323,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: v1beta1.ResolutionRequestStatus{},
 			},
-			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+			paramMap: map[string]*framework.FakeResolvedResource{
 				"other://resource": {
 					Content:       "some content",
 					AnnotationMap: map[string]string{"foo": "bar"},
@@ -350,7 +349,7 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "foo",
 					CreationTimestamp: metav1.Time{Time: time.Now()},
 					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 					},
 				},
 				Spec: v1beta1.ResolutionRequestSpec{
@@ -374,18 +373,18 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "foo",
 					CreationTimestamp: metav1.Time{Time: time.Now()},
 					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 					},
 				},
 				Spec: v1beta1.ResolutionRequestSpec{
 					Params: []pipelinev1.Param{{
-						Name:  resolutionframework.FakeParamName,
+						Name:  framework.FakeParamName,
 						Value: *pipelinev1.NewStructuredValues("bar"),
 					}},
 				},
 				Status: v1beta1.ResolutionRequestStatus{},
 			},
-			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+			paramMap: map[string]*framework.FakeResolvedResource{
 				"bar": {
 					ErrorWith: "fake failure",
 				},
@@ -403,18 +402,18 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "foo",
 					CreationTimestamp: metav1.Time{Time: time.Now().Add(-59 * time.Second)}, // 1 second before default timeout
 					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 					},
 				},
 				Spec: v1beta1.ResolutionRequestSpec{
 					Params: []pipelinev1.Param{{
-						Name:  resolutionframework.FakeParamName,
+						Name:  framework.FakeParamName,
 						Value: *pipelinev1.NewStructuredValues("bar"),
 					}},
 				},
 				Status: v1beta1.ResolutionRequestStatus{},
 			},
-			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+			paramMap: map[string]*framework.FakeResolvedResource{
 				"bar": {
 					WaitFor: 1100 * time.Millisecond,
 				},
@@ -434,12 +433,12 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "foo",
 					CreationTimestamp: metav1.Time{Time: time.Now()},
 					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 					},
 				},
 				Spec: v1beta1.ResolutionRequestSpec{
 					Params: []pipelinev1.Param{{
-						Name:  resolutionframework.FakeParamName,
+						Name:  framework.FakeParamName,
 						Value: *pipelinev1.NewStructuredValues("bar"),
 					}},
 				},
@@ -457,7 +456,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			},
-			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+			paramMap: map[string]*framework.FakeResolvedResource{
 				"bar": {
 					ErrorWith: "resolver should not have been called",
 				},
@@ -534,7 +533,7 @@ func TestReconcile(t *testing.T) {
 func TestResolveGoroutineLeak(t *testing.T) {
 	const numRequests = 5
 
-	paramMap := map[string]*resolutionframework.FakeResolvedResource{
+	paramMap := map[string]*framework.FakeResolvedResource{
 		"bar": {WaitFor: 200 * time.Millisecond},
 	}
 
@@ -550,12 +549,12 @@ func TestResolveGoroutineLeak(t *testing.T) {
 				Namespace:         "foo",
 				CreationTimestamp: metav1.Time{Time: time.Now()},
 				Labels: map[string]string{
-					resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+					resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
 				},
 			},
 			Spec: v1beta1.ResolutionRequestSpec{
 				Params: []pipelinev1.Param{{
-					Name:  resolutionframework.FakeParamName,
+					Name:  framework.FakeParamName,
 					Value: *pipelinev1.NewStructuredValues("bar"),
 				}},
 			},

--- a/pkg/remoteresolution/resolver/git/resolver.go
+++ b/pkg/remoteresolution/resolver/git/resolver.go
@@ -154,7 +154,7 @@ func (r *Resolver) GetResolutionTimeout(ctx context.Context, defaultTimeout time
 
 // Resolve performs the work of fetching a file from git given a map of
 // parameters.
-func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
+func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (framework.ResolvedResource, error) {
 	if len(req.Params) == 0 {
 		return nil, errors.New("no params")
 	}

--- a/pkg/remoteresolution/resolver/http/resolver.go
+++ b/pkg/remoteresolution/resolver/http/resolver.go
@@ -77,7 +77,7 @@ func (r *Resolver) Validate(ctx context.Context, req *v1beta1.ResolutionRequestS
 }
 
 // Resolve uses the given params to resolve the requested file or resource.
-func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
+func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (framework.ResolvedResource, error) {
 	if http.IsDisabled(ctx) {
 		return nil, errors.New(disabledError)
 	}

--- a/pkg/remoteresolution/resolver/hub/resolver.go
+++ b/pkg/remoteresolution/resolver/hub/resolver.go
@@ -95,7 +95,7 @@ func (r *Resolver) Validate(ctx context.Context, req *v1beta1.ResolutionRequestS
 }
 
 // Resolve uses the given params to resolve the requested file or resource.
-func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (resolutionframework.ResolvedResource, error) {
+func (r *Resolver) Resolve(ctx context.Context, req *v1beta1.ResolutionRequestSpec) (framework.ResolvedResource, error) {
 	if isDisabled(ctx) {
 		return nil, errors.New(disabledError)
 	}


### PR DESCRIPTION
# Changes

Part of #9617 

The shared types (ResolvedResource, ConfigWatcher, TimedResolution, ConfigStore) were defined in pkg/resolution/resolver/framework, causing pkg/remoteresolution/resolver/framework to import from the old deprecated package.

Move these types into pkg/remoteresolution/resolver/framework so it is self-contained and no longer depends on the old package. This is part of consolidating the two resolver frameworks into one #9617.

/kind cleanup

- Added `framework/configstore.go` and `framework/configstore_test.go` (copied from old package).
- Added `ConfigWatcher`, `TimedResolution`, and `ResolvedResource` interfaces directly to `framework/interface.go`, dropping the import of the old package.
- Refactored `fakeresolver.go` to inline `FakeResolvedResource`, `FakeResolver` and helper functions (previously imported from old package).
- Added `FilterResolutionRequestsBySelector`, `LeaderAwareFuncs`, and `ValidateResolver` to `controller.go`.
- Updated `reconciler.go` and `reconciler_test.go` to use local types throughout, and updated `Resolve()` return types across bundle, cluster, git, http, hub, and the resolver template.

---

**Edit**(on @waveywaves' suggestion): The `ResolvedResource` in `pkg/remoteresolution/resolver/framework/interface.go` uses `Data() []byte` and intentionally does NOT match `resolution/common.ResolvedResource` which has Data() ([]byte, error). The reconciler's `writeResolvedData` calls `resource.Data()` expecting `[]byte`

---

**Edit 2**: The shared type `ValidateResolvedResource` introduced in commit
[#18eca1c](https://github.com/tektoncd/pipeline/commit/18eca1c80809c901d0e66c7767f708ff6edc8200) was defined in `pkg/resolution/resolver/framework`, causing
`remoteresolution/framework` to import from the older package.

Move `ValidateResolvedResource` and `allowedResourceKinds` string slice
to `remoteresolution/framework`

---

**Edit 3**: The scope of this PR is limited to the `remoteresolution/resolver/framework` package not depending on the `resolution/resolver/framework`

### Deferred/Follow-up List [meant as subsequent PRs for this issue]:
- `pkg/remoteresolution/resolver/framework/cache` still depends on the old framework package and needs a follow-up interface extraction/migration.
- `bundle`, `cluster`, `git`, `http` and `hub` internals that still use the old framework package are intentionally left for per-resolver follow-ups.
- test files and config-context helper cleanup can be handled with those per-resolver follow-ups.

---

**Edit 4**: Note that the new `remoteresolution/resolver/framework.ResolvedResource` is a distinct named interface from the old `resolution/resolver/framework.ResolvedResource`. Since Go method return types must match exactly, resolver implementations returning the old type won’t satisfy the new `remoteresolution/resolver/framework.Resolver`, even though the method sets are identical.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
