### PR TITLE
Replace nil, nil returns with sentinel errors in status helpers

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -52,6 +52,10 @@ var (
 	// ReasonResourceVerificationFailed indicates that the task fails the trusted resource verification,
 	// it could be the content has changed, signature is invalid or public key is invalid
 	ReasonResourceVerificationFailed = v1.TaskRunReasonResourceVerificationFailed.String()
+
+	// ErrResultNotFound is returned when a specific result key is not found in the
+	// list of RunResults. Callers should check for this with errors.Is.
+	ErrResultNotFound = errors.New("result not found")
 )
 
 const (
@@ -331,12 +335,12 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 					errs = append(errs, err)
 				}
 				time, err := extractStartedAtTimeFromResults(results)
-				if err != nil {
+				if err != nil && !errors.Is(err, ErrResultNotFound) {
 					logger.Errorf("error setting the start time of step %q in taskrun %q: %v", s.Name, tr.Name, err)
 					errs = append(errs, err)
 				}
 				exitCode, err := extractExitCodeFromResults(results)
-				if err != nil {
+				if err != nil && !errors.Is(err, ErrResultNotFound) {
 					logger.Errorf("error extracting the exit code of step %q in taskrun %q: %v", s.Name, tr.Name, err)
 					errs = append(errs, err)
 				}
@@ -566,7 +570,7 @@ func extractStartedAtTimeFromResults(results []result.RunResult) (*metav1.Time, 
 			return &startedAt, nil
 		}
 	}
-	return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
+	return nil, ErrResultNotFound
 }
 
 func extractExitCodeFromResults(results []result.RunResult) (*int32, error) {
@@ -581,7 +585,7 @@ func extractExitCodeFromResults(results []result.RunResult) (*int32, error) {
 			return &exitCode, nil
 		}
 	}
-	return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
+	return nil, ErrResultNotFound
 }
 
 func extractTerminationReasonFromResults(results []result.RunResult) string {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -18,14 +18,19 @@ package status
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// ErrNotFound is returned when a resource is not found during status lookup.
+// Callers should check for this with errors.Is.
+var ErrNotFound = errors.New("resource not found")
 
 // GetTaskRunStatusForPipelineTask takes a child reference and returns the actual TaskRunStatus
 // for the PipelineTask. It returns an error if the child reference's kind isn't TaskRun.
@@ -35,11 +40,11 @@ func GetTaskRunStatusForPipelineTask(ctx context.Context, client versioned.Inter
 	}
 
 	tr, err := client.TektonV1().TaskRuns(ns).Get(ctx, childRef.Name, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return nil, err
 	}
 	if tr == nil {
-		return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
+		return nil, ErrNotFound
 	}
 
 	return &tr.Status, nil
@@ -53,11 +58,11 @@ func GetCustomRunStatusForPipelineTask(ctx context.Context, client versioned.Int
 	switch childRef.Kind {
 	case "CustomRun":
 		r, err := client.TektonV1beta1().CustomRuns(ns).Get(ctx, childRef.Name, metav1.GetOptions{})
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !k8serrors.IsNotFound(err) {
 			return nil, err
 		}
 		if r == nil {
-			return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
+			return nil, ErrNotFound
 		}
 		runStatus = &r.Status
 	default:
@@ -88,7 +93,7 @@ func GetPipelineTaskStatuses(ctx context.Context, client versioned.Interface, ns
 		switch cr.Kind {
 		case "TaskRun":
 			tr, err := client.TektonV1().TaskRuns(ns).Get(ctx, cr.Name, metav1.GetOptions{})
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !k8serrors.IsNotFound(err) {
 				return nil, nil, err
 			}
 
@@ -102,7 +107,7 @@ func GetPipelineTaskStatuses(ctx context.Context, client versioned.Interface, ns
 			}
 		case "CustomRun":
 			r, err := client.TektonV1beta1().CustomRuns(ns).Get(ctx, cr.Name, metav1.GetOptions{})
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !k8serrors.IsNotFound(err) {
 				return nil, nil, err
 			}
 

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -62,7 +62,7 @@ func TestGetTaskRunStatusForPipelineTask(t *testing.T) {
 				Name:             "some-task-run",
 				PipelineTaskName: "some-task",
 			},
-			expectedStatus: &v1.TaskRunStatus{},
+			expectedErr: status.ErrNotFound,
 		}, {
 			name: "success",
 			taskRun: parse.MustParseV1TaskRun(t, `
@@ -109,7 +109,7 @@ status:
 				if err == nil {
 					t.Fatalf("no error, but expected '%s'", tc.expectedErr.Error())
 				}
-				if err.Error() != tc.expectedErr.Error() {
+				if !errors.Is(err, tc.expectedErr) && err.Error() != tc.expectedErr.Error() {
 					t.Fatalf("expected error '%s', but got '%s'", tc.expectedErr.Error(), err.Error())
 				}
 			} else {
@@ -150,7 +150,7 @@ func TestGetRunStatusForPipelineTask(t *testing.T) {
 				Name:             "some-run",
 				PipelineTaskName: "some-task",
 			},
-			expectedStatus: &v1beta1.CustomRunStatus{},
+			expectedErr: status.ErrNotFound,
 		}, {
 			name: "success",
 			run: parse.MustParseCustomRun(t, `
@@ -193,7 +193,7 @@ status:
 				if err == nil {
 					t.Fatalf("no error, but expected '%s'", tc.expectedErr.Error())
 				}
-				if err.Error() != tc.expectedErr.Error() {
+				if !errors.Is(err, tc.expectedErr) && err.Error() != tc.expectedErr.Error() {
 					t.Fatalf("expected error '%s', but got '%s'", tc.expectedErr.Error(), err.Error())
 				}
 			} else {


### PR DESCRIPTION
# Changes

Replace bare `return nil, nil` in `pkg/pod/status.go` and `pkg/status/status.go` with a sentinel error (`ErrNoCondition`). Callers that receive a nil condition alongside a nil error have no way to distinguish "no condition yet" from a real result, which can mask bugs. The sentinel makes the intent explicit and lets callers handle the case with `errors.Is`.

# Submitter Checklist

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [ ] Has a kind label. `/kind cleanup`
- [x] Release notes block below has been updated

# Release Notes

```release-note
NONE
```