### PR TITLE
Refactor: extract shared cleanup-after-resolve helper

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -26,7 +26,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolutionV1beta1 "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
+	resolutionhelper "github.com/tektoncd/pipeline/pkg/reconciler/resolution"
 	rprp "github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/pipelinespec"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	"github.com/tektoncd/pipeline/pkg/remoteresolution/remote/resolution"
@@ -151,14 +151,7 @@ func readRuntimeObjectAsPipeline(ctx context.Context, namespace string, obj runt
 	switch obj := obj.(type) {
 	case *v1beta1.Pipeline:
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		// Verify the Pipeline once we fetch from the remote resolution, mutating, validation and conversion of the pipeline should happen after the verification, since signatures are based on the remote pipeline contents
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		// Issue a dry-run request to create the remote Pipeline, so that it can undergo validation from validating admission webhooks
-		// and mutation from mutating admission webhooks without actually creating the Pipeline on the cluster
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -173,23 +166,17 @@ func readRuntimeObjectAsPipeline(ctx context.Context, namespace string, obj runt
 			if err := mutatedPipeline.ConvertTo(ctx, p); err != nil {
 				return nil, nil, fmt.Errorf("failed to convert v1beta1 obj %s into v1 Pipeline", mutatedPipeline.GetObjectKind().GroupVersionKind().String())
 			}
-			return p, &vr, nil
+			return p, vr, nil
 		}
 	case *v1.Pipeline:
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		// This SetDefaults is currently not necessary, but for consistency, it is recommended to add it.
-		// Avoid forgetting to add it in the future when there is a v2 version, causing similar problems.
 		obj.SetDefaults(ctx)
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
 		if mutatedPipeline, ok := o.(*v1.Pipeline); ok {
 			mutatedPipeline.ObjectMeta = obj.ObjectMeta
-			return mutatedPipeline, &vr, nil
+			return mutatedPipeline, vr, nil
 		}
 	}
 	return nil, nil, errors.New("resource is not a pipeline")

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -26,8 +26,8 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolutionV1beta1 "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
 	rprp "github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/pipelinespec"
+	resolutionhelper "github.com/tektoncd/pipeline/pkg/reconciler/resolution"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	"github.com/tektoncd/pipeline/pkg/remoteresolution/remote/resolution"
 	remoteresource "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
@@ -151,14 +151,7 @@ func readRuntimeObjectAsPipeline(ctx context.Context, namespace string, obj runt
 	switch obj := obj.(type) {
 	case *v1beta1.Pipeline:
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		// Verify the Pipeline once we fetch from the remote resolution, mutating, validation and conversion of the pipeline should happen after the verification, since signatures are based on the remote pipeline contents
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		// Issue a dry-run request to create the remote Pipeline, so that it can undergo validation from validating admission webhooks
-		// and mutation from mutating admission webhooks without actually creating the Pipeline on the cluster
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -173,23 +166,17 @@ func readRuntimeObjectAsPipeline(ctx context.Context, namespace string, obj runt
 			if err := mutatedPipeline.ConvertTo(ctx, p); err != nil {
 				return nil, nil, fmt.Errorf("failed to convert v1beta1 obj %s into v1 Pipeline", mutatedPipeline.GetObjectKind().GroupVersionKind().String())
 			}
-			return p, &vr, nil
+			return p, vr, nil
 		}
 	case *v1.Pipeline:
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		// This SetDefaults is currently not necessary, but for consistency, it is recommended to add it.
-		// Avoid forgetting to add it in the future when there is a v2 version, causing similar problems.
 		obj.SetDefaults(ctx)
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
 		if mutatedPipeline, ok := o.(*v1.Pipeline); ok {
 			mutatedPipeline.ObjectMeta = obj.ObjectMeta
-			return mutatedPipeline, &vr, nil
+			return mutatedPipeline, vr, nil
 		}
 	}
 	return nil, nil, errors.New("resource is not a pipeline")

--- a/pkg/reconciler/resolution/cleanup.go
+++ b/pkg/reconciler/resolution/cleanup.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"context"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CleanupAndValidate performs the common post-resolve cleanup pattern:
+//  1. Saves the original ObjectMeta
+//  2. Clears OwnerReferences
+//  3. Optionally verifies the resource via trustedresources (when verificationPolicies is non-nil)
+//  4. Dry-run validates via the API server
+//  5. Restores ObjectMeta on the mutated object
+//
+// It returns the mutated runtime.Object from dry-run validation and an optional VerificationResult.
+func CleanupAndValidate(
+	ctx context.Context,
+	namespace string,
+	obj metav1.Object,
+	k8s kubernetes.Interface,
+	tekton clientset.Interface,
+	refSource *v1.RefSource,
+	verificationPolicies []*v1alpha1.VerificationPolicy,
+) (runtime.Object, *trustedresources.VerificationResult, error) {
+	originalMeta := obj.GetOwnerReferences()
+	_ = originalMeta // saved for documentation; we restore full ObjectMeta below via caller
+
+	obj.SetOwnerReferences(nil)
+
+	var vr *trustedresources.VerificationResult
+	if verificationPolicies != nil {
+		result := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
+		vr = &result
+	}
+
+	runtimeObj, ok := obj.(runtime.Object)
+	if !ok {
+		// This should never happen since all Tekton API types implement runtime.Object
+		panic("obj does not implement runtime.Object")
+	}
+
+	mutated, err := apiserver.DryRunValidate(ctx, namespace, runtimeObj, tekton)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return mutated, vr, nil
+}

--- a/pkg/reconciler/resolution/cleanup.go
+++ b/pkg/reconciler/resolution/cleanup.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"context"
+	"fmt"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CleanupAndValidate performs the common post-resolve pattern for resource
+// kinds covered by trustedresources verification (Task, Pipeline):
+//  1. Clears OwnerReferences on the resolved object
+//  2. Verifies the resource via trustedresources (always; with no matching
+//     policies the result is driven by the trusted-resources no-match-policy)
+//  3. Dry-run validates via the API server
+//
+// It returns the mutated runtime.Object from dry-run validation and the
+// VerificationResult. The helper does not preserve ObjectMeta: callers that
+// need the original metadata on the mutated object must restore it themselves.
+func CleanupAndValidate(
+	ctx context.Context,
+	namespace string,
+	obj runtime.Object,
+	k8s kubernetes.Interface,
+	tekton clientset.Interface,
+	refSource *v1.RefSource,
+	verificationPolicies []*v1alpha1.VerificationPolicy,
+) (runtime.Object, *trustedresources.VerificationResult, error) {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return nil, nil, fmt.Errorf("object %T does not implement metav1.Object", obj)
+	}
+	metaObj.SetOwnerReferences(nil)
+
+	result := trustedresources.VerifyResource(ctx, metaObj, k8s, refSource, verificationPolicies)
+
+	mutated, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return mutated, &result, nil
+}
+
+// CleanupAndDryRun performs the same OwnerReferences cleanup and dry-run
+// validation as CleanupAndValidate but without trustedresources verification,
+// for resource kinds that verification does not cover (e.g. StepAction).
+func CleanupAndDryRun(
+	ctx context.Context,
+	namespace string,
+	obj runtime.Object,
+	tekton clientset.Interface,
+) (runtime.Object, error) {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return nil, fmt.Errorf("object %T does not implement metav1.Object", obj)
+	}
+	metaObj.SetOwnerReferences(nil)
+
+	return apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+}

--- a/pkg/reconciler/resolution/cleanup_test.go
+++ b/pkg/reconciler/resolution/cleanup_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
+	"github.com/tektoncd/pipeline/pkg/reconciler/resolution"
+	"github.com/tektoncd/pipeline/pkg/trustedresources"
+	"github.com/tektoncd/pipeline/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+)
+
+func taskWithOwnerRefs() *v1.Task {
+	return &v1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-task",
+			Namespace:       "default",
+			OwnerReferences: []metav1.OwnerReference{{Name: "some-owner"}},
+		},
+	}
+}
+
+// TestCleanupAndValidate_NilPoliciesFailNoMatchPolicy guards against
+// verification being silently skipped when the lister returns a nil policy
+// slice: with no matching policies and no-match-policy "fail", the result
+// must be VerificationError, not a bypass.
+func TestCleanupAndValidate_NilPoliciesFailNoMatchPolicy(t *testing.T) {
+	ctx := test.SetupTrustedResourceConfig(t.Context(), config.FailNoMatchPolicy)
+	task := taskWithOwnerRefs()
+
+	mutated, vr, err := resolution.CleanupAndValidate(ctx, "default", task, fakek8s.NewSimpleClientset(), fake.NewSimpleClientset(), nil, nil)
+	if err != nil {
+		t.Fatalf("CleanupAndValidate: %v", err)
+	}
+	if mutated == nil {
+		t.Fatal("expected mutated object, got nil")
+	}
+	if vr == nil {
+		t.Fatal("expected a VerificationResult, got nil")
+	}
+	if vr.VerificationResultType != trustedresources.VerificationError {
+		t.Errorf("VerificationResultType = %v, want VerificationError", vr.VerificationResultType)
+	}
+	if !errors.Is(vr.Err, trustedresources.ErrNoMatchedPolicies) {
+		t.Errorf("Err = %v, want ErrNoMatchedPolicies", vr.Err)
+	}
+	if len(task.GetOwnerReferences()) != 0 {
+		t.Errorf("OwnerReferences not cleared: %v", task.GetOwnerReferences())
+	}
+}
+
+// TestCleanupAndValidate_NilPoliciesIgnoreNoMatchPolicy verifies the skip
+// path still works when no-match-policy is "ignore".
+func TestCleanupAndValidate_NilPoliciesIgnoreNoMatchPolicy(t *testing.T) {
+	ctx := test.SetupTrustedResourceConfig(t.Context(), config.IgnoreNoMatchPolicy)
+	task := taskWithOwnerRefs()
+
+	_, vr, err := resolution.CleanupAndValidate(ctx, "default", task, fakek8s.NewSimpleClientset(), fake.NewSimpleClientset(), nil, nil)
+	if err != nil {
+		t.Fatalf("CleanupAndValidate: %v", err)
+	}
+	if vr == nil {
+		t.Fatal("expected a VerificationResult, got nil")
+	}
+	if vr.VerificationResultType != trustedresources.VerificationSkip {
+		t.Errorf("VerificationResultType = %v, want VerificationSkip", vr.VerificationResultType)
+	}
+}
+
+func TestCleanupAndDryRun(t *testing.T) {
+	sa := &v1beta1.StepAction{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-stepaction",
+			Namespace:       "default",
+			OwnerReferences: []metav1.OwnerReference{{Name: "some-owner"}},
+		},
+	}
+
+	mutated, err := resolution.CleanupAndDryRun(t.Context(), "default", sa, fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("CleanupAndDryRun: %v", err)
+	}
+	if mutated == nil {
+		t.Fatal("expected mutated object, got nil")
+	}
+	if len(sa.GetOwnerReferences()) != 0 {
+		t.Errorf("OwnerReferences not cleared: %v", sa.GetOwnerReferences())
+	}
+}

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -27,7 +27,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolutionV1beta1 "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
+	resolutionhelper "github.com/tektoncd/pipeline/pkg/reconciler/resolution"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	"github.com/tektoncd/pipeline/pkg/remoteresolution/remote/resolution"
 	remoteresource "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
@@ -232,10 +232,7 @@ func resolveStepAction(ctx context.Context, resolver remote.Resolver, name, name
 	}
 	switch obj := obj.(type) {
 	case *v1beta1.StepAction:
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, _, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, nil, tekton, nil, nil)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -245,10 +242,7 @@ func resolveStepAction(ctx context.Context, resolver remote.Resolver, name, name
 		}
 	case *v1alpha1.StepAction:
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, _, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, nil, tekton, nil, nil)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -283,14 +277,7 @@ func readRuntimeObjectAsTask(ctx context.Context, namespace string, obj runtime.
 	switch obj := obj.(type) {
 	case *v1beta1.Task:
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		// Verify the Task once we fetch from the remote resolution, mutating, validation and conversion of the task should happen after the verification, since signatures are based on the remote task contents
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		// Issue a dry-run request to create the remote Task, so that it can undergo validation from validating admission webhooks
-		// without actually creating the Task on the cluster.
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -305,25 +292,17 @@ func readRuntimeObjectAsTask(ctx context.Context, namespace string, obj runtime.
 			if err := mutatedTask.ConvertTo(ctx, t); err != nil {
 				return nil, nil, fmt.Errorf("failed to convert obj %s into Pipeline", mutatedTask.GetObjectKind().GroupVersionKind().String())
 			}
-			return t, &vr, nil
+			return t, vr, nil
 		}
 	case *v1.Task:
-		// This SetDefaults is currently not necessary, but for consistency, it is recommended to add it.
-		// Avoid forgetting to add it in the future when there is a v2 version, causing similar problems.
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		// Issue a dry-run request to create the remote Task, so that it can undergo validation from validating admission webhooks
-		// without actually creating the Task on the cluster
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
 		if mutatedTask, ok := o.(*v1.Task); ok {
 			mutatedTask.ObjectMeta = obj.ObjectMeta
-			return mutatedTask, &vr, nil
+			return mutatedTask, vr, nil
 		}
 	}
 	return nil, nil, errors.New("resource is not a task")

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -27,7 +27,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolutionV1beta1 "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
+	resolutionhelper "github.com/tektoncd/pipeline/pkg/reconciler/resolution"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	"github.com/tektoncd/pipeline/pkg/remoteresolution/remote/resolution"
 	remoteresource "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
@@ -232,10 +232,7 @@ func resolveStepAction(ctx context.Context, resolver remote.Resolver, name, name
 	}
 	switch obj := obj.(type) {
 	case *v1beta1.StepAction:
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, err := resolutionhelper.CleanupAndDryRun(ctx, namespace, obj, tekton)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -245,10 +242,7 @@ func resolveStepAction(ctx context.Context, resolver remote.Resolver, name, name
 		}
 	case *v1alpha1.StepAction:
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, err := resolutionhelper.CleanupAndDryRun(ctx, namespace, obj, tekton)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -283,14 +277,7 @@ func readRuntimeObjectAsTask(ctx context.Context, namespace string, obj runtime.
 	switch obj := obj.(type) {
 	case *v1beta1.Task:
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		// Verify the Task once we fetch from the remote resolution, mutating, validation and conversion of the task should happen after the verification, since signatures are based on the remote task contents
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		// Issue a dry-run request to create the remote Task, so that it can undergo validation from validating admission webhooks
-		// without actually creating the Task on the cluster.
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -303,27 +290,19 @@ func readRuntimeObjectAsTask(ctx context.Context, namespace string, obj runtime.
 			}
 			mutatedTask.ObjectMeta = obj.ObjectMeta
 			if err := mutatedTask.ConvertTo(ctx, t); err != nil {
-				return nil, nil, fmt.Errorf("failed to convert obj %s into Pipeline", mutatedTask.GetObjectKind().GroupVersionKind().String())
+				return nil, nil, fmt.Errorf("failed to convert obj %s into Task", mutatedTask.GetObjectKind().GroupVersionKind().String())
 			}
-			return t, &vr, nil
+			return t, vr, nil
 		}
 	case *v1.Task:
-		// This SetDefaults is currently not necessary, but for consistency, it is recommended to add it.
-		// Avoid forgetting to add it in the future when there is a v2 version, causing similar problems.
 		obj.SetDefaults(ctx)
-		// Cleanup object from things we don't care about
-		// FIXME: extract this in a function
-		obj.ObjectMeta.OwnerReferences = nil
-		vr := trustedresources.VerifyResource(ctx, obj, k8s, refSource, verificationPolicies)
-		// Issue a dry-run request to create the remote Task, so that it can undergo validation from validating admission webhooks
-		// without actually creating the Task on the cluster
-		o, err := apiserver.DryRunValidate(ctx, namespace, obj, tekton)
+		o, vr, err := resolutionhelper.CleanupAndValidate(ctx, namespace, obj, k8s, tekton, refSource, verificationPolicies)
 		if err != nil {
 			return nil, nil, err
 		}
 		if mutatedTask, ok := o.(*v1.Task); ok {
 			mutatedTask.ObjectMeta = obj.ObjectMeta
-			return mutatedTask, &vr, nil
+			return mutatedTask, vr, nil
 		}
 	}
 	return nil, nil, errors.New("resource is not a task")


### PR DESCRIPTION
# Changes

Extract the duplicated cleanup-after-resolve logic from `pipelineref.go` and `taskref.go` into a shared `pkg/reconciler/resolution/cleanup.go` helper. Both reconcilers performed the same requester-cleanup sequence after resolving a remote resource; the helper eliminates the duplication.

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing — N/A, internal refactor
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed — existing tests cover both call sites
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [x] Has a kind label. `/kind cleanup`
- [x] Release notes block below has been updated

# Release Notes

```release-note
NONE
```