### PR TITLE
feat: use gotestsum for unit tests when available

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -124,6 +124,11 @@ You must install these tools:
    [`delve`](https://github.com/go-delve/delve/tree/master/Documentation/installation) is needed if you want to setup
    a debugging of the Tekton controller in VSCode or your IDE of choice.
 
+1. (Optional)
+   [`gotestsum`](https://github.com/gotestyourself/gotestsum) improves test
+   output formatting. When installed, `make test-unit` will automatically use
+   it. Install with `go install gotest.tools/gotestsum@latest`.
+
 ### Configure environment
 
 To [build, deploy and run your Tekton Objects with `ko`](#install-pipeline), you'll need to set these environment variables:
@@ -404,6 +409,37 @@ To make changes to these CRDs, you will probably interact with:
 #### Testing
 
 For comprehensive testing documentation, including how to run different test suites and understand test categorization, see the [Testing Guide](./test/README.md).
+
+##### Unit tests with `gotestsum`
+
+The `make test-unit` target automatically detects and uses [`gotestsum`](https://github.com/gotestyourself/gotestsum) when available, falling back to `go test` otherwise. `gotestsum` provides improved test output formatting compared to plain `go test`.
+
+The default output format is `testdox`. You can override it via the `DEFAULT_GOTESTSUM_FORMAT` variable:
+
+```shell
+# Use the default testdox format
+make test-unit
+
+# Override the output format
+make test-unit DEFAULT_GOTESTSUM_FORMAT=pkgname
+
+# Or add to your .envrc to make it permanent
+export DEFAULT_GOTESTSUM_FORMAT=pkgname
+```
+
+Available formats:
+
+| Format | Description |
+|--------|-------------|
+| `dots` | Print a character for each test |
+| `dots-v2` | Dots format, one package per line |
+| `pkgname` | Print a line for each package (gotestsum default) |
+| `pkgname-and-test-fails` | Line per package and failed test output |
+| `testname` | Print a line for each test and package |
+| `testdox` | Print a sentence for each test (**Makefile default**) |
+| `github-actions` | testname with GitHub Actions log grouping |
+| `standard-quiet` | Standard `go test` format |
+| `standard-verbose` | Standard `go test -v` format |
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ WOKE_VERSION     = v0.19.0
 GO           = go
 TIMEOUT_UNIT = 5m
 TIMEOUT_E2E  = 20m
+DEFAULT_GOTESTSUM_FORMAT ?= testdox
 V = 0
 Q = $(if $(filter 1,$V),,@)
 M = $(shell printf "\033[34;1m🐱\033[0m")
@@ -90,7 +91,11 @@ test-unit-verbose-and-race: ARGS=-v -race
 $(TEST_UNIT_TARGETS): test-unit
 .PHONY: $(TEST_UNIT_TARGETS) test-unit
 test-unit: ## Run unit tests
-	$(GO) test -timeout $(TIMEOUT_UNIT) $(ARGS) ./...
+	@if command -v gotestsum >/dev/null 2>&1; then \
+		gotestsum --format $(DEFAULT_GOTESTSUM_FORMAT) -- $(ARGS) -timeout $(TIMEOUT_UNIT) ./...; \
+	else \
+		$(GO) test -timeout $(TIMEOUT_UNIT) $(ARGS) ./...; \
+	fi
 
 TEST_E2E_TARGETS := test-e2e-short test-e2e-verbose test-e2e-race
 test-e2e-short:   ARGS=-short


### PR DESCRIPTION
# Changes

Use [`gotestsum`](https://github.com/gotestyourself/gotestsum) in `make test-unit` when available, falling back to `go test` otherwise. This follows the same pattern as [pipelines-as-code](https://github.com/openshift-pipelines/pipelines-as-code/pull/2675).

`gotestsum` provides improved test output formatting. The default format is `testdox` which gives a readable sentence for each test:

```
 ✓ Workspace binding validate valid (0.00s)
 ✓ Workspace binding validate invalid (0.00s)

DONE 1248 tests in 0.203s
```

The format can be overridden via the `DEFAULT_GOTESTSUM_FORMAT` variable:

```shell
make test-unit DEFAULT_GOTESTSUM_FORMAT=pkgname
```

Available formats:

| Format | Description |
|--------|-------------|
| `dots` | Print a character for each test |
| `dots-v2` | Dots format, one package per line |
| `pkgname` | Print a line for each package (gotestsum default) |
| `pkgname-and-test-fails` | Line per package and failed test output |
| `testname` | Print a line for each test and package |
| `testdox` | Print a sentence for each test (**Makefile default**) |
| `github-actions` | testname with GitHub Actions log grouping |
| `standard-quiet` | Standard `go test` format |
| `standard-verbose` | Standard `go test -v` format |

`DEVELOPMENT.md` is updated to document `gotestsum` as an optional tool and describe the available formats.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```