### PR TITLE
fix(e2e): replace ubuntu with busybox in dind-sidecar test Dockerfile

### DIFF
--- a/examples/v1/taskruns/dind-sidecar.yaml
+++ b/examples/v1/taskruns/dind-sidecar.yaml
@@ -26,8 +26,7 @@ spec:
 
           # Write a Dockerfile and `docker build` it.
           cat > Dockerfile << EOF
-          FROM ubuntu
-          RUN apt-get update
+          FROM busybox
           ENTRYPOINT ["echo", "hello"]
           EOF
           docker build -t hello .


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The dind-sidecar test Dockerfile used `FROM ubuntu` + `RUN apt-get update`, which hits external Ubuntu mirrors and fails intermittently with `Hash Sum mismatch` errors. This has been causing `TestExamples/v1/taskruns/dind-sidecar` to flake across multiple unrelated PRs.

Replace with `FROM busybox` which has no external dependency and is already cached from the earlier `docker run busybox echo hello` in the same test.

Related prior issues: #9138, #7496

/kind flake

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```