### PR TITLE
Warn on unanchored VerificationPolicy resource patterns

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
@@ -90,13 +90,27 @@ func (key *KeyRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs
 }
 
-// Validate ResourcePattern and make sure the Pattern is valid regex expression
+// Validate ResourcePattern and make sure the Pattern is valid regex expression.
+// Patterns that are not anchored with ^ and $ are flagged with a warning because
+// unanchored patterns can match unintended substrings in resource URIs, which
+// could allow an attacker to craft a URI that contains the trusted pattern as a
+// substring.
 func (r *ResourcePattern) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if _, err := regexp.Compile(r.Pattern); err != nil {
 		errs = errs.Also(apis.ErrInvalidValue(r.Pattern, "ResourcePattern", fmt.Sprintf("%v: %v", InvalidResourcePatternErr, err)))
 		return errs
 	}
-	return nil
+
+	if !strings.HasPrefix(r.Pattern, "^") || !strings.HasSuffix(r.Pattern, "$") {
+		errs = errs.Also(apis.ErrGeneric(
+			fmt.Sprintf("resource pattern %q is not anchored with ^ and $; "+
+				"unanchored patterns may match unintended resource URIs — "+
+				"consider using ^%s$ to match the full URI", r.Pattern, r.Pattern),
+			"pattern",
+		))
+	}
+
+	return errs
 }
 
 // validateHashAlgorithm checks if the algorithm is supported


### PR DESCRIPTION
Fixes #9737.

`ResourcePattern.Validate` now emits a validation error when the regex pattern is not anchored with `^` and `$`. Unanchored patterns use `regexp.MatchString` which matches substrings, meaning a pattern like `github.com/trusted-org/` would also match `github.com/attacker/evil?ref=github.com/trusted-org/`.

The error message includes a suggestion to add the anchors:
```
resource pattern "github.com/trusted-org/" is not anchored with ^ and $;
unanchored patterns may match unintended resource URIs —
consider using ^github.com/trusted-org/$ to match the full URI
```

This is a breaking change for existing unanchored patterns that pass validation today. Users would need to update their patterns to either add `^...$` anchors or wrap in `.*pattern.*` if they intentionally want substring matching.

```release-notes
VerificationPolicy now validates that resource patterns are anchored with ^ and $ to prevent unintended substring matching in trusted resource URIs
```