### PR TITLE
perf: strip ManagedFields from PipelineRun, TaskRun, and Pod informer caches

### DIFF
--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -31,6 +31,7 @@ import (
 	resolutionclient "github.com/tektoncd/pipeline/pkg/client/resolution/injection/client"
 	resolutioninformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	"github.com/tektoncd/pipeline/pkg/pipelinerunmetrics"
+	tektonreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
 	cloudeventclient "github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	resolution "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
@@ -104,6 +105,14 @@ func NewController(opts *pipeline.Options, clock clock.PassiveClock) func(contex
 				PromoteFilterFunc: pipelineRunFilterManagedBy,
 			}
 		})
+
+		// Strip managedFields from cached objects to reduce memory footprint and DeepCopy cost.
+		if err := pipelineRunInformer.Informer().SetTransform(tektonreconciler.StripManagedFields); err != nil {
+			logging.FromContext(ctx).Panicf("Failed to set PipelineRun informer transform: %w", err)
+		}
+		if err := taskRunInformer.Informer().SetTransform(tektonreconciler.StripManagedFields); err != nil {
+			logging.FromContext(ctx).Panicf("Failed to set TaskRun informer transform: %w", err)
+		}
 
 		if _, err := secretinformer.Informer().AddEventHandler(controller.HandleAll(tracerProvider.Handler)); err != nil {
 			logging.FromContext(ctx).Panicf("Couldn't register Secret informer event handler: %w", err)

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -29,6 +29,7 @@ import (
 	resolutionclient "github.com/tektoncd/pipeline/pkg/client/resolution/injection/client"
 	resolutioninformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	"github.com/tektoncd/pipeline/pkg/pod"
+	tektonreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
 	cloudeventclient "github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	resolution "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
@@ -115,6 +116,14 @@ func NewController(opts *pipeline.Options, clock clock.PassiveClock) func(contex
 				PromoteFilterFunc: taskRunFilterManagedBy,
 			}
 		})
+
+		// Strip managedFields from cached objects to reduce memory footprint and DeepCopy cost.
+		if err := taskRunInformer.Informer().SetTransform(tektonreconciler.StripManagedFields); err != nil {
+			logging.FromContext(ctx).Panicf("Failed to set TaskRun informer transform: %w", err)
+		}
+		if err := podInformer.Informer().SetTransform(tektonreconciler.StripManagedFields); err != nil {
+			logging.FromContext(ctx).Panicf("Failed to set Pod informer transform: %w", err)
+		}
 
 		if _, err := secretinformer.Informer().AddEventHandler(controller.HandleAll(tracerProvider.Handler)); err != nil {
 			logging.FromContext(ctx).Panicf("Couldn't register Secret informer event handler: %w", err)

--- a/pkg/reconciler/transform.go
+++ b/pkg/reconciler/transform.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// StripManagedFields is a shared informer cache transform that removes
+// metadata.managedFields from objects before they are stored in the cache.
+//
+// ManagedFields can be 30-70% of an object's serialized size. The Tekton
+// controller never reads them, but every DeepCopy during reconciliation
+// copies them in full. Stripping them reduces both memory footprint and
+// CPU time spent on DeepCopy operations.
+func StripManagedFields(obj interface{}) (interface{}, error) {
+	if accessor, ok := obj.(metav1.ObjectMetaAccessor); ok {
+		accessor.GetObjectMeta().SetManagedFields(nil)
+	}
+	return obj, nil
+}

--- a/pkg/reconciler/transform_test.go
+++ b/pkg/reconciler/transform_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestStripManagedFields(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  interface{}
+	}{
+		{
+			name: "strips managedFields from Pod",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Labels:    map[string]string{"app": "test"},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply},
+						{Manager: "kubelet", Operation: metav1.ManagedFieldsOperationUpdate},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := StripManagedFields(tt.obj)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			accessor, ok := result.(metav1.ObjectMetaAccessor)
+			if !ok {
+				t.Fatal("result does not implement ObjectMetaAccessor")
+			}
+
+			meta := accessor.GetObjectMeta()
+			if meta.GetManagedFields() != nil {
+				t.Error("managedFields should be nil after transform")
+			}
+			if meta.GetName() != "test-pod" {
+				t.Errorf("name should be preserved, got %q", meta.GetName())
+			}
+			if meta.GetNamespace() != "default" {
+				t.Errorf("namespace should be preserved, got %q", meta.GetNamespace())
+			}
+			if meta.GetLabels()["app"] != "test" {
+				t.Error("labels should be preserved")
+			}
+		})
+	}
+}
+
+func TestStripManagedFieldsNonAccessor(t *testing.T) {
+	input := "not-a-kubernetes-object"
+	result, err := StripManagedFields(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != input {
+		t.Error("non-accessor objects should pass through unchanged")
+	}
+}


### PR DESCRIPTION
## Changes

Add `SetTransform` to strip `metadata.managedFields` from PipelineRun, TaskRun, and Pod informer caches, reducing memory and DeepCopy overhead.

### New files

**`pkg/reconciler/transform.go`**
- Shared `StripManagedFields` transform function — clears `managedFields` via `ObjectMetaAccessor`, passes non-accessor objects through unchanged

**`pkg/reconciler/transform_test.go`**
- Verifies managedFields are stripped while other metadata (name, namespace, labels) is preserved
- Verifies non-accessor objects pass through unchanged

### Updated controllers

**`pkg/reconciler/pipelinerun/controller.go`**
- Applies `StripManagedFields` to PipelineRun and TaskRun informers
- Uses `Panicf` on failure (consistent with all other init errors in this function)

**`pkg/reconciler/taskrun/controller.go`**
- Applies `StripManagedFields` to TaskRun and Pod informers
- TaskRun transform is set from both controllers for self-containment (SetTransform overwrites, so calling it twice with the same function is harmless)
- Pod informer included — Pods are the fattest cached objects (3-5 field managers vs 1-2 for TaskRuns/PipelineRuns)

### Addressed review feedback from #9590

This implementation incorporates all review feedback from @waveywaves and @vdemeester on #9590:
- [x] Shared function in `pkg/reconciler/transform.go` (no copy-paste between controllers)
- [x] `Panicf` instead of `Warnf` (consistent with other init errors)
- [x] Pod informer also transformed (biggest memory savings)
- [x] TaskRun transform set from both controllers (self-contained)
- [x] Unit tests for the transform function

Fixes #9573

```release-note
NONE
```