### PR TITLE
[release-v1.0.x] fix: normalize VolumeMount paths before /tekton/ restriction check

### DIFF
--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -445,8 +445,9 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 	}
 
 	for j, vm := range s.VolumeMounts {
-		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+		cleanMountPath := filepath.Clean(vm.MountPath)
+		if strings.HasPrefix(cleanMountPath, "/tekton/") &&
+			!strings.HasPrefix(cleanMountPath, "/tekton/home") {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
 		}
 		if strings.HasPrefix(vm.Name, "tekton-internal-") {

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -407,6 +407,17 @@ func TestTaskSpecValidate(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "valid step with volumeMount under /tekton/home subdirectory",
+		fields: fields{
+			Steps: []v1.Step{{
+				Image: "myimage",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "foo",
+					MountPath: "/tekton/home/subdir",
+				}},
+			}},
+		},
+	}, {
 		name: "valid workspace",
 		fields: fields{
 			Steps: []v1.Step{{
@@ -1243,6 +1254,51 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `volumeMount cannot be mounted under /tekton/ (volumeMount "foo" mounted at "/tekton/foo")`,
+			Paths:   []string{"steps[0].volumeMounts[0].mountPath"},
+		},
+	}, {
+		name: "step volume mount path traversal to /tekton/results",
+		fields: fields{
+			Steps: []v1.Step{{
+				Image: "myimage",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "foo",
+					MountPath: "/tekton/home/../results",
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `volumeMount cannot be mounted under /tekton/ (volumeMount "foo" mounted at "/tekton/home/../results")`,
+			Paths:   []string{"steps[0].volumeMounts[0].mountPath"},
+		},
+	}, {
+		name: "step volume mount path traversal to /tekton/scripts",
+		fields: fields{
+			Steps: []v1.Step{{
+				Image: "myimage",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "foo",
+					MountPath: "/tekton/home/../scripts",
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `volumeMount cannot be mounted under /tekton/ (volumeMount "foo" mounted at "/tekton/home/../scripts")`,
+			Paths:   []string{"steps[0].volumeMounts[0].mountPath"},
+		},
+	}, {
+		name: "step volume mount nested path traversal to /tekton/run",
+		fields: fields{
+			Steps: []v1.Step{{
+				Image: "myimage",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "foo",
+					MountPath: "/tekton/home/../../tekton/run",
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `volumeMount cannot be mounted under /tekton/ (volumeMount "foo" mounted at "/tekton/home/../../tekton/run")`,
 			Paths:   []string{"steps[0].volumeMounts[0].mountPath"},
 		},
 	}, {

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -434,8 +434,9 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 	}
 
 	for j, vm := range s.VolumeMounts {
-		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+		cleanMountPath := filepath.Clean(vm.MountPath)
+		if strings.HasPrefix(cleanMountPath, "/tekton/") &&
+			!strings.HasPrefix(cleanMountPath, "/tekton/home") {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
 		}
 		if strings.HasPrefix(vm.Name, "tekton-internal-") {

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -411,6 +411,17 @@ func TestTaskSpecValidate(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "valid step with volumeMount under /tekton/home subdirectory",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Image: "myimage",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "foo",
+					MountPath: "/tekton/home/subdir",
+				}},
+			}},
+		},
+	}, {
 		name: "valid workspace",
 		fields: fields{
 			Steps: []v1beta1.Step{{
@@ -1246,6 +1257,51 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `volumeMount cannot be mounted under /tekton/ (volumeMount "foo" mounted at "/tekton/foo")`,
+			Paths:   []string{"steps[0].volumeMounts[0].mountPath"},
+		},
+	}, {
+		name: "step volume mount path traversal to /tekton/results",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Image: "myimage",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "foo",
+					MountPath: "/tekton/home/../results",
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `volumeMount cannot be mounted under /tekton/ (volumeMount "foo" mounted at "/tekton/home/../results")`,
+			Paths:   []string{"steps[0].volumeMounts[0].mountPath"},
+		},
+	}, {
+		name: "step volume mount path traversal to /tekton/scripts",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Image: "myimage",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "foo",
+					MountPath: "/tekton/home/../scripts",
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `volumeMount cannot be mounted under /tekton/ (volumeMount "foo" mounted at "/tekton/home/../scripts")`,
+			Paths:   []string{"steps[0].volumeMounts[0].mountPath"},
+		},
+	}, {
+		name: "step volume mount nested path traversal to /tekton/run",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Image: "myimage",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "foo",
+					MountPath: "/tekton/home/../../tekton/run",
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `volumeMount cannot be mounted under /tekton/ (volumeMount "foo" mounted at "/tekton/home/../../tekton/run")`,
 			Paths:   []string{"steps[0].volumeMounts[0].mountPath"},
 		},
 	}, {


### PR DESCRIPTION
Cherry-pick of the fix for GHSA-rx35-6rhx-7858 to `release-v1.0.x`.

### Summary

A validation bypass in the VolumeMount path restriction allows mounting volumes under restricted `/tekton/` internal paths by using `..` path traversal components. The restriction check uses `strings.HasPrefix` without `filepath.Clean`, so a path like `/tekton/home/../results` passes validation but resolves to `/tekton/results` at runtime.

### Fix

Add `filepath.Clean` before the `strings.HasPrefix` check in the VolumeMount path validation to prevent path traversal bypass via `..` components.

**Note:** On v1.0.x, the v1 volumeMount check lives in `task_validation.go` (it was refactored into `container_validation.go` in later releases).

Applied to both v1 (`task_validation.go`) and v1beta1 (`task_validation.go`).

/kind bug