### PR TITLE
test: remove cache.Clear() from setup() to fix parallel test flakiness

### DIFF
--- a/test/util.go
+++ b/test/util.go
@@ -32,7 +32,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/names"
-	"github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,8 +71,6 @@ var (
 func setup(ctx context.Context, t *testing.T, fn ...func(context.Context, *testing.T, *clients, string)) (*clients, string) {
 	t.Helper()
 	skipIfExcluded(t)
-
-	cache.Get(ctx).Clear()
 
 	namespace := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")
 


### PR DESCRIPTION
## Problem

`setup()` in `test/util.go` called `cache.Get(ctx).Clear()`, which wipes the shared resolver cache. With parallel tests, this caused `TestBundleResolverCacheWithFourResolverReplicas` to flake: three of the five parallel cache tests call `t.Parallel()` before `setup()`, so their `Clear()` fires concurrently with the replica-warming phase of the four-replica test, invalidating its pre-warmed entries.

Affected parallel tests that call `t.Parallel()` before `setup()` (i.e. `Clear()` fires concurrently):
- `TestBundleResolverCache`
- `TestResolverCacheErrorHandling`
- `TestResolverCacheInvalidParams`

## Fix

Remove `cache.Get(ctx).Clear()` from `setup()`.

Each cache test already generates a unique image reference via `ObjectNameForTest(t)`, giving each test a distinct cache key. No test can accidentally hit another test's cached entry, so the `Clear()` was never needed for isolation — it only introduced a race.

Non-cache tests don't assert on cache state, so removing this call has no impact on them.

Fixes #9364

## Test plan
- [ ] Existing cache tests pass without `Clear()` (isolation is preserved via unique image refs)
- [ ] `TestBundleResolverCacheWithFourResolverReplicas` no longer flakes under `-parallel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)