### PR TITLE
docs: clarify retry-count substitution requires taskSpec

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1263,6 +1263,11 @@ taskSpec:
 **Note:** Every `PipelineTask` can only access its own `retries` and `retry-count`. These
 values aren't accessible for other `PipelineTask`s.
 
+**Note:** `$(context.task.retry-count)` is only substituted when the `PipelineTask`
+defines its task body inline with `taskSpec`. When the `PipelineTask` uses `taskRef`,
+the variable is passed through as a literal string because the referenced `Task` is
+resolved before the retry-count context is available.
+
 ## Using `Results`
 
 Tasks can emit [`Results`](tasks.md#emitting-results) when they execute. A Pipeline can use these

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -72,7 +72,7 @@ For instructions on using variable substitutions see the relevant section of [th
 | `context.taskRun.namespace`                        | The namespace of the `TaskRun` that this `Task` is running in.                                                                 |
 | `context.taskRun.uid`                              | The uid of the `TaskRun` that this `Task` is running in.                                                                       |
 | `context.task.name`                                | The name of this `Task`.                                                                                                       |
-| `context.task.retry-count`                         | The current retry number of this `Task`.                                                                                       |
+| `context.task.retry-count`                         | The current retry number of this `Task`. Only substituted when the `PipelineTask` uses an inline `taskSpec`; with `taskRef` the value is passed through as a literal string. |
 | `steps.step-<stepName>.exitCode.path`              | The path to the file where a Step's exit code is stored.                                                                       |
 | `steps.step-unnamed-<stepIndex>.exitCode.path`     | The path to the file where a Step's exit code is stored for a step without any name.                                           |
 | `artifacts.path`                                   | The path to the file where the `Task` writes its artifacts data.                                                               |


### PR DESCRIPTION
# Changes

Adds a note in `docs/pipelines.md` and extends the `context.task.retry-count` row in `docs/variables.md` to clarify that `$(context.task.retry-count)` is only substituted when the `PipelineTask` uses an inline `taskSpec`. With `taskRef`, the referenced `Task` is resolved before the retry-count context is available, so the placeholder passes through as a literal string.

Fixes #7063.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```