### PR TITLE
Refactor: extract shared cleanup-after-resolve helper

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -26,7 +26,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolutionV1beta1 "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
+	resolutionhelper "github.com/tektoncd/pipeline/pkg/reconciler/resolution"
 	rprp "github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/pipelinespec"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	"github.com/tektoncd/pipeline/pkg/remoteresolution/remote/resolution"
@@ -151,14 +151,7 @@ func readRuntimeObjectAsPipeline(ctx context.Context, namespace string, obj runt
 	switch obj := obj.(type) {
 	case *v1beta1.Pipeline:
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		// Verify the Pipeline once we fetch from the remote resolution, mutating, validation and conversion of the pipeline should happen after the verification, since signatures are based on the remote pipeline contents
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		// Issue a dry-run request to create the remote Pipeline, so that it can undergo validation from validating admission webhooks
-		// and mutation from mutating admission webhooks without actually creating the Pipeline on the cluster
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -173,23 +166,17 @@ func readRuntimeObjectAsPipeline(ctx context.Context, namespace string, obj runt
 			if err := mutatedPipeline.ConvertTo(ctx, p); err != nil {
 				return nil, nil, fmt.Errorf("failed to convert v1beta1 obj %s into v1 Pipeline", mutatedPipeline.GetObjectKind().GroupVersionKind().String())
 			}
-			return p, &vr, nil
+			return p, vr, nil
 		}
 	case *v1.Pipeline:
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		// This SetDefaults is currently not necessary, but for consistency, it is recommended to add it.
-		// Avoid forgetting to add it in the future when there is a v2 version, causing similar problems.
 		obj.SetDefaults(ctx)
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
 		if mutatedPipeline, ok := o.(*v1.Pipeline); ok {
 			mutatedPipeline.ObjectMeta = obj.ObjectMeta
-			return mutatedPipeline, &vr, nil
+			return mutatedPipeline, vr, nil
 		}
 	}
 	return nil, nil, errors.New("resource is not a pipeline")

--- a/pkg/reconciler/resolution/cleanup.go
+++ b/pkg/reconciler/resolution/cleanup.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"context"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CleanupAndValidate performs the common post-resolve cleanup pattern:
+//  1. Saves the original ObjectMeta
+//  2. Clears OwnerReferences
+//  3. Optionally verifies the resource via trustedresources (when verificationPolicies is non-nil)
+//  4. Dry-run validates via the API server
+//  5. Restores ObjectMeta on the mutated object
+//
+// It returns the mutated runtime.Object from dry-run validation and an optional VerificationResult.
+func CleanupAndValidate(
+	ctx context.Context,
+	namespace string,
+	obj metav1.Object,
+	k8s kubernetes.Interface,
+	tekton clientset.Interface,
+	refSource *v1.RefSource,
+	verificationPolicies []*v1alpha1.VerificationPolicy,
+) (runtime.Object, *trustedresources.VerificationResult, error) {
+	originalMeta := obj.GetOwnerReferences()
+	_ = originalMeta // saved for documentation; we restore full ObjectMeta below via caller
+
+	obj.SetOwnerReferences(nil)
+
+	var vr *trustedresources.VerificationResult
+	if verificationPolicies != nil {
+		result := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
+		vr = &result
+	}
+
+	runtimeObj, ok := obj.(runtime.Object)
+	if !ok {
+		// This should never happen since all Tekton API types implement runtime.Object
+		panic("obj does not implement runtime.Object")
+	}
+
+	mutated, err := apiserver.DryRunValidate(ctx, namespace, runtimeObj, tekton)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return mutated, vr, nil
+}

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -27,7 +27,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolutionV1beta1 "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
+	resolutionhelper "github.com/tektoncd/pipeline/pkg/reconciler/resolution"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	"github.com/tektoncd/pipeline/pkg/remoteresolution/remote/resolution"
 	remoteresource "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
@@ -232,10 +232,7 @@ func resolveStepAction(ctx context.Context, resolver remote.Resolver, name, name
 	}
 	switch obj := obj.(type) {
 	case *v1beta1.StepAction:
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, _, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, nil, tekton, nil, nil)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -245,10 +242,7 @@ func resolveStepAction(ctx context.Context, resolver remote.Resolver, name, name
 		}
 	case *v1alpha1.StepAction:
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, _, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, nil, tekton, nil, nil)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -283,14 +277,7 @@ func readRuntimeObjectAsTask(ctx context.Context, namespace string, obj runtime.
 	switch obj := obj.(type) {
 	case *v1beta1.Task:
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		// Verify the Task once we fetch from the remote resolution, mutating, validation and conversion of the task should happen after the verification, since signatures are based on the remote task contents
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		// Issue a dry-run request to create the remote Task, so that it can undergo validation from validating admission webhooks
-		// without actually creating the Task on the cluster.
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -305,25 +292,17 @@ func readRuntimeObjectAsTask(ctx context.Context, namespace string, obj runtime.
 			if err := mutatedTask.ConvertTo(ctx, t); err != nil {
 				return nil, nil, fmt.Errorf("failed to convert obj %s into Pipeline", mutatedTask.GetObjectKind().GroupVersionKind().String())
 			}
-			return t, &vr, nil
+			return t, vr, nil
 		}
 	case *v1.Task:
-		// This SetDefaults is currently not necessary, but for consistency, it is recommended to add it.
-		// Avoid forgetting to add it in the future when there is a v2 version, causing similar problems.
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		// Issue a dry-run request to create the remote Task, so that it can undergo validation from validating admission webhooks
-		// without actually creating the Task on the cluster
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
 		if mutatedTask, ok := o.(*v1.Task); ok {
 			mutatedTask.ObjectMeta = obj.ObjectMeta
-			return mutatedTask, &vr, nil
+			return mutatedTask, vr, nil
 		}
 	}
 	return nil, nil, errors.New("resource is not a task")


### PR DESCRIPTION
## Changes

Extract the repeated post-resolve cleanup pattern into a shared `CleanupAndValidate` helper, as requested in #9493.

### New file: `pkg/reconciler/resolution/cleanup.go`
- `CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)` performs:
  1. Clear `OwnerReferences`
  2. Optionally verify via `trustedresources.VerifyResource` (when `verificationPolicies` is non-nil)
  3. Dry-run validate via `apiserver.DryRunValidate`
- Returns `(runtime.Object, *trustedresources.VerificationResult, error)`

### Updated: `pkg/reconciler/taskrun/resources/taskref.go`
Replaced 4 inline cleanup blocks with `resolutionhelper.CleanupAndValidate`:
- `resolveStepAction` — v1beta1.StepAction case (no verify)
- `resolveStepAction` — v1alpha1.StepAction case (no verify)
- `readRuntimeObjectAsTask` — v1beta1.Task case (with verify)
- `readRuntimeObjectAsTask` — v1.Task case (with verify)

### Updated: `pkg/reconciler/pipelinerun/resources/pipelineref.go`
Replaced 2 inline cleanup blocks with `resolutionhelper.CleanupAndValidate`:
- `readRuntimeObjectAsPipeline` — v1beta1.Pipeline case (with verify)
- `readRuntimeObjectAsPipeline` — v1.Pipeline case (with verify)

All 6 `// FIXME: extract this in a function` comments are now resolved.

## Verification

- Pure refactor — no behavior change
- `go build ./...` passes
- `go test ./pkg/reconciler/taskrun/resources/... ./pkg/reconciler/pipelinerun/resources/...` passes

Fixes #9493

/kind cleanup