### PR TITLE
docs: add bundle resolver configuration options default values

### DIFF
--- a/docs/bundle-resolver.md
+++ b/docs/bundle-resolver.md
@@ -37,14 +37,16 @@ for the name, namespace and defaults that the resolver ships with.
 
 ### Options
 
-| Option Name          | Description                                                       | Example Values        |
-|----------------------|-------------------------------------------------------------------|-----------------------|
-| `backoff-duration`   | The initial duration for a backoff.                               | `500ms`, `2s`         |
-| `backoff-factor`     | The factor by which the sleep duration increases every step.      | `2.5`, `4.0`          |
-| `backoff-jitter`     | A random amount of additioan sleep between 0 andduration * jitter.| `0.1`, `0.5`          |
-| `backoff-steps`      | The number of backoffs to attempt.                                | `3`, `7`              |
-| `backoff-cap`        | The maxumum backoff duration. If reached, remaining steps are zeroed.| `10s`, `20s`       |
-| `default-kind`       | The default layer kind in the bundle image.                       | `task`, `pipeline`    |
+| Option Name                | Description                                                                  | Default Value| Example Values   |
+|----------------------------|------------------------------------------------------------------------------|---------|-----------------------|
+| `backoff-duration`         | The initial duration for backoff retries.                                    | `2s`    | `500ms`, `2s`         |
+| `backoff-factor`           | The factor by which the sleep duration increases at each retry step.         | `2.0`   | `2.5`, `4.0`          |
+| `backoff-jitter`           | Random jitter added to each backoff duration (`duration * jitter`).          | `0.1`   | `0.1`, `0.5`          |
+| `backoff-steps`            | The number of backoff retries to attempt.                                    | `2`     | `3`, `7`              |
+| `backoff-cap`              | The maximum backoff duration. If reached, remaining retry steps are capped.  | `10s`   | `10s`, `20s`          |
+| `default-service-account`  | The service account used for bundle requests when `secret` is not provided.  | `default` | `build-bot`, `default` |
+| `default-kind`             | The default layer kind in the bundle image.                                  | `task`  | `task`, `pipeline`    |
+
 
 ### Caching Options
 

--- a/docs/bundle-resolver.md
+++ b/docs/bundle-resolver.md
@@ -44,7 +44,7 @@ for the name, namespace and defaults that the resolver ships with.
 | `backoff-jitter`           | Random jitter added to each backoff duration (`duration * jitter`).          | `0.1`   | `0.1`, `0.5`          |
 | `backoff-steps`            | The number of backoff retries to attempt.                                    | `2`     | `3`, `7`              |
 | `backoff-cap`              | The maximum backoff duration. If reached, remaining retry steps are capped.  | `10s`   | `10s`, `20s`          |
-| `default-service-account`  | The service account used for bundle requests when `secret` is not provided.  | `default` | `build-bot`, `default` |
+| `default-service-account`  | the default service account name to use for bundle requests.                 | `default` | `build-bot`, `default` |
 | `default-kind`             | The default layer kind in the bundle image.                                  | `task`  | `task`, `pipeline`    |
 
 

--- a/docs/bundle-resolver.md
+++ b/docs/bundle-resolver.md
@@ -44,7 +44,7 @@ for the name, namespace and defaults that the resolver ships with.
 | `backoff-jitter`           | Random jitter added to each backoff duration (`duration * jitter`).          | `0.1`   | `0.1`, `0.5`          |
 | `backoff-steps`            | The number of backoff retries to attempt.                                    | `2`     | `3`, `7`              |
 | `backoff-cap`              | The maximum backoff duration. If reached, remaining retry steps are capped.  | `10s`   | `10s`, `20s`          |
-| `default-service-account`  | the default service account name to use for bundle requests.                 | `default` | `build-bot`, `default` |
+| `default-service-account`  | The default service account name to use for bundle requests.                 | `default` | `build-bot`, `default` |
 | `default-kind`             | The default layer kind in the bundle image.                                  | `task`  | `task`, `pipeline`    |
 
 

--- a/docs/bundle-resolver.md
+++ b/docs/bundle-resolver.md
@@ -37,14 +37,16 @@ for the name, namespace and defaults that the resolver ships with.
 
 ### Options
 
-| Option Name          | Description                                                       | Example Values        |
-|----------------------|-------------------------------------------------------------------|-----------------------|
-| `backoff-duration`   | The initial duration for a backoff.                               | `500ms`, `2s`         |
-| `backoff-factor`     | The factor by which the sleep duration increases every step.      | `2.5`, `4.0`          |
-| `backoff-jitter`     | A random amount of additioan sleep between 0 andduration * jitter.| `0.1`, `0.5`          |
-| `backoff-steps`      | The number of backoffs to attempt.                                | `3`, `7`              |
-| `backoff-cap`        | The maxumum backoff duration. If reached, remaining steps are zeroed.| `10s`, `20s`       |
-| `default-kind`       | The default layer kind in the bundle image.                       | `task`, `pipeline`    |
+| Option Name                | Description                                                                  | Default Value | Required | Example Values         |
+|----------------------------|------------------------------------------------------------------------------|---------------|----------|------------------------|
+| `backoff-duration`         | The initial duration for backoff retries.                                    | `2s`          | false    | `500ms`, `2s`          |
+| `backoff-factor`           | The factor by which the sleep duration increases at each retry step.         | `2.0`         | false    | `2.5`, `4.0`           |
+| `backoff-jitter`           | Random jitter added to each backoff duration (`duration * jitter`).          | `0.1`         | false    | `0.1`, `0.5`           |
+| `backoff-steps`            | The number of backoff retries to attempt.                                    | `2`           | false    | `3`, `7`               |
+| `backoff-cap`              | The maximum backoff duration. If reached, remaining retry steps are capped.  | `10s`         | false    | `10s`, `20s`           |
+| `default-service-account`  | The default service account name to use for bundle requests.                 | `default`     | true     | `build-bot`, `default` |
+| `default-kind`             | The default layer kind in the bundle image.                                  | `task`        | true     | `task`, `pipeline`     |
+
 
 ### Caching Options
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fixes https://github.com/tektoncd/pipeline/issues/8958, which adds bundle resolver configuration options default values. 
Follows the same formatting and naming as other table in the doc by adding a "Default Value" column before the "Example Values" column.
Reference for default values:
- https://github.com/tektoncd/pipeline/blob/main/pkg/resolution/resolver/bundle/config.go#L26
- https://github.com/tektoncd/pipeline/blob/main/config/resolvers/bundleresolver-config.yaml

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
