### PR TITLE
fix(metrics): use "anonymous" pipeline tag for inline TaskRun pipelines

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -35,6 +35,12 @@ for sending metrics to an OpenTelemetry Collector or compatible backend.
 
 The Labels/Tags marked as "\*" are optional. There is a choice between Histogram and LastValue(Gauge) for pipelinerun and taskrun duration metrics.
 
+> **Note:** The `pipeline` tag is set to `"anonymous"` when the PipelineRun uses an inline
+> pipeline spec (`pipelineSpec`) instead of a named reference (`pipelineRef`). This applies
+> to both `pipelinerun_duration_seconds` and `pipelinerun_taskrun_duration_seconds` metrics,
+> preventing high-cardinality issues caused by unique PipelineRun names being used as the
+> pipeline identifier.
+
 > **Note:** All metrics now carry an `otel_scope_name` label identifying the
 > instrumentation package. This label is informational and transparent to
 > most PromQL queries.

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -455,6 +455,12 @@ func getTaskTagName(tr *v1.TaskRun) string {
 func IsPartOfPipeline(tr *v1.TaskRun) (bool, string, string) {
 	if pipelineName, ok := tr.Labels[pipeline.PipelineLabelKey]; ok {
 		if pipelineRun, ok := tr.Labels[pipeline.PipelineRunLabelKey]; ok {
+			// When the pipeline label equals the pipelinerun label, the pipeline
+			// was defined inline (anonymous). Use "anonymous" to avoid high cardinality
+			// metrics from unique PipelineRun names.
+			if pipelineName == pipelineRun {
+				pipelineName = anonymous
+			}
 			return true, pipelineName, pipelineRun
 		}
 	}

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -617,6 +617,47 @@ func TestRecordTaskRunDurationCount(t *testing.T) {
 		expectedCount:    1,
 		expectedDuration: 60,
 	}, {
+		name: "for succeeded taskrun in anonymous pipelinerun",
+		taskRun: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "taskrun-1", Namespace: "ns",
+				Labels: map[string]string{
+					// anonymous pipeline: both labels share the same value
+					pipeline.PipelineLabelKey:    "pipelinerun-1",
+					pipeline.PipelineRunLabelKey: "pipelinerun-1",
+				},
+			},
+			Spec: v1.TaskRunSpec{
+				TaskRef: &v1.TaskRef{Name: "task-1"},
+			},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					StartTime:      &startTime,
+					CompletionTime: &completionTime,
+				},
+			},
+		},
+		beforeCondition:  nil,
+		countWithReason:  false,
+		taskrunLevel:     config.TaskrunLevelAtTaskrun,
+		pipelinerunLevel: config.PipelinerunLevelAtPipelinerun,
+		expectedTags: map[string]string{
+			"pipeline":    "anonymous",
+			"pipelinerun": "pipelinerun-1",
+			"task":        "task-1",
+			"taskrun":     "taskrun-1",
+			"namespace":   "ns",
+			"status":      "success",
+		},
+		expectedCount:    1,
+		expectedDuration: 60,
+	}, {
 		name: "for succeeded taskrun ref cluster task",
 		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "taskrun-1", Namespace: "ns", Labels: map[string]string{
@@ -1326,6 +1367,19 @@ func TestTaskRunIsOfPipelinerun(t *testing.T) {
 		expectedValue:         true,
 		expetectedPipeline:    "pipeline",
 		expetectedPipelineRun: "pipelinerun",
+	}, {
+		name: "anonymous pipeline (pipeline label == pipelinerun label)",
+		tr: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					pipeline.PipelineLabelKey:    "pipelinerun-xyz",
+					pipeline.PipelineRunLabelKey: "pipelinerun-xyz",
+				},
+			},
+		},
+		expectedValue:         true,
+		expetectedPipeline:    "anonymous",
+		expetectedPipelineRun: "pipelinerun-xyz",
 	}, {
 		name:          "no",
 		tr:            &v1.TaskRun{},


### PR DESCRIPTION
When a PipelineRun uses an inline pipeline spec (no PipelineRef), Tekton sets tekton.dev/pipeline to the PipelineRun name. This caused high cardinality in TaskRun metrics since each unique PipelineRun name became a distinct label value.

Detect anonymous pipelines by checking whether the tekton.dev/pipeline label equals the tekton.dev/pipelinerun label, and substitute "anonymous" — mirroring the existing behavior in pipelinerunmetrics.getPipelineTagName.

Fixes: https://github.com/tektoncd/pipeline/issues/9140

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix high-cardinality metrics for TaskRuns belonging to inline (anonymous) PipelineRuns.
The `pipeline` tag in TaskRun metrics now uses "anonymous" instead of the PipelineRun name when the pipeline is defined inline (`pipelineSpec`), consistent with PipelineRun metrics behavior.
```
