### PR TITLE
Warn on unanchored VerificationPolicy resource patterns

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
@@ -90,13 +90,27 @@ func (key *KeyRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs
 }
 
-// Validate ResourcePattern and make sure the Pattern is valid regex expression
+// Validate ResourcePattern and make sure the Pattern is valid regex expression.
+// Patterns that are not anchored with ^ and $ are flagged with a warning because
+// unanchored patterns can match unintended substrings in resource URIs, which
+// could allow an attacker to craft a URI that contains the trusted pattern as a
+// substring.
 func (r *ResourcePattern) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if _, err := regexp.Compile(r.Pattern); err != nil {
 		errs = errs.Also(apis.ErrInvalidValue(r.Pattern, "ResourcePattern", fmt.Sprintf("%v: %v", InvalidResourcePatternErr, err)))
 		return errs
 	}
-	return nil
+
+	if !strings.HasPrefix(r.Pattern, "^") || !strings.HasSuffix(r.Pattern, "$") {
+		errs = errs.Also(apis.ErrGeneric(
+			fmt.Sprintf("resource pattern %q is not anchored with ^ and $; "+
+				"unanchored patterns may match unintended resource URIs — "+
+				"consider using ^%s$ to match the full URI", r.Pattern, r.Pattern),
+			"pattern",
+		))
+	}
+
+	return errs
 }
 
 // validateHashAlgorithm checks if the algorithm is supported

--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
@@ -101,13 +101,17 @@ func (r *ResourcePattern) Validate(ctx context.Context) (errs *apis.FieldError) 
 		return errs
 	}
 
+	// Heuristic check: a pattern like `^a$|b` passes the prefix/suffix test
+	// without being fully anchored. That is acceptable for a warning-level
+	// diagnostic. Note this is a UX guardrail only: the substring-matching
+	// bypass is already prevented at evaluation time by getMatchedPolicies,
+	// which strips the resolver prefix and anchors the pattern.
 	if !strings.HasPrefix(r.Pattern, "^") || !strings.HasSuffix(r.Pattern, "$") {
 		errs = errs.Also(apis.ErrGeneric(
-			fmt.Sprintf("resource pattern %q is not anchored with ^ and $; "+
-				"unanchored patterns may match unintended resource URIs — "+
-				"consider using ^%s$ to match the full URI", r.Pattern, r.Pattern),
+			fmt.Sprintf("resource pattern %q is not anchored with ^ and $ and may match unintended resource URIs; "+
+				"see https://tekton.dev/docs/pipelines/trusted-resources/ for guidance on writing anchored patterns", r.Pattern),
 			"pattern",
-		))
+		).At(apis.WarningLevel))
 	}
 
 	return errs

--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
@@ -91,10 +91,11 @@ func (key *KeyRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 }
 
 // Validate ResourcePattern and make sure the Pattern is valid regex expression.
-// Patterns that are not anchored with ^ and $ are flagged with a warning because
-// unanchored patterns can match unintended substrings in resource URIs, which
-// could allow an attacker to craft a URI that contains the trusted pattern as a
-// substring.
+// Patterns that are not anchored with ^ and $ are flagged with a warning, since an
+// unanchored pattern matches anywhere in a resource URI and so is usually broader
+// than its author intended. This is a usability guardrail rather than a security
+// control: substring matching is already prevented at evaluation time by
+// getMatchedPolicies, which strips the resolver prefix and anchors the pattern.
 func (r *ResourcePattern) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if _, err := regexp.Compile(r.Pattern); err != nil {
 		errs = errs.Also(apis.ErrInvalidValue(r.Pattern, "ResourcePattern", fmt.Sprintf("%v: %v", InvalidResourcePatternErr, err)))

--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation_test.go
@@ -228,7 +228,9 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.verificationPolicy.Validate(t.Context())
-			if d := cmp.Diff(tt.want.Error(), err.Error()); d != "" {
+			// Compare only error-level diagnostics; unanchored test patterns
+			// additionally produce warning-level diagnostics.
+			if d := cmp.Diff(tt.want.Error(), err.Filter(apis.ErrorLevel).Error()); d != "" {
 				t.Error("VerificationPolicy validate error mismatch", diff.PrintWantGot(d))
 			}
 		})
@@ -340,9 +342,50 @@ func TestVerificationPolicy_Valid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.verificationPolicy.Validate(t.Context())
-			if err != nil {
+			// Unanchored patterns produce warning-level diagnostics; only
+			// error-level diagnostics make a VerificationPolicy invalid.
+			if err.Filter(apis.ErrorLevel) != nil {
 				t.Errorf("validating valid VerificationPolicy: %v", err)
 			}
 		})
 	}
+}
+
+func TestVerificationPolicy_UnanchoredPatternWarnsNotRejects(t *testing.T) {
+	vpWithPattern := func(pattern string) *v1alpha1.VerificationPolicy {
+		return &v1alpha1.VerificationPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vp",
+			},
+			Spec: v1alpha1.VerificationPolicySpec{
+				Resources: []v1alpha1.ResourcePattern{{Pattern: pattern}},
+				Authorities: []v1alpha1.Authority{
+					{
+						Name: "foo",
+						Key: &v1alpha1.KeyRef{
+							Data:          "inlinekey",
+							HashAlgorithm: "sha256",
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("unanchored pattern warns without rejecting", func(t *testing.T) {
+		err := vpWithPattern("https://github.com/tektoncd/catalog.git").Validate(t.Context())
+		if err.Filter(apis.ErrorLevel) != nil {
+			t.Errorf("unanchored pattern must not be rejected, got error: %v", err)
+		}
+		if err.Filter(apis.WarningLevel) == nil {
+			t.Error("expected a warning for unanchored pattern, got none")
+		}
+	})
+
+	t.Run("anchored pattern has no diagnostics", func(t *testing.T) {
+		err := vpWithPattern(`^(git\+)?https://github\.com/tektoncd/catalog\.git$`).Validate(t.Context())
+		if err != nil {
+			t.Errorf("anchored pattern must validate cleanly, got: %v", err)
+		}
+	})
 }

--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation_test.go
@@ -374,6 +374,11 @@ func TestVerificationPolicy_UnanchoredPatternWarnsNotRejects(t *testing.T) {
 
 	t.Run("unanchored pattern warns without rejecting", func(t *testing.T) {
 		err := vpWithPattern("https://github.com/tektoncd/catalog.git").Validate(t.Context())
+		// Guard explicitly: if the warning ever stops being emitted, report that
+		// rather than panicking inside Filter on a nil FieldError.
+		if err == nil {
+			t.Fatal("expected a warning for unanchored pattern, got no diagnostics")
+		}
 		if err.Filter(apis.ErrorLevel) != nil {
 			t.Errorf("unanchored pattern must not be rejected, got error: %v", err)
 		}


### PR DESCRIPTION
# Changes

Add a warning-level admission diagnostic when a `VerificationPolicy` resource pattern is not anchored with `^` and `$`. Unanchored patterns can match unintended resource URIs, which makes policies confusing to reason about.

**Note:** this is a UX guardrail, not a security fix. The substring-matching bypass (GHSA-rmx9-2pp3-xhcr / CVE-2026-25542) is already fixed at evaluation time in `getMatchedPolicies()` via `stripResolverPrefix()` + `anchorPattern()`. This change only surfaces a warning at admission so policy authors notice unanchored patterns earlier; it does not change matching behavior and should not be backported as a security fix.

The warning points at the [trusted resources docs](https://tekton.dev/docs/pipelines/trusted-resources/) rather than suggesting a verbatim `^pattern$` rewrite, since the unescaped form leaves regex metacharacters unanchored in meaning. The anchored-prefix/suffix check is a heuristic (e.g. `^a$|b` passes it), which is acceptable for a warning-level diagnostic.

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing — N/A, validation warning only
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [x] Has a kind label. `/kind bug`
- [x] Release notes block below has been updated

# Release Notes

```release-note
VerificationPolicy resource patterns that are not anchored with ^ and $ now produce a warning at admission time.
```

---

**Not a security fix.** The substring-matching bypass (GHSA-rmx9-2pp3-xhcr / CVE-2026-25542) is already fixed at evaluation time in `getMatchedPolicies()` via `stripResolverPrefix()` + `anchorPattern()`. This PR is a usability guardrail that surfaces an over-broad pattern at admission time, and should not be mistaken for a security fix or backported as one.