### PR TITLE
Replace nil, nil returns with sentinel errors in status helpers

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -52,6 +52,10 @@ var (
 	// ReasonResourceVerificationFailed indicates that the task fails the trusted resource verification,
 	// it could be the content has changed, signature is invalid or public key is invalid
 	ReasonResourceVerificationFailed = v1.TaskRunReasonResourceVerificationFailed.String()
+
+	// ErrResultNotFound is returned when a specific result key is not found in the
+	// list of RunResults. Callers should check for this with errors.Is.
+	ErrResultNotFound = errors.New("result not found")
 )
 
 const (
@@ -331,12 +335,12 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 					errs = append(errs, err)
 				}
 				time, err := extractStartedAtTimeFromResults(results)
-				if err != nil {
+				if err != nil && !errors.Is(err, ErrResultNotFound) {
 					logger.Errorf("error setting the start time of step %q in taskrun %q: %v", s.Name, tr.Name, err)
 					errs = append(errs, err)
 				}
 				exitCode, err := extractExitCodeFromResults(results)
-				if err != nil {
+				if err != nil && !errors.Is(err, ErrResultNotFound) {
 					logger.Errorf("error extracting the exit code of step %q in taskrun %q: %v", s.Name, tr.Name, err)
 					errs = append(errs, err)
 				}
@@ -566,7 +570,7 @@ func extractStartedAtTimeFromResults(results []result.RunResult) (*metav1.Time, 
 			return &startedAt, nil
 		}
 	}
-	return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
+	return nil, ErrResultNotFound
 }
 
 func extractExitCodeFromResults(results []result.RunResult) (*int32, error) {
@@ -581,7 +585,7 @@ func extractExitCodeFromResults(results []result.RunResult) (*int32, error) {
 			return &exitCode, nil
 		}
 	}
-	return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
+	return nil, ErrResultNotFound
 }
 
 func extractTerminationReasonFromResults(results []result.RunResult) string {

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -54,6 +54,10 @@ var (
 	ReasonResourceVerificationFailed = v1.TaskRunReasonResourceVerificationFailed.String()
 )
 
+// ErrResultNotFound is returned when a specific result key is not found in the
+// list of RunResults. Callers should check for this with errors.Is.
+var ErrResultNotFound = errors.New("result not found")
+
 const (
 	// ReasonExceededResourceQuota indicates that the TaskRun failed to create a pod due to
 	// a ResourceQuota in the namespace
@@ -331,12 +335,12 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 					errs = append(errs, err)
 				}
 				time, err := extractStartedAtTimeFromResults(results)
-				if err != nil {
+				if err != nil && !errors.Is(err, ErrResultNotFound) {
 					logger.Errorf("error setting the start time of step %q in taskrun %q: %v", s.Name, tr.Name, err)
 					errs = append(errs, err)
 				}
 				exitCode, err := extractExitCodeFromResults(results)
-				if err != nil {
+				if err != nil && !errors.Is(err, ErrResultNotFound) {
 					logger.Errorf("error extracting the exit code of step %q in taskrun %q: %v", s.Name, tr.Name, err)
 					errs = append(errs, err)
 				}
@@ -566,7 +570,7 @@ func extractStartedAtTimeFromResults(results []result.RunResult) (*metav1.Time, 
 			return &startedAt, nil
 		}
 	}
-	return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
+	return nil, ErrResultNotFound
 }
 
 func extractExitCodeFromResults(results []result.RunResult) (*int32, error) {
@@ -581,7 +585,7 @@ func extractExitCodeFromResults(results []result.RunResult) (*int32, error) {
 			return &exitCode, nil
 		}
 	}
-	return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
+	return nil, ErrResultNotFound
 }
 
 func extractTerminationReasonFromResults(results []result.RunResult) string {

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -4519,4 +4520,53 @@ func Test_getFailureMessage_consistent_with_reason(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExtractStartedAtTimeFromResults(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		results := []result.RunResult{{Key: "StartedAt", Value: "2026-01-02T15:04:05.000Z"}}
+		got, err := extractStartedAtTimeFromResults(results)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected a time, got nil")
+		}
+	})
+	t.Run("missing returns ErrResultNotFound", func(t *testing.T) {
+		_, err := extractStartedAtTimeFromResults([]result.RunResult{{Key: "Other", Value: "x"}})
+		if !errors.Is(err, ErrResultNotFound) {
+			t.Fatalf("expected ErrResultNotFound, got %v", err)
+		}
+	})
+	t.Run("unparseable value returns a non-sentinel error", func(t *testing.T) {
+		_, err := extractStartedAtTimeFromResults([]result.RunResult{{Key: "StartedAt", Value: "not-a-time"}})
+		if err == nil || errors.Is(err, ErrResultNotFound) {
+			t.Fatalf("expected a parse error distinct from ErrResultNotFound, got %v", err)
+		}
+	})
+}
+
+func TestExtractExitCodeFromResults(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		got, err := extractExitCodeFromResults([]result.RunResult{{Key: "ExitCode", Value: "0"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil || *got != 0 {
+			t.Fatalf("expected exit code 0, got %v", got)
+		}
+	})
+	t.Run("missing returns ErrResultNotFound", func(t *testing.T) {
+		_, err := extractExitCodeFromResults([]result.RunResult{{Key: "Other", Value: "x"}})
+		if !errors.Is(err, ErrResultNotFound) {
+			t.Fatalf("expected ErrResultNotFound, got %v", err)
+		}
+	})
+	t.Run("unparseable value returns a non-sentinel error", func(t *testing.T) {
+		_, err := extractExitCodeFromResults([]result.RunResult{{Key: "ExitCode", Value: "NaN"}})
+		if err == nil || errors.Is(err, ErrResultNotFound) {
+			t.Fatalf("expected a parse error distinct from ErrResultNotFound, got %v", err)
+		}
+	})
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -18,14 +18,19 @@ package status
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// ErrNotFound is returned when a resource is not found during status lookup.
+// Callers should check for this with errors.Is.
+var ErrNotFound = errors.New("resource not found")
 
 // GetTaskRunStatusForPipelineTask takes a child reference and returns the actual TaskRunStatus
 // for the PipelineTask. It returns an error if the child reference's kind isn't TaskRun.
@@ -35,11 +40,11 @@ func GetTaskRunStatusForPipelineTask(ctx context.Context, client versioned.Inter
 	}
 
 	tr, err := client.TektonV1().TaskRuns(ns).Get(ctx, childRef.Name, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return nil, err
 	}
 	if tr == nil {
-		return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
+		return nil, ErrNotFound
 	}
 
 	return &tr.Status, nil
@@ -53,11 +58,11 @@ func GetCustomRunStatusForPipelineTask(ctx context.Context, client versioned.Int
 	switch childRef.Kind {
 	case "CustomRun":
 		r, err := client.TektonV1beta1().CustomRuns(ns).Get(ctx, childRef.Name, metav1.GetOptions{})
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !k8serrors.IsNotFound(err) {
 			return nil, err
 		}
 		if r == nil {
-			return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
+			return nil, ErrNotFound
 		}
 		runStatus = &r.Status
 	default:
@@ -88,7 +93,7 @@ func GetPipelineTaskStatuses(ctx context.Context, client versioned.Interface, ns
 		switch cr.Kind {
 		case "TaskRun":
 			tr, err := client.TektonV1().TaskRuns(ns).Get(ctx, cr.Name, metav1.GetOptions{})
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !k8serrors.IsNotFound(err) {
 				return nil, nil, err
 			}
 
@@ -102,7 +107,7 @@ func GetPipelineTaskStatuses(ctx context.Context, client versioned.Interface, ns
 			}
 		case "CustomRun":
 			r, err := client.TektonV1beta1().CustomRuns(ns).Get(ctx, cr.Name, metav1.GetOptions{})
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !k8serrors.IsNotFound(err) {
 				return nil, nil, err
 			}
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -18,14 +18,19 @@ package status
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// ErrNotFound is returned when a resource is not found during status lookup.
+// Callers should check for this with errors.Is.
+var ErrNotFound = errors.New("resource not found")
 
 // GetTaskRunStatusForPipelineTask takes a child reference and returns the actual TaskRunStatus
 // for the PipelineTask. It returns an error if the child reference's kind isn't TaskRun.
@@ -35,11 +40,11 @@ func GetTaskRunStatusForPipelineTask(ctx context.Context, client versioned.Inter
 	}
 
 	tr, err := client.TektonV1().TaskRuns(ns).Get(ctx, childRef.Name, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("%w: TaskRun %s", ErrNotFound, childRef.Name)
+		}
 		return nil, err
-	}
-	if tr == nil {
-		return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
 	}
 
 	return &tr.Status, nil
@@ -53,11 +58,11 @@ func GetCustomRunStatusForPipelineTask(ctx context.Context, client versioned.Int
 	switch childRef.Kind {
 	case "CustomRun":
 		r, err := client.TektonV1beta1().CustomRuns(ns).Get(ctx, childRef.Name, metav1.GetOptions{})
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil, fmt.Errorf("%w: CustomRun %s", ErrNotFound, childRef.Name)
+			}
 			return nil, err
-		}
-		if r == nil {
-			return nil, nil //nolint:nilnil // would be more ergonomic to return a sentinel error
 		}
 		runStatus = &r.Status
 	default:
@@ -88,7 +93,7 @@ func GetPipelineTaskStatuses(ctx context.Context, client versioned.Interface, ns
 		switch cr.Kind {
 		case "TaskRun":
 			tr, err := client.TektonV1().TaskRuns(ns).Get(ctx, cr.Name, metav1.GetOptions{})
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !k8serrors.IsNotFound(err) {
 				return nil, nil, err
 			}
 
@@ -102,7 +107,7 @@ func GetPipelineTaskStatuses(ctx context.Context, client versioned.Interface, ns
 			}
 		case "CustomRun":
 			r, err := client.TektonV1beta1().CustomRuns(ns).Get(ctx, cr.Name, metav1.GetOptions{})
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !k8serrors.IsNotFound(err) {
 				return nil, nil, err
 			}
 

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -62,7 +62,7 @@ func TestGetTaskRunStatusForPipelineTask(t *testing.T) {
 				Name:             "some-task-run",
 				PipelineTaskName: "some-task",
 			},
-			expectedStatus: &v1.TaskRunStatus{},
+			expectedErr: status.ErrNotFound,
 		}, {
 			name: "success",
 			taskRun: parse.MustParseV1TaskRun(t, `
@@ -109,7 +109,7 @@ status:
 				if err == nil {
 					t.Fatalf("no error, but expected '%s'", tc.expectedErr.Error())
 				}
-				if err.Error() != tc.expectedErr.Error() {
+				if !errors.Is(err, tc.expectedErr) && err.Error() != tc.expectedErr.Error() {
 					t.Fatalf("expected error '%s', but got '%s'", tc.expectedErr.Error(), err.Error())
 				}
 			} else {
@@ -150,7 +150,7 @@ func TestGetRunStatusForPipelineTask(t *testing.T) {
 				Name:             "some-run",
 				PipelineTaskName: "some-task",
 			},
-			expectedStatus: &v1beta1.CustomRunStatus{},
+			expectedErr: status.ErrNotFound,
 		}, {
 			name: "success",
 			run: parse.MustParseCustomRun(t, `
@@ -193,7 +193,7 @@ status:
 				if err == nil {
 					t.Fatalf("no error, but expected '%s'", tc.expectedErr.Error())
 				}
-				if err.Error() != tc.expectedErr.Error() {
+				if !errors.Is(err, tc.expectedErr) && err.Error() != tc.expectedErr.Error() {
 					t.Fatalf("expected error '%s', but got '%s'", tc.expectedErr.Error(), err.Error())
 				}
 			} else {


### PR DESCRIPTION
# Changes

Replace bare `return nil, nil` in `pkg/pod/status.go` and `pkg/status/status.go` with sentinel errors. Callers that receive a nil result alongside a nil error have no way to distinguish "not found" from a real result. The sentinels make the intent explicit and let callers handle it with `errors.Is`.

- `pkg/pod`: `ErrResultNotFound`, returned by `extractStartedAtTimeFromResults` and `extractExitCodeFromResults` when the named result is absent.
- `pkg/status`: `ErrNotFound`, returned by `GetTaskRunStatusForPipelineTask` and `GetCustomRunStatusForPipelineTask` when the referenced resource does not exist (detected via `apierrors.IsNotFound`, since the generated clientset returns a non-nil empty object on not-found).

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing — N/A, internal change
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [x] Has a kind label. `/kind cleanup`
- [x] Release notes block below has been updated

# Release Notes

```release-note
NONE
```