### PR TITLE
perf(taskrun): skip sidecar teardown when status shows no running sidecars (#9755)

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -163,21 +163,25 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 		// and may not have had all of the assumed default specified.
 		tr.SetDefaults(ctx)
 
-		useTektonSidecar := true
-		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
-			dc := c.KubeClientSet.Discovery()
-			sv, err := dc.ServerVersion()
-			if err != nil {
-				return err
+		// When sidecar teardown is unnecessary, skip stopSidecars and discovery — avoids
+		// a live Pods().Get and ServerVersion on every resync of completed TaskRuns (#9755).
+		if taskRunNeedsSidecarDonePath(tr) {
+			useTektonSidecar := true
+			if config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
+				dc := c.KubeClientSet.Discovery()
+				sv, err := dc.ServerVersion()
+				if err != nil {
+					return err
+				}
+				if podconvert.IsNativeSidecarSupport(sv) {
+					useTektonSidecar = false
+					logger.Infof("Using Kubernetes Native Sidecars \n")
+				}
 			}
-			if podconvert.IsNativeSidecarSupport(sv) {
-				useTektonSidecar = false
-				logger.Infof("Using Kubernetes Native Sidecars \n")
-			}
-		}
-		if useTektonSidecar {
-			if err := c.stopSidecars(ctx, tr); err != nil {
-				return err
+			if useTektonSidecar {
+				if err := c.stopSidecars(ctx, tr); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -374,6 +378,32 @@ func (c *Reconciler) durationAndCountMetrics(ctx context.Context, tr *v1.TaskRun
 			logger.Warnf("Failed to log the duration and count of taskruns : %v", err)
 		}
 	}
+}
+
+// taskRunNeedsSidecarDonePath returns true when the TaskRun done path should run
+// discovery and possibly stopSidecars. When false, completed TaskRun resyncs avoid
+// ServerVersion and Pods().Get (#9755).
+//
+// We skip when status lists every sidecar as terminated, or when sidecar status is
+// still empty but the resolved task spec has no sidecars. If status is empty and the
+// task declares sidecars (or TaskSpec is unavailable), we still run the path so we do
+// not skip teardown before sidecar status has been written.
+func taskRunNeedsSidecarDonePath(tr *v1.TaskRun) bool {
+	if podconvert.IsSidecarStatusRunning(tr) {
+		return true
+	}
+	if len(tr.Status.Sidecars) > 0 {
+		// Every entry has Terminated set (IsSidecarStatusRunning is false).
+		return false
+	}
+	ts := tr.Status.TaskSpec
+	if ts == nil {
+		ts = tr.Spec.TaskSpec
+	}
+	if ts == nil {
+		return true
+	}
+	return len(ts.Sidecars) > 0
 }
 
 func (c *Reconciler) stopSidecars(ctx context.Context, tr *v1.TaskRun) error {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -95,17 +95,12 @@ type Reconciler struct {
 	resolutionRequester      resolution.Requester
 	tracerProvider           trace.TracerProvider
 
-	// sidecarMode caches ServerVersion + IsNativeSidecarSupport when EnableKubernetesSidecar
-	// is true, so the done path does not call Discovery on every resync (#9755). After the first
-	// successful discovery, useTektonSidecarMode only reads computed/useTektonNop from memory
-	// (RLock); Discovery runs at most once per reconciler (Lock), and errors retry until success.
+	// Native-sidecar detection (ServerVersion + IsNativeSidecarSupport) when EnableKubernetesSidecar
+	// is set is memoized via sync.OnceValues after lazy init guarded by nativeSidecarOnce (#9755).
 	// Status.Sidecars cannot be used to skip stopSidecars: injected containers (e.g. Istio)
 	// are not listed there but buildSidecarStopPatch stops them using the live Pod.
-	sidecarMode struct {
-		sync.RWMutex
-		computed     bool
-		useTektonNop bool // if true, run stopSidecars; if false, native Kubernetes sidecars
-	}
+	nativeSidecarOnce        sync.Once
+	nativeSidecarFromCluster func() (useTektonNop bool, err error)
 }
 
 const (
@@ -379,37 +374,32 @@ func (c *Reconciler) durationAndCountMetrics(ctx context.Context, tr *v1.TaskRun
 }
 
 // useTektonSidecarMode returns whether the done path should run stopSidecars (Tekton nop
-// image) vs skipping it for native Kubernetes sidecars. ServerVersion is queried at most once
-// per reconciler when EnableKubernetesSidecar is true; later reconciles return the cached
-// useTektonNop without calling Discovery.
+// image) vs skipping it for native Kubernetes sidecars. When EnableKubernetesSidecar is enabled,
+// ServerVersion is queried at most once per reconciler; later reconciles reuse the memoized result.
 func (c *Reconciler) useTektonSidecarMode(ctx context.Context, logger *zap.SugaredLogger) (bool, error) {
 	if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
 		return true, nil
 	}
-	c.sidecarMode.RLock()
-	if c.sidecarMode.computed {
-		v := c.sidecarMode.useTektonNop
-		c.sidecarMode.RUnlock()
-		return v, nil
-	}
-	c.sidecarMode.RUnlock()
+	c.nativeSidecarOnce.Do(func() {
+		c.nativeSidecarFromCluster = newNativeSidecarFromCluster(c.KubeClientSet, logger)
+	})
+	return c.nativeSidecarFromCluster()
+}
 
-	c.sidecarMode.Lock()
-	defer c.sidecarMode.Unlock()
-	if c.sidecarMode.computed {
-		return c.sidecarMode.useTektonNop, nil
-	}
-	sv, err := c.KubeClientSet.Discovery().ServerVersion()
-	if err != nil {
-		return false, err
-	}
-	native := podconvert.IsNativeSidecarSupport(sv)
-	c.sidecarMode.useTektonNop = !native
-	c.sidecarMode.computed = true
-	if native {
-		logger.Infof("Using Kubernetes Native Sidecars \n")
-	}
-	return c.sidecarMode.useTektonNop, nil
+// newNativeSidecarFromCluster returns a function that queries ServerVersion at most once and
+// returns whether to use Tekton nop sidecar teardown (true) vs native Kubernetes sidecars (false).
+func newNativeSidecarFromCluster(client kubernetes.Interface, log *zap.SugaredLogger) func() (bool, error) {
+	return sync.OnceValues(func() (bool, error) {
+		sv, err := client.Discovery().ServerVersion()
+		if err != nil {
+			return false, err
+		}
+		if podconvert.IsNativeSidecarSupport(sv) {
+			log.Info("Using Kubernetes Native Sidecars")
+			return false, nil
+		}
+		return true, nil
+	})
 }
 
 func (c *Reconciler) stopSidecars(ctx context.Context, tr *v1.TaskRun) error {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -96,11 +96,13 @@ type Reconciler struct {
 	tracerProvider           trace.TracerProvider
 
 	// sidecarMode caches ServerVersion + IsNativeSidecarSupport when EnableKubernetesSidecar
-	// is true, so the done path does not call Discovery on every resync (#9755).
+	// is true, so the done path does not call Discovery on every resync (#9755). After the first
+	// successful discovery, useTektonSidecarMode only reads computed/useTektonNop from memory
+	// (RLock); Discovery runs at most once per reconciler (Lock), and errors retry until success.
 	// Status.Sidecars cannot be used to skip stopSidecars: injected containers (e.g. Istio)
 	// are not listed there but buildSidecarStopPatch stops them using the live Pod.
 	sidecarMode struct {
-		sync.Mutex
+		sync.RWMutex
 		computed     bool
 		useTektonNop bool // if true, run stopSidecars; if false, native Kubernetes sidecars
 	}
@@ -378,11 +380,20 @@ func (c *Reconciler) durationAndCountMetrics(ctx context.Context, tr *v1.TaskRun
 
 // useTektonSidecarMode returns whether the done path should run stopSidecars (Tekton nop
 // image) vs skipping it for native Kubernetes sidecars. ServerVersion is queried at most once
-// per reconciler when EnableKubernetesSidecar is true.
+// per reconciler when EnableKubernetesSidecar is true; later reconciles return the cached
+// useTektonNop without calling Discovery.
 func (c *Reconciler) useTektonSidecarMode(ctx context.Context, logger *zap.SugaredLogger) (bool, error) {
 	if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
 		return true, nil
 	}
+	c.sidecarMode.RLock()
+	if c.sidecarMode.computed {
+		v := c.sidecarMode.useTektonNop
+		c.sidecarMode.RUnlock()
+		return v, nil
+	}
+	c.sidecarMode.RUnlock()
+
 	c.sidecarMode.Lock()
 	defer c.sidecarMode.Unlock()
 	if c.sidecarMode.computed {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tektoncd/pipeline/internal/sidecarlogresults"
@@ -95,6 +96,16 @@ type Reconciler struct {
 	pvcHandler               volumeclaim.PvcHandler
 	resolutionRequester      resolution.Requester
 	tracerProvider           trace.TracerProvider
+
+	// sidecarMode caches ServerVersion + IsNativeSidecarSupport when EnableKubernetesSidecar
+	// is true, so the done path does not call Discovery on every resync (#9755).
+	// Status.Sidecars cannot be used to skip stopSidecars: injected containers (e.g. Istio)
+	// are not listed there but buildSidecarStopPatch stops them using the live Pod.
+	sidecarMode struct {
+		sync.Mutex
+		computed     bool
+		useTektonNop bool // if true, run stopSidecars; if false, native Kubernetes sidecars
+	}
 }
 
 const (
@@ -163,25 +174,17 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 		// and may not have had all of the assumed default specified.
 		tr.SetDefaults(ctx)
 
-		// When sidecar teardown is unnecessary, skip stopSidecars and discovery — avoids
-		// a live Pods().Get and ServerVersion on every resync of completed TaskRuns (#9755).
-		if taskRunNeedsSidecarDonePath(tr) {
-			useTektonSidecar := true
-			if config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
-				dc := c.KubeClientSet.Discovery()
-				sv, err := dc.ServerVersion()
-				if err != nil {
-					return err
-				}
-				if podconvert.IsNativeSidecarSupport(sv) {
-					useTektonSidecar = false
-					logger.Infof("Using Kubernetes Native Sidecars \n")
-				}
-			}
-			if useTektonSidecar {
-				if err := c.stopSidecars(ctx, tr); err != nil {
-					return err
-				}
+		// stopSidecars must run whenever we use Tekton-managed sidecars: TaskRun status only
+		// lists containers with the sidecar- prefix; injected sidecars are visible only on
+		// the Pod (see buildSidecarStopPatch). Cache ServerVersion + native-sidecar detection
+		// so we do not call Discovery on every resync (#9755).
+		useTektonSidecar, err := c.useTektonSidecarMode(ctx, logger)
+		if err != nil {
+			return err
+		}
+		if useTektonSidecar {
+			if err := c.stopSidecars(ctx, tr); err != nil {
+				return err
 			}
 		}
 
@@ -380,30 +383,29 @@ func (c *Reconciler) durationAndCountMetrics(ctx context.Context, tr *v1.TaskRun
 	}
 }
 
-// taskRunNeedsSidecarDonePath returns true when the TaskRun done path should run
-// discovery and possibly stopSidecars. When false, completed TaskRun resyncs avoid
-// ServerVersion and Pods().Get (#9755).
-//
-// We skip when status lists every sidecar as terminated, or when sidecar status is
-// still empty but the resolved task spec has no sidecars. If status is empty and the
-// task declares sidecars (or TaskSpec is unavailable), we still run the path so we do
-// not skip teardown before sidecar status has been written.
-func taskRunNeedsSidecarDonePath(tr *v1.TaskRun) bool {
-	if podconvert.IsSidecarStatusRunning(tr) {
-		return true
+// useTektonSidecarMode returns whether the done path should run stopSidecars (Tekton nop
+// image) vs skipping it for native Kubernetes sidecars. ServerVersion is queried at most once
+// per reconciler when EnableKubernetesSidecar is true.
+func (c *Reconciler) useTektonSidecarMode(ctx context.Context, logger *zap.SugaredLogger) (bool, error) {
+	if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
+		return true, nil
 	}
-	if len(tr.Status.Sidecars) > 0 {
-		// Every entry has Terminated set (IsSidecarStatusRunning is false).
-		return false
+	c.sidecarMode.Lock()
+	defer c.sidecarMode.Unlock()
+	if c.sidecarMode.computed {
+		return c.sidecarMode.useTektonNop, nil
 	}
-	ts := tr.Status.TaskSpec
-	if ts == nil {
-		ts = tr.Spec.TaskSpec
+	sv, err := c.KubeClientSet.Discovery().ServerVersion()
+	if err != nil {
+		return false, err
 	}
-	if ts == nil {
-		return true
+	native := podconvert.IsNativeSidecarSupport(sv)
+	c.sidecarMode.useTektonNop = !native
+	c.sidecarMode.computed = true
+	if native {
+		logger.Infof("Using Kubernetes Native Sidecars \n")
 	}
-	return len(ts.Sidecars) > 0
+	return c.sidecarMode.useTektonNop, nil
 }
 
 func (c *Reconciler) stopSidecars(ctx context.Context, tr *v1.TaskRun) error {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tektoncd/pipeline/internal/sidecarlogresults"
@@ -93,6 +94,16 @@ type Reconciler struct {
 	pvcHandler               volumeclaim.PvcHandler
 	resolutionRequester      resolution.Requester
 	tracerProvider           trace.TracerProvider
+
+	// sidecarMode caches ServerVersion + IsNativeSidecarSupport when EnableKubernetesSidecar
+	// is true, so the done path does not call Discovery on every resync (#9755).
+	// Status.Sidecars cannot be used to skip stopSidecars: injected containers (e.g. Istio)
+	// are not listed there but buildSidecarStopPatch stops them using the live Pod.
+	sidecarMode struct {
+		sync.Mutex
+		computed     bool
+		useTektonNop bool // if true, run stopSidecars; if false, native Kubernetes sidecars
+	}
 }
 
 const (
@@ -156,17 +167,13 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	if tr.IsDone() {
 		logger.Infof("taskrun done : %s \n", tr.Name)
 
-		useTektonSidecar := true
-		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
-			dc := c.KubeClientSet.Discovery()
-			sv, err := dc.ServerVersion()
-			if err != nil {
-				return err
-			}
-			if podconvert.IsNativeSidecarSupport(sv) {
-				useTektonSidecar = false
-				logger.Infof("Using Kubernetes Native Sidecars \n")
-			}
+		// stopSidecars must run whenever we use Tekton-managed sidecars: TaskRun status only
+		// lists containers with the sidecar- prefix; injected sidecars are visible only on
+		// the Pod (see buildSidecarStopPatch). Cache ServerVersion + native-sidecar detection
+		// so we do not call Discovery on every resync (#9755).
+		useTektonSidecar, err := c.useTektonSidecarMode(ctx, logger)
+		if err != nil {
+			return err
 		}
 		if useTektonSidecar {
 			if err := c.stopSidecars(ctx, tr); err != nil {
@@ -367,6 +374,31 @@ func (c *Reconciler) durationAndCountMetrics(ctx context.Context, tr *v1.TaskRun
 			logger.Warnf("Failed to log the duration and count of taskruns : %v", err)
 		}
 	}
+}
+
+// useTektonSidecarMode returns whether the done path should run stopSidecars (Tekton nop
+// image) vs skipping it for native Kubernetes sidecars. ServerVersion is queried at most once
+// per reconciler when EnableKubernetesSidecar is true.
+func (c *Reconciler) useTektonSidecarMode(ctx context.Context, logger *zap.SugaredLogger) (bool, error) {
+	if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
+		return true, nil
+	}
+	c.sidecarMode.Lock()
+	defer c.sidecarMode.Unlock()
+	if c.sidecarMode.computed {
+		return c.sidecarMode.useTektonNop, nil
+	}
+	sv, err := c.KubeClientSet.Discovery().ServerVersion()
+	if err != nil {
+		return false, err
+	}
+	native := podconvert.IsNativeSidecarSupport(sv)
+	c.sidecarMode.useTektonNop = !native
+	c.sidecarMode.computed = true
+	if native {
+		logger.Infof("Using Kubernetes Native Sidecars \n")
+	}
+	return c.sidecarMode.useTektonNop, nil
 }
 
 func (c *Reconciler) stopSidecars(ctx context.Context, tr *v1.TaskRun) error {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -6059,6 +6059,178 @@ status:
 	}
 }
 
+func TestReconcile_DoneTaskRun_SkipsStopSidecarsWithoutRunningSidecarsInStatus(t *testing.T) {
+	tcs := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "no sidecars in status",
+			yaml: `
+metadata:
+  name: test-taskrun
+  namespace: foo
+status:
+  conditions:
+  - status: "True"
+    type: Succeeded
+  podName: test-taskrun-pod
+  startTime: "2000-01-01T01:01:01Z"
+  taskSpec:
+    steps:
+    - name: step1
+      image: busybox
+`,
+		},
+		{
+			name: "all sidecars terminated",
+			yaml: `
+metadata:
+  name: test-taskrun
+  namespace: foo
+status:
+  conditions:
+  - status: "True"
+    type: Succeeded
+  podName: test-taskrun-pod
+  sidecars:
+  - name: sidecar1
+    terminated:
+      exitCode: 0
+      finishedAt: "2000-01-01T02:00:00Z"
+      reason: Completed
+      startedAt: "2000-01-01T01:01:01Z"
+  startTime: "2000-01-01T01:01:01Z"
+`,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := parse.MustParseV1TaskRun(t, tc.yaml)
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-taskrun-pod",
+					Namespace: "foo",
+				},
+			}
+			d := test.Data{
+				Pods:     []*corev1.Pod{pod},
+				TaskRuns: []*v1.TaskRun{tr},
+			}
+			testAssets, cancel := getTaskRunController(t, d)
+			defer cancel()
+			c := testAssets.Controller
+			clients := testAssets.Clients
+			if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); err != nil {
+				t.Fatalf("Reconcile: %v", err)
+			}
+			for _, action := range clients.Kube.Actions() {
+				if action.Matches("get", "pods") {
+					t.Fatalf("expected no pods get when sidecars are absent or all terminated, got action %#v", action)
+				}
+			}
+		})
+	}
+}
+
+func TestTaskRunNeedsSidecarDonePath(t *testing.T) {
+	tcs := []struct {
+		name string
+		tr   *v1.TaskRun
+		want bool
+	}{
+		{
+			name: "sidecar still running in status",
+			tr: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Sidecars: []v1.SidecarState{{
+							ContainerState: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{},
+							},
+							Name: "sc",
+						}},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "all sidecars terminated in status",
+			tr: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Sidecars: []v1.SidecarState{{
+							ContainerState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+							},
+							Name: "sc",
+						}},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty sidecar status and no task spec",
+			tr: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "empty sidecar status task has no sidecars",
+			tr: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						TaskSpec: &v1.TaskSpec{
+							Steps: []v1.Step{{Name: "s", Image: "img"}},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty sidecar status task declares sidecars",
+			tr: &v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						TaskSpec: &v1.TaskSpec{
+							Steps:    []v1.Step{{Name: "s", Image: "img"}},
+							Sidecars: []v1.Sidecar{{Name: "sc", Image: "img"}},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "empty sidecar status uses spec.taskSpec for inline task",
+			tr: &v1.TaskRun{
+				Spec: v1.TaskRunSpec{
+					TaskSpec: &v1.TaskSpec{
+						Steps: []v1.Step{{Name: "s", Image: "img"}},
+					},
+				},
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := taskRunNeedsSidecarDonePath(tc.tr); got != tc.want {
+				t.Fatalf("taskRunNeedsSidecarDonePath() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestStopSidecars_WithInjectedSidecarsNoTaskSpecSidecars(t *testing.T) {
 	sidecarTask := &v1.Task{
 		ObjectMeta: objectMeta("test-task-injected-sidecar", "foo"),

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -6038,6 +6038,111 @@ status:
 	}
 }
 
+// TestStopSidecars_DeclaredSidecarTerminatedInStatusButInjectedStillRuns covers the case where
+// TaskRun.Status.Sidecars only reflects sidecar- prefixed containers; a non-prefixed injected
+// sidecar can still be running on the Pod and must be stopped via the live Pod (see #9760 review).
+func TestStopSidecars_DeclaredSidecarTerminatedInStatusButInjectedStillRuns(t *testing.T) {
+	sidecarTask := &v1.Task{
+		ObjectMeta: objectMeta("test-task-injected-terminated-status", "foo"),
+		Spec: v1.TaskSpec{
+			Steps: []v1.Step{simpleStep},
+			Sidecars: []v1.Sidecar{{
+				Name:  "sidecar1",
+				Image: "image-id",
+			}},
+		},
+	}
+
+	taskRun := parse.MustParseV1TaskRun(t, `
+metadata:
+  name: test-taskrun-injected-terminated-status
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task-injected-terminated-status
+status:
+  podName: test-taskrun-injected-terminated-status-pod
+  conditions:
+  - message: Build succeeded
+    reason: Build succeeded
+    status: "True"
+    type: Succeeded
+  sidecars:
+  - name: sidecar1
+    container: sidecar-sidecar1
+    terminated:
+      exitCode: 0
+      finishedAt: "2000-01-01T02:00:00Z"
+      reason: Completed
+      startedAt: "2000-01-01T01:01:01Z"
+`)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-taskrun-injected-terminated-status-pod",
+			Namespace: "foo",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "step-do-something", Image: "my-step-image"},
+				{Name: "sidecar1", Image: "image-id"},
+				{Name: "injected-sidecar", Image: "some-image"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "step-do-something",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+				},
+				{
+					Name:  "sidecar-sidecar1",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}},
+				},
+				{
+					Name:  "injected-sidecar",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+			},
+		},
+	}
+
+	d := test.Data{
+		Pods:     []*corev1.Pod{pod},
+		TaskRuns: []*v1.TaskRun{taskRun},
+		Tasks:    []*v1.Task{sidecarTask},
+	}
+
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(taskRun)); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	getPodFound := false
+	for _, action := range clients.Kube.Actions() {
+		if action.Matches("get", "pods") {
+			getPodFound = true
+			break
+		}
+	}
+	if !getPodFound {
+		t.Fatalf("expected Pods().Get to stop a still-running injected sidecar not listed in TaskRun status")
+	}
+
+	retrievedPod, err := clients.Kube.CoreV1().Pods(pod.Namespace).Get(testAssets.Ctx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get pod: %v", err)
+	}
+	if d := cmp.Diff(images.NopImage, retrievedPod.Spec.Containers[2].Image); d != "" {
+		t.Errorf("expected injected sidecar image replaced with nop %s", diff.PrintWantGot(d))
+	}
+}
+
 func TestStopSidecars_WithInjectedSidecarsNoTaskSpecSidecars(t *testing.T) {
 	sidecarTask := &v1.Task{
 		ObjectMeta: objectMeta("test-task-injected-sidecar", "foo"),

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -6059,175 +6059,108 @@ status:
 	}
 }
 
-func TestReconcile_DoneTaskRun_SkipsStopSidecarsWithoutRunningSidecarsInStatus(t *testing.T) {
-	tcs := []struct {
-		name string
-		yaml string
-	}{
-		{
-			name: "no sidecars in status",
-			yaml: `
-metadata:
-  name: test-taskrun
-  namespace: foo
-status:
-  conditions:
-  - status: "True"
-    type: Succeeded
-  podName: test-taskrun-pod
-  startTime: "2000-01-01T01:01:01Z"
-  taskSpec:
-    steps:
-    - name: step1
-      image: busybox
-`,
+// TestStopSidecars_DeclaredSidecarTerminatedInStatusButInjectedStillRuns covers the case where
+// TaskRun.Status.Sidecars only reflects sidecar- prefixed containers; a non-prefixed injected
+// sidecar can still be running on the Pod and must be stopped via the live Pod (see #9760 review).
+func TestStopSidecars_DeclaredSidecarTerminatedInStatusButInjectedStillRuns(t *testing.T) {
+	sidecarTask := &v1.Task{
+		ObjectMeta: objectMeta("test-task-injected-terminated-status", "foo"),
+		Spec: v1.TaskSpec{
+			Steps: []v1.Step{simpleStep},
+			Sidecars: []v1.Sidecar{{
+				Name:  "sidecar1",
+				Image: "image-id",
+			}},
 		},
-		{
-			name: "all sidecars terminated",
-			yaml: `
+	}
+
+	taskRun := parse.MustParseV1TaskRun(t, `
 metadata:
-  name: test-taskrun
+  name: test-taskrun-injected-terminated-status
   namespace: foo
+spec:
+  taskRef:
+    name: test-task-injected-terminated-status
 status:
+  podName: test-taskrun-injected-terminated-status-pod
   conditions:
-  - status: "True"
+  - message: Build succeeded
+    reason: Build succeeded
+    status: "True"
     type: Succeeded
-  podName: test-taskrun-pod
   sidecars:
   - name: sidecar1
+    container: sidecar-sidecar1
     terminated:
       exitCode: 0
       finishedAt: "2000-01-01T02:00:00Z"
       reason: Completed
       startedAt: "2000-01-01T01:01:01Z"
-  startTime: "2000-01-01T01:01:01Z"
-`,
-		},
-	}
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			tr := parse.MustParseV1TaskRun(t, tc.yaml)
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-taskrun-pod",
-					Namespace: "foo",
-				},
-			}
-			d := test.Data{
-				Pods:     []*corev1.Pod{pod},
-				TaskRuns: []*v1.TaskRun{tr},
-			}
-			testAssets, cancel := getTaskRunController(t, d)
-			defer cancel()
-			c := testAssets.Controller
-			clients := testAssets.Clients
-			if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr)); err != nil {
-				t.Fatalf("Reconcile: %v", err)
-			}
-			for _, action := range clients.Kube.Actions() {
-				if action.Matches("get", "pods") {
-					t.Fatalf("expected no pods get when sidecars are absent or all terminated, got action %#v", action)
-				}
-			}
-		})
-	}
-}
+`)
 
-func TestTaskRunNeedsSidecarDonePath(t *testing.T) {
-	tcs := []struct {
-		name string
-		tr   *v1.TaskRun
-		want bool
-	}{
-		{
-			name: "sidecar still running in status",
-			tr: &v1.TaskRun{
-				Status: v1.TaskRunStatus{
-					TaskRunStatusFields: v1.TaskRunStatusFields{
-						Sidecars: []v1.SidecarState{{
-							ContainerState: corev1.ContainerState{
-								Running: &corev1.ContainerStateRunning{},
-							},
-							Name: "sc",
-						}},
-					},
-				},
-			},
-			want: true,
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-taskrun-injected-terminated-status-pod",
+			Namespace: "foo",
 		},
-		{
-			name: "all sidecars terminated in status",
-			tr: &v1.TaskRun{
-				Status: v1.TaskRunStatus{
-					TaskRunStatusFields: v1.TaskRunStatusFields{
-						Sidecars: []v1.SidecarState{{
-							ContainerState: corev1.ContainerState{
-								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
-							},
-							Name: "sc",
-						}},
-					},
-				},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "step-do-something", Image: "my-step-image"},
+				{Name: "sidecar1", Image: "image-id"},
+				{Name: "injected-sidecar", Image: "some-image"},
 			},
-			want: false,
 		},
-		{
-			name: "empty sidecar status and no task spec",
-			tr: &v1.TaskRun{
-				Status: v1.TaskRunStatus{
-					TaskRunStatusFields: v1.TaskRunStatusFields{},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "step-do-something",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+				},
+				{
+					Name:  "sidecar-sidecar1",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}},
+				},
+				{
+					Name:  "injected-sidecar",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				},
 			},
-			want: true,
-		},
-		{
-			name: "empty sidecar status task has no sidecars",
-			tr: &v1.TaskRun{
-				Status: v1.TaskRunStatus{
-					TaskRunStatusFields: v1.TaskRunStatusFields{
-						TaskSpec: &v1.TaskSpec{
-							Steps: []v1.Step{{Name: "s", Image: "img"}},
-						},
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "empty sidecar status task declares sidecars",
-			tr: &v1.TaskRun{
-				Status: v1.TaskRunStatus{
-					TaskRunStatusFields: v1.TaskRunStatusFields{
-						TaskSpec: &v1.TaskSpec{
-							Steps:    []v1.Step{{Name: "s", Image: "img"}},
-							Sidecars: []v1.Sidecar{{Name: "sc", Image: "img"}},
-						},
-					},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "empty sidecar status uses spec.taskSpec for inline task",
-			tr: &v1.TaskRun{
-				Spec: v1.TaskRunSpec{
-					TaskSpec: &v1.TaskSpec{
-						Steps: []v1.Step{{Name: "s", Image: "img"}},
-					},
-				},
-				Status: v1.TaskRunStatus{
-					TaskRunStatusFields: v1.TaskRunStatusFields{},
-				},
-			},
-			want: false,
 		},
 	}
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := taskRunNeedsSidecarDonePath(tc.tr); got != tc.want {
-				t.Fatalf("taskRunNeedsSidecarDonePath() = %v, want %v", got, tc.want)
-			}
-		})
+
+	d := test.Data{
+		Pods:     []*corev1.Pod{pod},
+		TaskRuns: []*v1.TaskRun{taskRun},
+		Tasks:    []*v1.Task{sidecarTask},
+	}
+
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(taskRun)); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	getPodFound := false
+	for _, action := range clients.Kube.Actions() {
+		if action.Matches("get", "pods") {
+			getPodFound = true
+			break
+		}
+	}
+	if !getPodFound {
+		t.Fatalf("expected Pods().Get to stop a still-running injected sidecar not listed in TaskRun status")
+	}
+
+	retrievedPod, err := clients.Kube.CoreV1().Pods(pod.Namespace).Get(testAssets.Ctx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get pod: %v", err)
+	}
+	if d := cmp.Diff(images.NopImage, retrievedPod.Spec.Containers[2].Image); d != "" {
+		t.Errorf("expected injected sidecar image replaced with nop %s", diff.PrintWantGot(d))
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes [#9755](https://github.com/tektoncd/pipeline/issues/9755).

Finished TaskRuns were still paying Discovery().ServerVersion() (with EnableKubernetesSidecar) and stopSidecars → Pods().Get on every resync.

Cache native-sidecar detection (ServerVersion + support check) per reconciler so discovery is not repeated on resync.
Do not skip stopSidecars from Status.Sidecars alone—injected/non-sidecar- containers are not in that status; live pod inspection stays required.
Test: TestStopSidecars_DeclaredSidecarTerminatedInStatusButInjectedStillRuns.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
