### PR TITLE
build(deps): bump code.gitea.io/sdk/gitea from 0.21.0 to 0.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 )
 
 require (
-	code.gitea.io/sdk/gitea v0.21.0
+	code.gitea.io/sdk/gitea v0.23.0
 	github.com/go-jose/go-jose/v3 v3.0.5
 	github.com/goccy/kpoward v0.1.0
 	github.com/google/cel-go v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-code.gitea.io/sdk/gitea v0.21.0 h1:69n6oz6kEVHRo1+APQQyizkhrZrLsTLXey9142pfkD4=
-code.gitea.io/sdk/gitea v0.21.0/go.mod h1:tnBjVhuKJCn8ibdyyhvUyxrR1Ca2KHEoTWoukNhXQPA=
+code.gitea.io/sdk/gitea v0.23.0 h1:abrKhTr6enJZaQj9sZlWQY9jMHd49xGxa0+gtd1HiXg=
+code.gitea.io/sdk/gitea v0.23.0/go.mod h1:yyF5+GhljqvA30sRDreoyHILruNiy4ASufugzYg0VHM=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 fortio.org/safecast v1.2.0 h1:ckQJNenMJHycqPsi/QrzA4EUX5WQkyd+hGO4mxt/a8w=
 fortio.org/safecast v1.2.0/go.mod h1:xZmcPk3vi4kuUFf+tq4SvnlVdwViqf6ZSZl91Jr9Jdg=

--- a/vendor/code.gitea.io/sdk/gitea/action_run.go
+++ b/vendor/code.gitea.io/sdk/gitea/action_run.go
@@ -1,0 +1,279 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// ActionTask represents a workflow run task (from /actions/tasks endpoint)
+// This is the format returned by older Gitea versions
+type ActionTask struct {
+	ID           int64     `json:"id"`
+	Name         string    `json:"name"` // Workflow name
+	HeadBranch   string    `json:"head_branch"`
+	HeadSHA      string    `json:"head_sha"`
+	RunNumber    int64     `json:"run_number"`
+	Event        string    `json:"event"`
+	DisplayTitle string    `json:"display_title"` // PR title or commit message
+	Status       string    `json:"status"`
+	WorkflowID   string    `json:"workflow_id"` // e.g. "ci.yml"
+	URL          string    `json:"url"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	RunStartedAt time.Time `json:"run_started_at"`
+}
+
+// ActionTaskResponse holds the response for listing action tasks
+type ActionTaskResponse struct {
+	TotalCount   int64         `json:"total_count"`
+	WorkflowRuns []*ActionTask `json:"workflow_runs"`
+}
+
+// ActionWorkflowRun represents a workflow run (from /actions/runs endpoint)
+// This is the format returned by newer Gitea versions
+type ActionWorkflowRun struct {
+	ID             int64       `json:"id"`
+	DisplayTitle   string      `json:"display_title"`
+	Event          string      `json:"event"`
+	HeadBranch     string      `json:"head_branch"`
+	HeadSha        string      `json:"head_sha"`
+	Path           string      `json:"path"`
+	RunAttempt     int64       `json:"run_attempt"`
+	RunNumber      int64       `json:"run_number"`
+	Status         string      `json:"status"`
+	Conclusion     string      `json:"conclusion"`
+	URL            string      `json:"url"`
+	HTMLURL        string      `json:"html_url"`
+	StartedAt      time.Time   `json:"started_at"`
+	CompletedAt    time.Time   `json:"completed_at"`
+	Actor          *User       `json:"actor"`
+	TriggerActor   *User       `json:"trigger_actor"`
+	Repository     *Repository `json:"repository"`
+	HeadRepository *Repository `json:"head_repository"`
+	RepositoryID   int64       `json:"repository_id"`
+}
+
+// ActionWorkflowRunsResponse holds the response for listing workflow runs
+type ActionWorkflowRunsResponse struct {
+	TotalCount   int64                `json:"total_count"`
+	WorkflowRuns []*ActionWorkflowRun `json:"workflow_runs"`
+}
+
+// ActionWorkflowJob represents a job within a workflow run
+type ActionWorkflowJob struct {
+	ID          int64                 `json:"id"`
+	RunID       int64                 `json:"run_id"`
+	RunURL      string                `json:"run_url"`
+	RunAttempt  int64                 `json:"run_attempt"`
+	Name        string                `json:"name"`
+	HeadBranch  string                `json:"head_branch"`
+	HeadSha     string                `json:"head_sha"`
+	Status      string                `json:"status"`
+	Conclusion  string                `json:"conclusion"`
+	URL         string                `json:"url"`
+	HTMLURL     string                `json:"html_url"`
+	CreatedAt   time.Time             `json:"created_at"`
+	StartedAt   time.Time             `json:"started_at"`
+	CompletedAt time.Time             `json:"completed_at"`
+	RunnerID    int64                 `json:"runner_id"`
+	RunnerName  string                `json:"runner_name"`
+	Labels      []string              `json:"labels"`
+	Steps       []*ActionWorkflowStep `json:"steps"`
+}
+
+// ActionWorkflowJobsResponse holds the response for listing workflow jobs
+type ActionWorkflowJobsResponse struct {
+	TotalCount int64                `json:"total_count"`
+	Jobs       []*ActionWorkflowJob `json:"jobs"`
+}
+
+// ActionWorkflowStep represents a step within a job
+type ActionWorkflowStep struct {
+	Name        string    `json:"name"`
+	Number      int64     `json:"number"`
+	Status      string    `json:"status"`
+	Conclusion  string    `json:"conclusion"`
+	StartedAt   time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at"`
+}
+
+// ListRepoActionRunsOptions options for listing repository action runs
+type ListRepoActionRunsOptions struct {
+	ListOptions
+	Branch  string // Filter by branch
+	Event   string // Filter by triggering event
+	Status  string // Filter by status (pending, queued, in_progress, failure, success, skipped)
+	Actor   string // Filter by actor (user who triggered the run)
+	HeadSHA string // Filter by the SHA of the head commit
+}
+
+// QueryEncode encodes the options to URL query parameters
+func (opt *ListRepoActionRunsOptions) QueryEncode() string {
+	query := opt.getURLQuery()
+	if opt.Branch != "" {
+		query.Add("branch", opt.Branch)
+	}
+	if opt.Event != "" {
+		query.Add("event", opt.Event)
+	}
+	if opt.Status != "" {
+		query.Add("status", opt.Status)
+	}
+	if opt.Actor != "" {
+		query.Add("actor", opt.Actor)
+	}
+	if opt.HeadSHA != "" {
+		query.Add("head_sha", opt.HeadSHA)
+	}
+	return query.Encode()
+}
+
+// ListRepoActionJobsOptions options for listing repository action jobs
+type ListRepoActionJobsOptions struct {
+	ListOptions
+	Status string // Filter by status (pending, queued, in_progress, failure, success, skipped)
+}
+
+// QueryEncode encodes the options to URL query parameters
+func (opt *ListRepoActionJobsOptions) QueryEncode() string {
+	query := opt.getURLQuery()
+	if opt.Status != "" {
+		query.Add("status", opt.Status)
+	}
+	return query.Encode()
+}
+
+// ListRepoActionRuns lists workflow runs for a repository.
+// Requires Gitea 1.25.0 or later. For older versions, use ListRepoActionTasks.
+func (c *Client) ListRepoActionRuns(owner, repo string, opt ListRepoActionRunsOptions) (*ActionWorkflowRunsResponse, *Response, error) {
+	if err := c.checkServerVersionGreaterThanOrEqual(version1_25_0); err != nil {
+		return nil, nil, err
+	}
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/actions/runs", owner, repo))
+	link.RawQuery = opt.QueryEncode()
+
+	resp := new(ActionWorkflowRunsResponse)
+	response, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, resp)
+	return resp, response, err
+}
+
+// GetRepoActionRun gets a single workflow run.
+// Requires Gitea 1.25.0 or later.
+func (c *Client) GetRepoActionRun(owner, repo string, runID int64) (*ActionWorkflowRun, *Response, error) {
+	if err := c.checkServerVersionGreaterThanOrEqual(version1_25_0); err != nil {
+		return nil, nil, err
+	}
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+
+	run := new(ActionWorkflowRun)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/actions/runs/%d", owner, repo, runID), jsonHeader, nil, run)
+	return run, resp, err
+}
+
+// ListRepoActionRunJobs lists jobs for a workflow run.
+// Requires Gitea 1.25.0 or later.
+func (c *Client) ListRepoActionRunJobs(owner, repo string, runID int64, opt ListRepoActionJobsOptions) (*ActionWorkflowJobsResponse, *Response, error) {
+	if err := c.checkServerVersionGreaterThanOrEqual(version1_25_0); err != nil {
+		return nil, nil, err
+	}
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/actions/runs/%d/jobs", owner, repo, runID))
+	link.RawQuery = opt.QueryEncode()
+
+	resp := new(ActionWorkflowJobsResponse)
+	response, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, resp)
+	return resp, response, err
+}
+
+// ListRepoActionJobs lists all jobs for a repository.
+// Requires Gitea 1.25.0 or later.
+func (c *Client) ListRepoActionJobs(owner, repo string, opt ListRepoActionJobsOptions) (*ActionWorkflowJobsResponse, *Response, error) {
+	if err := c.checkServerVersionGreaterThanOrEqual(version1_25_0); err != nil {
+		return nil, nil, err
+	}
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/actions/jobs", owner, repo))
+	link.RawQuery = opt.QueryEncode()
+
+	resp := new(ActionWorkflowJobsResponse)
+	response, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, resp)
+	return resp, response, err
+}
+
+// GetRepoActionJob gets a single job.
+// Requires Gitea 1.25.0 or later.
+func (c *Client) GetRepoActionJob(owner, repo string, jobID int64) (*ActionWorkflowJob, *Response, error) {
+	if err := c.checkServerVersionGreaterThanOrEqual(version1_25_0); err != nil {
+		return nil, nil, err
+	}
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+
+	job := new(ActionWorkflowJob)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/actions/jobs/%d", owner, repo, jobID), jsonHeader, nil, job)
+	return job, resp, err
+}
+
+// GetRepoActionJobLogs gets the logs for a specific job.
+// Requires Gitea 1.25.0 or later.
+func (c *Client) GetRepoActionJobLogs(owner, repo string, jobID int64) ([]byte, *Response, error) {
+	if err := c.checkServerVersionGreaterThanOrEqual(version1_25_0); err != nil {
+		return nil, nil, err
+	}
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+
+	return c.getResponse("GET", fmt.Sprintf("/repos/%s/%s/actions/jobs/%d/logs", owner, repo, jobID), nil, nil)
+}
+
+// ListRepoActionTasks lists workflow tasks for a repository (Gitea 1.24.x and earlier)
+// Use this for older Gitea versions that don't have /actions/runs endpoint
+func (c *Client) ListRepoActionTasks(owner, repo string, opt ListOptions) (*ActionTaskResponse, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/actions/tasks", owner, repo))
+	link.RawQuery = opt.getURLQuery().Encode()
+
+	resp := new(ActionTaskResponse)
+	response, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, resp)
+	return resp, response, err
+}
+
+// DeleteRepoActionRun deletes a workflow run.
+// Requires Gitea 1.25.0 or later.
+func (c *Client) DeleteRepoActionRun(owner, repo string, runID int64) (*Response, error) {
+	if err := c.checkServerVersionGreaterThanOrEqual(version1_25_0); err != nil {
+		return nil, err
+	}
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+
+	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/actions/runs/%d", owner, repo, runID), jsonHeader, nil)
+	return resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/activity.go
+++ b/vendor/code.gitea.io/sdk/gitea/activity.go
@@ -1,0 +1,24 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import "time"
+
+// Activity represents a user or organization activity
+type Activity struct {
+	ID        int64       `json:"id"`
+	ActUserID int64       `json:"act_user_id"`
+	ActUser   *User       `json:"act_user"`
+	OpType    string      `json:"op_type"`
+	Content   string      `json:"content"`
+	RepoID    int64       `json:"repo_id"`
+	Repo      *Repository `json:"repo"`
+	CommentID int64       `json:"comment_id"`
+	Comment   *Comment    `json:"comment"`
+	RefName   string      `json:"ref_name"`
+	IsPrivate bool        `json:"is_private"`
+	UserID    int64       `json:"user_id"`
+	Created   time.Time   `json:"created"`
+}

--- a/vendor/code.gitea.io/sdk/gitea/activitypub.go
+++ b/vendor/code.gitea.io/sdk/gitea/activitypub.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ActivityPub represents an ActivityPub object
+type ActivityPub map[string]interface{}
+
+// GetActivityPubPerson returns the Person actor for a user
+func (c *Client) GetActivityPubPerson(userID int64) (ActivityPub, *Response, error) {
+	result := make(ActivityPub)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/activitypub/user-id/%d", userID),
+		jsonHeader, nil, &result)
+	return result, resp, err
+}
+
+// SendActivityPubInbox sends an ActivityPub message to a user's inbox
+func (c *Client) SendActivityPubInbox(userID int64, activity ActivityPub) (*Response, error) {
+	body, err := json.Marshal(activity)
+	if err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("POST",
+		fmt.Sprintf("/activitypub/user-id/%d/inbox", userID),
+		jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// GetActivityPubPersonResponse returns the raw ActivityPub Person response
+func (c *Client) GetActivityPubPersonResponse(userID int64) ([]byte, *Response, error) {
+	resp, err := c.doRequest("GET",
+		fmt.Sprintf("/activitypub/user-id/%d", userID),
+		jsonHeader, nil)
+	if err != nil {
+		return nil, resp, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	return data, resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/admin_badges.go
+++ b/vendor/code.gitea.io/sdk/gitea/admin_badges.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Badge represents a user badge
+type Badge struct {
+	ID          int64  `json:"id"`
+	Slug        string `json:"slug"`
+	Description string `json:"description"`
+	ImageURL    string `json:"image_url"`
+}
+
+// ListUserBadges lists badges of a user
+func (c *Client) ListUserBadges(username string) ([]*Badge, *Response, error) {
+	if err := escapeValidatePathSegments(&username); err != nil {
+		return nil, nil, err
+	}
+	badges := make([]*Badge, 0, 5)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/admin/users/%s/badges", username),
+		jsonHeader, nil, &badges)
+	return badges, resp, err
+}
+
+// UserBadgeOption represents options for adding badges to a user
+type UserBadgeOption struct {
+	BadgeSlugs []string `json:"badge_slugs"`
+}
+
+// AddUserBadges adds badges to a user by their slugs
+func (c *Client) AddUserBadges(username string, opt UserBadgeOption) (*Response, error) {
+	if err := escapeValidatePathSegments(&username); err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("POST",
+		fmt.Sprintf("/admin/users/%s/badges", username),
+		jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent && status != http.StatusCreated {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// DeleteUserBadge deletes a user's badge
+func (c *Client) DeleteUserBadge(username string, opt UserBadgeOption) (*Response, error) {
+	if err := escapeValidatePathSegments(&username); err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("DELETE",
+		fmt.Sprintf("/admin/users/%s/badges", username),
+		jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}

--- a/vendor/code.gitea.io/sdk/gitea/admin_cron.go
+++ b/vendor/code.gitea.io/sdk/gitea/admin_cron.go
@@ -42,6 +42,5 @@ func (c *Client) RunCronTasks(task string) (*Response, error) {
 	if err := escapeValidatePathSegments(&task); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("POST", fmt.Sprintf("/admin/cron/%s", task), jsonHeader, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("POST", fmt.Sprintf("/admin/cron/%s", task), jsonHeader, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/admin_email.go
+++ b/vendor/code.gitea.io/sdk/gitea/admin_email.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"net/url"
+)
+
+// ListAdminEmailsOptions options for listing all emails
+type ListAdminEmailsOptions struct {
+	ListOptions
+}
+
+// ListAdminEmails lists all email addresses
+func (c *Client) ListAdminEmails(opt ListAdminEmailsOptions) ([]*Email, *Response, error) {
+	opt.setDefaults()
+
+	link, _ := url.Parse("/admin/emails")
+	link.RawQuery = opt.getURLQuery().Encode()
+
+	emails := make([]*Email, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &emails)
+	return emails, resp, err
+}
+
+// SearchAdminEmailsOptions options for searching emails
+type SearchAdminEmailsOptions struct {
+	ListOptions
+	Query string `json:"q,omitempty"`
+}
+
+// SearchAdminEmails searches email addresses
+func (c *Client) SearchAdminEmails(opt SearchAdminEmailsOptions) ([]*Email, *Response, error) {
+	opt.setDefaults()
+
+	link, _ := url.Parse("/admin/emails/search")
+	query := opt.getURLQuery()
+	if opt.Query != "" {
+		query.Add("q", opt.Query)
+	}
+	link.RawQuery = query.Encode()
+
+	emails := make([]*Email, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &emails)
+	return emails, resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/admin_hooks.go
+++ b/vendor/code.gitea.io/sdk/gitea/admin_hooks.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// ListAdminHooksOptions options for listing admin hooks
+type ListAdminHooksOptions struct {
+	ListOptions
+	// Type of hooks to list: system, default, or all
+	Type string `json:"type,omitempty"`
+}
+
+// ListAdminHooks lists all system webhooks
+func (c *Client) ListAdminHooks(opt ListAdminHooksOptions) ([]*Hook, *Response, error) {
+	opt.setDefaults()
+
+	link, _ := url.Parse("/admin/hooks")
+	query := opt.getURLQuery()
+	if opt.Type != "" {
+		query.Add("type", opt.Type)
+	}
+	link.RawQuery = query.Encode()
+
+	hooks := make([]*Hook, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &hooks)
+	return hooks, resp, err
+}
+
+// CreateAdminHook creates a system webhook
+func (c *Client) CreateAdminHook(opt CreateHookOption) (*Hook, *Response, error) {
+	if err := opt.Validate(); err != nil {
+		return nil, nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	hook := new(Hook)
+	resp, err := c.getParsedResponse("POST", "/admin/hooks", jsonHeader, bytes.NewReader(body), hook)
+	return hook, resp, err
+}
+
+// GetAdminHook gets a system webhook by ID
+func (c *Client) GetAdminHook(id int64) (*Hook, *Response, error) {
+	hook := new(Hook)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/admin/hooks/%d", id), jsonHeader, nil, hook)
+	return hook, resp, err
+}
+
+// EditAdminHook edits a system webhook
+func (c *Client) EditAdminHook(id int64, opt EditHookOption) (*Hook, *Response, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	hook := new(Hook)
+	resp, err := c.getParsedResponse("PATCH", fmt.Sprintf("/admin/hooks/%d", id), jsonHeader, bytes.NewReader(body), hook)
+	return hook, resp, err
+}
+
+// DeleteAdminHook deletes a system webhook
+func (c *Client) DeleteAdminHook(id int64) (*Response, error) {
+	status, resp, err := c.getStatusCode("DELETE", fmt.Sprintf("/admin/hooks/%d", id), jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}

--- a/vendor/code.gitea.io/sdk/gitea/admin_repo.go
+++ b/vendor/code.gitea.io/sdk/gitea/admin_repo.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 )
 
 // AdminCreateRepo create a repo
@@ -22,4 +23,46 @@ func (c *Client) AdminCreateRepo(user string, opt CreateRepoOption) (*Repository
 	repo := new(Repository)
 	resp, err := c.getParsedResponse("POST", fmt.Sprintf("/admin/users/%s/repos", user), jsonHeader, bytes.NewReader(body), repo)
 	return repo, resp, err
+}
+
+// ListUnadoptedReposOptions options for listing unadopted repositories
+type ListUnadoptedReposOptions struct {
+	ListOptions
+	Pattern string `json:"pattern,omitempty"`
+}
+
+// ListUnadoptedRepos lists unadopted repositories
+func (c *Client) ListUnadoptedRepos(opt ListUnadoptedReposOptions) ([]string, *Response, error) {
+	opt.setDefaults()
+
+	link, _ := url.Parse("/admin/unadopted")
+	query := opt.getURLQuery()
+	if opt.Pattern != "" {
+		query.Add("pattern", opt.Pattern)
+	}
+	link.RawQuery = query.Encode()
+
+	repos := make([]string, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &repos)
+	return repos, resp, err
+}
+
+// AdoptUnadoptedRepo adopts an unadopted repository
+func (c *Client) AdoptUnadoptedRepo(owner, repo string) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+	return c.doRequestWithStatusHandle("POST",
+		fmt.Sprintf("/admin/unadopted/%s/%s", owner, repo),
+		jsonHeader, nil)
+}
+
+// DeleteUnadoptedRepo deletes an unadopted repository
+func (c *Client) DeleteUnadoptedRepo(owner, repo string) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+	return c.doRequestWithStatusHandle("DELETE",
+		fmt.Sprintf("/admin/unadopted/%s/%s", owner, repo),
+		jsonHeader, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/attachment.go
+++ b/vendor/code.gitea.io/sdk/gitea/attachment.go
@@ -106,6 +106,5 @@ func (c *Client) DeleteReleaseAttachment(user, repo string, release, id int64) (
 	if err := escapeValidatePathSegments(&user, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/releases/%d/assets/%d", user, repo, release, id), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/releases/%d/assets/%d", user, repo, release, id), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/git_hook.go
+++ b/vendor/code.gitea.io/sdk/gitea/git_hook.go
@@ -57,8 +57,7 @@ func (c *Client) EditRepoGitHook(user, repo, id string, opt EditGitHookOption) (
 	if err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PATCH", fmt.Sprintf("/repos/%s/%s/hooks/git/%s", user, repo, id), jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("PATCH", fmt.Sprintf("/repos/%s/%s/hooks/git/%s", user, repo, id), jsonHeader, bytes.NewReader(body))
 }
 
 // DeleteRepoGitHook delete one Git hook from a repository
@@ -66,6 +65,5 @@ func (c *Client) DeleteRepoGitHook(user, repo, id string) (*Response, error) {
 	if err := escapeValidatePathSegments(&user, &repo, &id); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/hooks/git/%s", user, repo, id), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/hooks/git/%s", user, repo, id), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/hook.go
+++ b/vendor/code.gitea.io/sdk/gitea/hook.go
@@ -191,8 +191,7 @@ func (c *Client) EditOrgHook(org string, id int64, opt EditHookOption) (*Respons
 	if err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PATCH", fmt.Sprintf("/orgs/%s/hooks/%d", org, id), jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("PATCH", fmt.Sprintf("/orgs/%s/hooks/%d", org, id), jsonHeader, bytes.NewReader(body))
 }
 
 // EditMyHook modify one hook of the authenticated user, with hook id and options
@@ -201,8 +200,7 @@ func (c *Client) EditMyHook(id int64, opt EditHookOption) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PATCH", fmt.Sprintf("/user/hooks/%d", id), jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("PATCH", fmt.Sprintf("/user/hooks/%d", id), jsonHeader, bytes.NewReader(body))
 }
 
 // EditRepoHook modify one hook of a repository, with hook id and options
@@ -214,8 +212,7 @@ func (c *Client) EditRepoHook(user, repo string, id int64, opt EditHookOption) (
 	if err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PATCH", fmt.Sprintf("/repos/%s/%s/hooks/%d", user, repo, id), jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("PATCH", fmt.Sprintf("/repos/%s/%s/hooks/%d", user, repo, id), jsonHeader, bytes.NewReader(body))
 }
 
 // DeleteOrgHook delete one hook from an organization, with hook id
@@ -223,14 +220,12 @@ func (c *Client) DeleteOrgHook(org string, id int64) (*Response, error) {
 	if err := escapeValidatePathSegments(&org); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/orgs/%s/hooks/%d", org, id), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/orgs/%s/hooks/%d", org, id), nil, nil)
 }
 
 // DeleteMyHook delete one hook from the authenticated user, with hook id
 func (c *Client) DeleteMyHook(id int64) (*Response, error) {
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/user/hooks/%d", id), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/user/hooks/%d", id), nil, nil)
 }
 
 // DeleteRepoHook delete one hook from a repository, with hook id
@@ -238,6 +233,5 @@ func (c *Client) DeleteRepoHook(user, repo string, id int64) (*Response, error) 
 	if err := escapeValidatePathSegments(&user, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/hooks/%d", user, repo, id), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/hooks/%d", user, repo, id), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/httpsign.go
+++ b/vendor/code.gitea.io/sdk/gitea/httpsign.go
@@ -147,7 +147,7 @@ func (c *Client) SignRequest(r *http.Request) error {
 
 	if c.httpsigner.cert {
 		// add our certificate to the headers to sign
-		pubkey, _ := ssh.ParsePublicKey(c.httpsigner.Signer.PublicKey().Marshal())
+		pubkey, _ := ssh.ParsePublicKey(c.httpsigner.PublicKey().Marshal())
 		if cert, ok := pubkey.(*ssh.Certificate); ok {
 			certString := base64.RawStdEncoding.EncodeToString(cert.Marshal())
 			r.Header.Add("x-ssh-certificate", certString)
@@ -175,17 +175,26 @@ func (c *Client) SignRequest(r *http.Request) error {
 	}
 
 	// create a signer for the request and headers, the signature will be valid for 10 seconds
-	var (
-		signer httpsig.SSHSigner
-		err    error
-	)
+	var err error
 
 	// use legacyhttpsig to sign with RSA-SHA1 on older gitea releases
 	if err = c.checkServerVersionGreaterThanOrEqual(version1_23_0); err != nil {
-		signer, _, err = legacyhttpsig.NewSSHSigner(c.httpsigner.Signer, httpsig.DigestSha512, headersToSign, legacyhttpsig.Signature, 10)
-	} else {
-		signer, _, err = httpsig.NewSSHSigner(c.httpsigner.Signer, httpsig.DigestSha512, headersToSign, httpsig.Signature, 10)
+		// Legacy signer
+		legacySigner, _, err := legacyhttpsig.NewSSHSigner(c.httpsigner, httpsig.DigestSha512, headersToSign, legacyhttpsig.Signature, 10)
+		if err != nil {
+			return fmt.Errorf("legacy httpsig.NewSSHSigner failed: %s", err)
+		}
+
+		// sign the request, use the fingerprint if we don't have a certificate
+		keyID := "gitea"
+		if !c.httpsigner.cert {
+			keyID = ssh.FingerprintSHA256(c.httpsigner.PublicKey())
+		}
+
+		return legacySigner.SignRequest(keyID, r, contents)
 	}
+	// Modern signer
+	modernSigner, _, err := httpsig.NewSSHSigner(c.httpsigner, httpsig.DigestSha512, headersToSign, httpsig.Signature, 10)
 	if err != nil {
 		return fmt.Errorf("httpsig.NewSSHSigner failed: %s", err)
 	}
@@ -193,15 +202,10 @@ func (c *Client) SignRequest(r *http.Request) error {
 	// sign the request, use the fingerprint if we don't have a certificate
 	keyID := "gitea"
 	if !c.httpsigner.cert {
-		keyID = ssh.FingerprintSHA256(c.httpsigner.Signer.PublicKey())
+		keyID = ssh.FingerprintSHA256(c.httpsigner.PublicKey())
 	}
 
-	err = signer.SignRequest(keyID, r, contents)
-	if err != nil {
-		return fmt.Errorf("httpsig.Signrequest failed: %s", err)
-	}
-
-	return nil
+	return modernSigner.SignRequest(keyID, r, contents)
 }
 
 // findCertSigner returns the Signer containing a valid certificate

--- a/vendor/code.gitea.io/sdk/gitea/issue.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue.go
@@ -294,10 +294,9 @@ func (c *Client) DeleteIssue(user, repo string, id int64) (*Response, error) {
 	if err := escapeValidatePathSegments(&user, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE",
+	return c.doRequestWithStatusHandle("DELETE",
 		fmt.Sprintf("/repos/%s/%s/issues/%d", user, repo, id),
 		nil, nil)
-	return resp, err
 }
 
 func (c *Client) issueBackwardsCompatibility(issue *Issue) {

--- a/vendor/code.gitea.io/sdk/gitea/issue_comment.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue_comment.go
@@ -149,6 +149,42 @@ func (c *Client) DeleteIssueComment(owner, repo string, commentID int64) (*Respo
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/issues/comments/%d", owner, repo, commentID), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/issues/comments/%d", owner, repo, commentID), nil, nil)
+}
+
+// GetIssueCommentAttachment gets a comment attachment
+func (c *Client) GetIssueCommentAttachment(owner, repo string, commentID, attachmentID int64) (*Attachment, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	attachment := new(Attachment)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/issues/comments/%d/assets/%d", owner, repo, commentID, attachmentID),
+		nil, nil, &attachment)
+	return attachment, resp, err
+}
+
+// EditIssueCommentAttachment updates a comment attachment
+func (c *Client) EditIssueCommentAttachment(owner, repo string, commentID, attachmentID int64, form EditAttachmentOptions) (*Attachment, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	body, err := json.Marshal(&form)
+	if err != nil {
+		return nil, nil, err
+	}
+	attachment := new(Attachment)
+	resp, err := c.getParsedResponse("PATCH",
+		fmt.Sprintf("/repos/%s/%s/issues/comments/%d/assets/%d", owner, repo, commentID, attachmentID),
+		jsonHeader, bytes.NewReader(body), attachment)
+	return attachment, resp, err
+}
+
+// DeleteIssueCommentAttachment deletes a comment attachment
+func (c *Client) DeleteIssueCommentAttachment(owner, repo string, commentID, attachmentID int64) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+	return c.doRequestWithStatusHandle("DELETE",
+		fmt.Sprintf("/repos/%s/%s/issues/comments/%d/assets/%d", owner, repo, commentID, attachmentID), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/issue_ext.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue_ext.go
@@ -1,0 +1,178 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// IssueBlockedBy represents an issue that blocks another issue
+type IssueBlockedBy struct {
+	Index     int64     `json:"index"`
+	Title     string    `json:"title"`
+	State     string    `json:"state"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// ListIssueBlocks lists issues that are blocked by the specified issue
+func (c *Client) ListIssueBlocks(owner, repo string, index int64) ([]*Issue, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	issues := make([]*Issue, 0, 5)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/blocks", owner, repo, index),
+		jsonHeader, nil, &issues)
+	return issues, resp, err
+}
+
+// IssueMeta represents issue reference for blocking/dependency operations
+type IssueMeta struct {
+	Index int64 `json:"index"`
+}
+
+// CreateIssueBlocking blocks an issue with another issue
+func (c *Client) CreateIssueBlocking(owner, repo string, index int64, opt IssueMeta) (*Issue, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	issue := new(Issue)
+	resp, err := c.getParsedResponse("POST",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/blocks", owner, repo, index),
+		jsonHeader, bytes.NewReader(body), &issue)
+	return issue, resp, err
+}
+
+// RemoveIssueBlocking removes an issue block
+func (c *Client) RemoveIssueBlocking(owner, repo string, index int64, opt IssueMeta) (*Issue, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	issue := new(Issue)
+	resp, err := c.getParsedResponse("DELETE",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/blocks", owner, repo, index),
+		jsonHeader, bytes.NewReader(body), &issue)
+	return issue, resp, err
+}
+
+// GetIssueDependencies lists issues that block the specified issue (its dependencies)
+func (c *Client) GetIssueDependencies(owner, repo string, index int64) ([]*Issue, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	issues := make([]*Issue, 0, 5)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/dependencies", owner, repo, index),
+		jsonHeader, nil, &issues)
+	return issues, resp, err
+}
+
+// CreateIssueDependency creates a new issue dependency
+func (c *Client) CreateIssueDependency(owner, repo string, index int64, opt IssueMeta) (*Issue, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	issue := new(Issue)
+	resp, err := c.getParsedResponse("POST",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/dependencies", owner, repo, index),
+		jsonHeader, bytes.NewReader(body), &issue)
+	return issue, resp, err
+}
+
+// RemoveIssueDependency removes an issue dependency
+func (c *Client) RemoveIssueDependency(owner, repo string, index int64, opt IssueMeta) (*Issue, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	issue := new(Issue)
+	resp, err := c.getParsedResponse("DELETE",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/dependencies", owner, repo, index),
+		jsonHeader, bytes.NewReader(body), &issue)
+	return issue, resp, err
+}
+
+// LockIssueOption represents options for locking an issue
+type LockIssueOption struct {
+	LockReason string `json:"lock_reason"`
+}
+
+// LockIssue locks an issue
+func (c *Client) LockIssue(owner, repo string, index int64, opt LockIssueOption) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("PUT",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/lock", owner, repo, index),
+		jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// UnlockIssue unlocks an issue
+func (c *Client) UnlockIssue(owner, repo string, index int64) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("DELETE",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/lock", owner, repo, index),
+		jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// EditDeadlineOption represents options for updating issue deadline
+type EditDeadlineOption struct {
+	Deadline *time.Time `json:"due_date"`
+}
+
+// UpdateIssueDeadline updates an issue's deadline
+func (c *Client) UpdateIssueDeadline(owner, repo string, index int64, opt EditDeadlineOption) (*Issue, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	issue := new(Issue)
+	resp, err := c.getParsedResponse("POST",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/deadline", owner, repo, index),
+		jsonHeader, bytes.NewReader(body), &issue)
+	return issue, resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/issue_label.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue_label.go
@@ -8,144 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"regexp"
-	"strings"
 )
-
-// Label a label to an issue or a pr
-type Label struct {
-	ID   int64  `json:"id"`
-	Name string `json:"name"`
-	// example: 00aabb
-	Color       string `json:"color"`
-	Description string `json:"description"`
-	URL         string `json:"url"`
-}
-
-// ListLabelsOptions options for listing repository's labels
-type ListLabelsOptions struct {
-	ListOptions
-}
-
-// ListRepoLabels list labels of one repository
-func (c *Client) ListRepoLabels(owner, repo string, opt ListLabelsOptions) ([]*Label, *Response, error) {
-	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
-		return nil, nil, err
-	}
-	opt.setDefaults()
-	labels := make([]*Label, 0, opt.PageSize)
-	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/labels?%s", owner, repo, opt.getURLQuery().Encode()), nil, nil, &labels)
-	return labels, resp, err
-}
-
-// GetRepoLabel get one label of repository by repo it
-func (c *Client) GetRepoLabel(owner, repo string, id int64) (*Label, *Response, error) {
-	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
-		return nil, nil, err
-	}
-	label := new(Label)
-	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/labels/%d", owner, repo, id), nil, nil, label)
-	return label, resp, err
-}
-
-// CreateLabelOption options for creating a label
-type CreateLabelOption struct {
-	Name string `json:"name"`
-	// example: #00aabb
-	Color       string `json:"color"`
-	Description string `json:"description"`
-}
-
-// Validate the CreateLabelOption struct
-func (opt CreateLabelOption) Validate() error {
-	aw, err := regexp.MatchString("^#?[0-9,a-f,A-F]{6}$", opt.Color)
-	if err != nil {
-		return err
-	}
-	if !aw {
-		return fmt.Errorf("invalid color format")
-	}
-	if len(strings.TrimSpace(opt.Name)) == 0 {
-		return fmt.Errorf("empty name not allowed")
-	}
-	return nil
-}
-
-// CreateLabel create one label of repository
-func (c *Client) CreateLabel(owner, repo string, opt CreateLabelOption) (*Label, *Response, error) {
-	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
-		return nil, nil, err
-	}
-	if err := opt.Validate(); err != nil {
-		return nil, nil, err
-	}
-	if len(opt.Color) == 6 {
-		if err := c.checkServerVersionGreaterThanOrEqual(version1_12_0); err != nil {
-			opt.Color = "#" + opt.Color
-		}
-	}
-	body, err := json.Marshal(&opt)
-	if err != nil {
-		return nil, nil, err
-	}
-	label := new(Label)
-	resp, err := c.getParsedResponse("POST",
-		fmt.Sprintf("/repos/%s/%s/labels", owner, repo),
-		jsonHeader, bytes.NewReader(body), label)
-	return label, resp, err
-}
-
-// EditLabelOption options for editing a label
-type EditLabelOption struct {
-	Name        *string `json:"name"`
-	Color       *string `json:"color"`
-	Description *string `json:"description"`
-}
-
-// Validate the EditLabelOption struct
-func (opt EditLabelOption) Validate() error {
-	if opt.Color != nil {
-		aw, err := regexp.MatchString("^#?[0-9,a-f,A-F]{6}$", *opt.Color)
-		if err != nil {
-			return err
-		}
-		if !aw {
-			return fmt.Errorf("invalid color format")
-		}
-	}
-	if opt.Name != nil {
-		if len(strings.TrimSpace(*opt.Name)) == 0 {
-			return fmt.Errorf("empty name not allowed")
-		}
-	}
-	return nil
-}
-
-// EditLabel modify one label with options
-func (c *Client) EditLabel(owner, repo string, id int64, opt EditLabelOption) (*Label, *Response, error) {
-	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
-		return nil, nil, err
-	}
-	if err := opt.Validate(); err != nil {
-		return nil, nil, err
-	}
-	body, err := json.Marshal(&opt)
-	if err != nil {
-		return nil, nil, err
-	}
-	label := new(Label)
-	resp, err := c.getParsedResponse("PATCH", fmt.Sprintf("/repos/%s/%s/labels/%d", owner, repo, id), jsonHeader, bytes.NewReader(body), label)
-	return label, resp, err
-}
-
-// DeleteLabel delete one label of repository by id
-func (c *Client) DeleteLabel(owner, repo string, id int64) (*Response, error) {
-	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
-		return nil, err
-	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/labels/%d", owner, repo, id), nil, nil)
-	return resp, err
-}
 
 // GetIssueLabels get labels of one issue via issue id
 func (c *Client) GetIssueLabels(owner, repo string, index int64, opts ListLabelsOptions) ([]*Label, *Response, error) {
@@ -197,8 +60,7 @@ func (c *Client) DeleteIssueLabel(owner, repo string, index, label int64) (*Resp
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%d", owner, repo, index, label), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%d", owner, repo, index, label), nil, nil)
 }
 
 // ClearIssueLabels delete all the labels of one issue.
@@ -206,6 +68,5 @@ func (c *Client) ClearIssueLabels(owner, repo string, index int64) (*Response, e
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, index), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, index), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/issue_milestone.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue_milestone.go
@@ -192,8 +192,7 @@ func (c *Client) DeleteMilestone(owner, repo string, id int64) (*Response, error
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/milestones/%d", owner, repo, id), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/milestones/%d", owner, repo, id), nil, nil)
 }
 
 // DeleteMilestoneByName delete one milestone by name
@@ -209,8 +208,7 @@ func (c *Client) DeleteMilestoneByName(owner, repo, name string) (*Response, err
 	if err := escapeValidatePathSegments(&owner, &repo, &name); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/milestones/%s", owner, repo, name), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/milestones/%s", owner, repo, name), nil, nil)
 }
 
 // resolveMilestoneByName is a fallback method to find milestone id by name

--- a/vendor/code.gitea.io/sdk/gitea/issue_pin.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue_pin.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ListRepoPinnedIssues lists a repo's pinned issues
+func (c *Client) ListRepoPinnedIssues(owner, repo string) ([]*Issue, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	issues := make([]*Issue, 0, 5)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/issues/pinned", owner, repo),
+		jsonHeader, nil, &issues)
+	return issues, resp, err
+}
+
+// PinIssue pins an issue
+func (c *Client) PinIssue(owner, repo string, index int64) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("POST",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/pin", owner, repo, index),
+		jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// UnpinIssue unpins an issue
+func (c *Client) UnpinIssue(owner, repo string, index int64) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("DELETE",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/pin", owner, repo, index),
+		jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// MoveIssuePin moves a pinned issue to the given position
+func (c *Client) MoveIssuePin(owner, repo string, index, position int64) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("PATCH",
+		fmt.Sprintf("/repos/%s/%s/issues/%d/pin/%d", owner, repo, index, position),
+		jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}

--- a/vendor/code.gitea.io/sdk/gitea/issue_reaction.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue_reaction.go
@@ -68,8 +68,7 @@ func (c *Client) DeleteIssueReaction(owner, repo string, index int64, reaction s
 	if err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/reactions", owner, repo, index), jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/reactions", owner, repo, index), jsonHeader, bytes.NewReader(body))
 }
 
 // PostIssueCommentReaction add a reaction to a comment of an issue
@@ -97,8 +96,7 @@ func (c *Client) DeleteIssueCommentReaction(owner, repo string, commentID int64,
 	if err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE",
+	return c.doRequestWithStatusHandle("DELETE",
 		fmt.Sprintf("/repos/%s/%s/issues/comments/%d/reactions", owner, repo, commentID),
 		jsonHeader, bytes.NewReader(body))
-	return resp, err
 }

--- a/vendor/code.gitea.io/sdk/gitea/issue_stopwatch.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue_stopwatch.go
@@ -32,8 +32,7 @@ func (c *Client) DeleteIssueStopwatch(owner, repo string, index int64) (*Respons
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/stopwatch/delete", owner, repo, index), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/stopwatch/delete", owner, repo, index), nil, nil)
 }
 
 // StartIssueStopWatch starts a stopwatch for an existing issue for a given
@@ -42,8 +41,7 @@ func (c *Client) StartIssueStopWatch(owner, repo string, index int64) (*Response
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("POST", fmt.Sprintf("/repos/%s/%s/issues/%d/stopwatch/start", owner, repo, index), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("POST", fmt.Sprintf("/repos/%s/%s/issues/%d/stopwatch/start", owner, repo, index), nil, nil)
 }
 
 // StopIssueStopWatch stops an existing stopwatch for an issue in a given
@@ -52,6 +50,5 @@ func (c *Client) StopIssueStopWatch(owner, repo string, index int64) (*Response,
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("POST", fmt.Sprintf("/repos/%s/%s/issues/%d/stopwatch/stop", owner, repo, index), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("POST", fmt.Sprintf("/repos/%s/%s/issues/%d/stopwatch/stop", owner, repo, index), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/issue_tracked_time.go
+++ b/vendor/code.gitea.io/sdk/gitea/issue_tracked_time.go
@@ -128,8 +128,7 @@ func (c *Client) ResetIssueTime(owner, repo string, index int64) (*Response, err
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/times", owner, repo, index), jsonHeader, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/times", owner, repo, index), jsonHeader, nil)
 }
 
 // DeleteTime delete a specific tracked time by id of a single issue for a given repository
@@ -137,6 +136,5 @@ func (c *Client) DeleteTime(owner, repo string, index, timeID int64) (*Response,
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/times/%d", owner, repo, index, timeID), jsonHeader, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/issues/%d/times/%d", owner, repo, index, timeID), jsonHeader, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/miscellaneous.go
+++ b/vendor/code.gitea.io/sdk/gitea/miscellaneous.go
@@ -1,0 +1,234 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// GitignoreTemplateInfo represents a gitignore template
+type GitignoreTemplateInfo struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+}
+
+// LabelTemplate represents a label template
+type LabelTemplate struct {
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+	Exclusive   bool   `json:"exclusive"`
+}
+
+// LicensesTemplateListEntry represents a license in the list
+type LicensesTemplateListEntry struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// LicenseTemplateInfo represents a license template
+type LicenseTemplateInfo struct {
+	Key            string `json:"key"`
+	Name           string `json:"name"`
+	URL            string `json:"url"`
+	Body           string `json:"body"`
+	Implementation string `json:"implementation"`
+}
+
+// MarkdownOption represents options for rendering markdown
+type MarkdownOption struct {
+	Text    string `json:"Text"`
+	Mode    string `json:"Mode"`
+	Context string `json:"Context"`
+	Wiki    bool   `json:"Wiki"`
+}
+
+// MarkupOption represents options for rendering markup
+type MarkupOption struct {
+	Text     string `json:"Text"`
+	Mode     string `json:"Mode"`
+	Context  string `json:"Context"`
+	FilePath string `json:"FilePath"`
+	Wiki     bool   `json:"Wiki"`
+}
+
+// NodeInfo represents nodeinfo about the server
+type NodeInfo struct {
+	Version           string                 `json:"version"`
+	Software          NodeInfoSoftware       `json:"software"`
+	Protocols         []string               `json:"protocols"`
+	Services          NodeInfoServices       `json:"services"`
+	OpenRegistrations bool                   `json:"openRegistrations"`
+	Usage             NodeInfoUsage          `json:"usage"`
+	Metadata          map[string]interface{} `json:"metadata"`
+}
+
+// NodeInfoSoftware represents software information
+type NodeInfoSoftware struct {
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	Repository string `json:"repository"`
+	Homepage   string `json:"homepage"`
+}
+
+// NodeInfoServices represents third party services
+type NodeInfoServices struct {
+	Inbound  []string `json:"inbound"`
+	Outbound []string `json:"outbound"`
+}
+
+// NodeInfoUsage represents usage statistics
+type NodeInfoUsage struct {
+	Users         NodeInfoUsageUsers `json:"users"`
+	LocalPosts    int64              `json:"localPosts"`
+	LocalComments int64              `json:"localComments"`
+}
+
+// NodeInfoUsageUsers represents user statistics
+type NodeInfoUsageUsers struct {
+	Total          int64 `json:"total"`
+	ActiveHalfyear int64 `json:"activeHalfyear"`
+	ActiveMonth    int64 `json:"activeMonth"`
+}
+
+// ListGitignoresTemplates lists all gitignore templates
+func (c *Client) ListGitignoresTemplates() ([]string, *Response, error) {
+	templates := make([]string, 0, 10)
+	resp, err := c.getParsedResponse("GET", "/gitignore/templates", jsonHeader, nil, &templates)
+	return templates, resp, err
+}
+
+// GetGitignoreTemplateInfo gets information about a gitignore template
+func (c *Client) GetGitignoreTemplateInfo(name string) (*GitignoreTemplateInfo, *Response, error) {
+	if err := escapeValidatePathSegments(&name); err != nil {
+		return nil, nil, err
+	}
+	template := new(GitignoreTemplateInfo)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/gitignore/templates/%s", name),
+		jsonHeader, nil, &template)
+	return template, resp, err
+}
+
+// ListLabelTemplates lists all label templates
+func (c *Client) ListLabelTemplates() ([]string, *Response, error) {
+	templates := make([]string, 0, 10)
+	resp, err := c.getParsedResponse("GET", "/label/templates", jsonHeader, nil, &templates)
+	return templates, resp, err
+}
+
+// GetLabelTemplate gets all labels in a template
+func (c *Client) GetLabelTemplate(name string) ([]*LabelTemplate, *Response, error) {
+	if err := escapeValidatePathSegments(&name); err != nil {
+		return nil, nil, err
+	}
+	labels := make([]*LabelTemplate, 0, 10)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/label/templates/%s", name),
+		jsonHeader, nil, &labels)
+	return labels, resp, err
+}
+
+// ListLicenseTemplates lists all license templates
+func (c *Client) ListLicenseTemplates() ([]*LicensesTemplateListEntry, *Response, error) {
+	licenses := make([]*LicensesTemplateListEntry, 0, 10)
+	resp, err := c.getParsedResponse("GET", "/licenses", jsonHeader, nil, &licenses)
+	return licenses, resp, err
+}
+
+// GetLicenseTemplateInfo gets information about a license template
+func (c *Client) GetLicenseTemplateInfo(name string) (*LicenseTemplateInfo, *Response, error) {
+	if err := escapeValidatePathSegments(&name); err != nil {
+		return nil, nil, err
+	}
+	license := new(LicenseTemplateInfo)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/licenses/%s", name),
+		jsonHeader, nil, &license)
+	return license, resp, err
+}
+
+// RenderMarkdown renders a markdown document as HTML
+func (c *Client) RenderMarkdown(opt MarkdownOption) (string, *Response, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return "", nil, err
+	}
+
+	resp, err := c.doRequest("POST", "/markdown", jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return "", resp, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	html, err := io.ReadAll(resp.Body)
+	return string(html), resp, err
+}
+
+// RenderMarkdownRaw renders raw markdown as HTML
+func (c *Client) RenderMarkdownRaw(markdown string) (string, *Response, error) {
+	resp, err := c.doRequest("POST", "/markdown/raw",
+		map[string][]string{"Content-Type": {"text/plain"}},
+		bytes.NewReader([]byte(markdown)))
+	if err != nil {
+		return "", resp, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	html, err := io.ReadAll(resp.Body)
+	return string(html), resp, err
+}
+
+// RenderMarkup renders a markup document as HTML
+func (c *Client) RenderMarkup(opt MarkupOption) (string, *Response, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return "", nil, err
+	}
+
+	resp, err := c.doRequest("POST", "/markup", jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return "", resp, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	html, err := io.ReadAll(resp.Body)
+	return string(html), resp, err
+}
+
+// GetNodeInfo gets the nodeinfo of the Gitea application
+func (c *Client) GetNodeInfo() (*NodeInfo, *Response, error) {
+	nodeInfo := new(NodeInfo)
+	resp, err := c.getParsedResponse("GET", "/nodeinfo", jsonHeader, nil, &nodeInfo)
+	return nodeInfo, resp, err
+}
+
+// GetSigningKeyGPG gets the default GPG signing key
+func (c *Client) GetSigningKeyGPG() (string, *Response, error) {
+	resp, err := c.doRequest("GET", "/signing-key.gpg", nil, nil)
+	if err != nil {
+		return "", resp, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	key, err := io.ReadAll(resp.Body)
+	return string(key), resp, err
+}
+
+// GetSigningKeySSH gets the default SSH signing key
+func (c *Client) GetSigningKeySSH() (string, *Response, error) {
+	resp, err := c.doRequest("GET", "/signing-key.pub", nil, nil)
+	if err != nil {
+		return "", resp, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	key, err := io.ReadAll(resp.Body)
+	return string(key), resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/notifications.go
+++ b/vendor/code.gitea.io/sdk/gitea/notifications.go
@@ -174,7 +174,7 @@ func (c *Client) ReadNotification(id int64, status ...NotifyStatus) (*Notificati
 		resp, err := c.getParsedResponse("PATCH", link, nil, nil, thread)
 		return thread, resp, err
 	}
-	_, resp, err := c.getResponse("PATCH", link, nil, nil)
+	resp, err := c.doRequestWithStatusHandle("PATCH", link, nil, nil)
 	return nil, resp, err
 }
 
@@ -210,7 +210,7 @@ func (c *Client) ReadNotifications(opt MarkNotificationOptions) ([]*Notification
 		resp, err := c.getParsedResponse("PUT", link.String(), nil, nil, &threads)
 		return threads, resp, err
 	}
-	_, resp, err := c.getResponse("PUT", link.String(), nil, nil)
+	resp, err := c.doRequestWithStatusHandle("PUT", link.String(), nil, nil)
 	return nil, resp, err
 }
 
@@ -252,6 +252,6 @@ func (c *Client) ReadRepoNotifications(owner, repo string, opt MarkNotificationO
 		resp, err := c.getParsedResponse("PUT", link.String(), nil, nil, &threads)
 		return threads, resp, err
 	}
-	_, resp, err := c.getResponse("PUT", link.String(), nil, nil)
+	resp, err := c.doRequestWithStatusHandle("PUT", link.String(), nil, nil)
 	return nil, resp, err
 }

--- a/vendor/code.gitea.io/sdk/gitea/oauth2.go
+++ b/vendor/code.gitea.io/sdk/gitea/oauth2.go
@@ -88,6 +88,6 @@ func (c *Client) DeleteOauth2(oauth2id int64) (*Response, error) {
 	if err := c.checkServerVersionGreaterThanOrEqual(version1_12_0); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/user/applications/oauth2/%d", oauth2id), nil, nil)
+	resp, err := c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/user/applications/oauth2/%d", oauth2id), nil, nil)
 	return resp, err
 }

--- a/vendor/code.gitea.io/sdk/gitea/org.go
+++ b/vendor/code.gitea.io/sdk/gitea/org.go
@@ -141,8 +141,7 @@ func (c *Client) EditOrg(orgname string, opt EditOrgOption) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PATCH", fmt.Sprintf("/orgs/%s", orgname), jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("PATCH", fmt.Sprintf("/orgs/%s", orgname), jsonHeader, bytes.NewReader(body))
 }
 
 // DeleteOrg deletes an organization
@@ -150,6 +149,5 @@ func (c *Client) DeleteOrg(orgname string) (*Response, error) {
 	if err := escapeValidatePathSegments(&orgname); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/orgs/%s", orgname), jsonHeader, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/orgs/%s", orgname), jsonHeader, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/org_action.go
+++ b/vendor/code.gitea.io/sdk/gitea/org_action.go
@@ -31,10 +31,152 @@ func (c *Client) ListOrgActionSecret(org string, opt ListOrgActionSecretOption) 
 	return secrets, resp, err
 }
 
+type OrgActionVariable struct {
+	OwnerID     int64  `json:"owner_id"`
+	RepoID      int64  `json:"repo_id"`
+	Name        string `json:"name"`
+	Data        string `json:"data"`
+	Description string `json:"description"`
+}
+
+// ListOrgActionVariableOption lists OrgActionVariable options
+type ListOrgActionVariableOption struct {
+	ListOptions
+}
+
+// ListOrgActionVariable lists an organization's action variables
+func (c *Client) ListOrgActionVariable(org string, opt ListOrgActionVariableOption) ([]*OrgActionVariable, *Response, error) {
+	if err := escapeValidatePathSegments(&org); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+	variables := make([]*OrgActionVariable, 0, opt.PageSize)
+
+	link, _ := url.Parse(fmt.Sprintf("/orgs/%s/actions/variables", org))
+	link.RawQuery = opt.getURLQuery().Encode()
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &variables)
+	return variables, resp, err
+}
+
+// GetOrgActionVariable gets a single organization's action variable by name
+func (c *Client) GetOrgActionVariable(org, name string) (*OrgActionVariable, *Response, error) {
+	if err := escapeValidatePathSegments(&org, &name); err != nil {
+		return nil, nil, err
+	}
+	var variable OrgActionVariable
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/orgs/%s/actions/variables/%s", org, name),
+		jsonHeader, nil, &variable)
+	if err != nil {
+		return nil, resp, err
+	}
+	return &variable, resp, nil
+}
+
+// CreateOrgActionVariableOption represents the options for creating an org action variable.
+type CreateOrgActionVariableOption struct {
+	Name        string `json:"name"`        // Name is the name of the variable.
+	Value       string `json:"value"`       // Value is the value of the variable.
+	Description string `json:"description"` // Description is the description of the variable.
+}
+
+// Validate checks if the CreateOrgActionVariableOption is valid.
+func (opt *CreateOrgActionVariableOption) Validate() error {
+	if len(opt.Name) == 0 {
+		return fmt.Errorf("name required")
+	}
+	if len(opt.Name) > 30 {
+		return fmt.Errorf("name too long")
+	}
+	if len(opt.Value) == 0 {
+		return fmt.Errorf("value required")
+	}
+	return nil
+}
+
+// CreateOrgActionVariable creates a variable for the specified organization in the Gitea Actions.
+func (c *Client) CreateOrgActionVariable(org string, opt CreateOrgActionVariableOption) (*Response, error) {
+	if err := escapeValidatePathSegments(&org); err != nil {
+		return nil, err
+	}
+	if err := (&opt).Validate(); err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+
+	status, resp, err := c.getStatusCode("POST", fmt.Sprintf("/orgs/%s/actions/variables/%s", org, opt.Name), jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	switch status {
+	case http.StatusCreated:
+		return resp, nil
+	case http.StatusNoContent:
+		return resp, nil
+	case http.StatusNotFound:
+		return resp, fmt.Errorf("forbidden")
+	case http.StatusBadRequest:
+		return resp, fmt.Errorf("bad request")
+	default:
+		return resp, fmt.Errorf("unexpected Status: %d", status)
+	}
+}
+
+// UpdateOrgActionVariableOption represents the options for updating an org action variable.
+type UpdateOrgActionVariableOption struct {
+	Value       string `json:"value"`       // Value is the new value of the variable.
+	Description string `json:"description"` // Description is the new description of the variable.
+}
+
+// Validate checks if the UpdateOrgActionVariableOption is valid.
+func (opt *UpdateOrgActionVariableOption) Validate() error {
+	if len(opt.Value) == 0 {
+		return fmt.Errorf("value required")
+	}
+	return nil
+}
+
+// UpdateOrgActionVariable updates a variable for the specified organization in the Gitea Actions.
+func (c *Client) UpdateOrgActionVariable(org, name string, opt UpdateOrgActionVariableOption) (*Response, error) {
+	if err := escapeValidatePathSegments(&org, &name); err != nil {
+		return nil, err
+	}
+	if err := (&opt).Validate(); err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+
+	status, resp, err := c.getStatusCode("PUT", fmt.Sprintf("/orgs/%s/actions/variables/%s", org, name), jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	switch status {
+	case http.StatusOK:
+		return resp, nil
+	case http.StatusNoContent:
+		return resp, nil
+	case http.StatusNotFound:
+		return resp, fmt.Errorf("forbidden")
+	case http.StatusBadRequest:
+		return resp, fmt.Errorf("bad request")
+	default:
+		return resp, fmt.Errorf("unexpected Status: %d", status)
+	}
+}
+
 // CreateSecretOption represents the options for creating a secret.
 type CreateSecretOption struct {
-	Name string `json:"name"` // Name is the name of the secret.
-	Data string `json:"data"` // Data is the data of the secret.
+	Name        string `json:"name"`        // Name is the name of the secret.
+	Data        string `json:"data"`        // Data is the data of the secret.
+	Description string `json:"description"` // Description is the description of the secret.
 }
 
 // Validate checks if the CreateSecretOption is valid.

--- a/vendor/code.gitea.io/sdk/gitea/org_block.go
+++ b/vendor/code.gitea.io/sdk/gitea/org_block.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// ListOrgBlocksOptions options for listing organization blocks
+type ListOrgBlocksOptions struct {
+	ListOptions
+}
+
+// ListOrgBlocks lists users blocked by the organization
+func (c *Client) ListOrgBlocks(org string, opt ListOrgBlocksOptions) ([]*User, *Response, error) {
+	if err := escapeValidatePathSegments(&org); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+
+	link, _ := url.Parse(fmt.Sprintf("/orgs/%s/blocks", org))
+	link.RawQuery = opt.getURLQuery().Encode()
+
+	users := make([]*User, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &users)
+	return users, resp, err
+}
+
+// CheckOrgBlock checks if a user is blocked by the organization
+func (c *Client) CheckOrgBlock(org, username string) (bool, *Response, error) {
+	if err := escapeValidatePathSegments(&org, &username); err != nil {
+		return false, nil, err
+	}
+	status, resp, err := c.getStatusCode("GET",
+		fmt.Sprintf("/orgs/%s/blocks/%s", org, username),
+		jsonHeader, nil)
+	if err != nil {
+		return false, resp, err
+	}
+	return status == http.StatusNoContent, resp, nil
+}
+
+// BlockOrgUser blocks a user from the organization
+func (c *Client) BlockOrgUser(org, username string) (*Response, error) {
+	if err := escapeValidatePathSegments(&org, &username); err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("PUT",
+		fmt.Sprintf("/orgs/%s/blocks/%s", org, username),
+		jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// UnblockOrgUser unblocks a user from the organization
+func (c *Client) UnblockOrgUser(org, username string) (*Response, error) {
+	if err := escapeValidatePathSegments(&org, &username); err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("DELETE",
+		fmt.Sprintf("/orgs/%s/blocks/%s", org, username),
+		jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}

--- a/vendor/code.gitea.io/sdk/gitea/org_label.go
+++ b/vendor/code.gitea.io/sdk/gitea/org_label.go
@@ -1,0 +1,116 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// ListOrgLabelsOptions options for listing organization labels
+type ListOrgLabelsOptions struct {
+	ListOptions
+}
+
+// ListOrgLabels returns the labels defined at the org level
+func (c *Client) ListOrgLabels(orgName string, opt ListOrgLabelsOptions) ([]*Label, *Response, error) {
+	if err := escapeValidatePathSegments(&orgName); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+	labels := make([]*Label, 0, opt.PageSize)
+	link, _ := url.Parse(fmt.Sprintf("/orgs/%s/labels", orgName))
+	link.RawQuery = opt.getURLQuery().Encode()
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &labels)
+	return labels, resp, err
+}
+
+type CreateOrgLabelOption struct {
+	// Name of the label
+	Name string `json:"name"`
+	// Color of the label in hex format without #
+	Color string `json:"color"`
+	// Description of the label
+	Description string `json:"description"`
+	// Whether this is an exclusive label
+	Exclusive bool `json:"exclusive"`
+}
+
+// Validate the CreateLabelOption struct
+func (opt CreateOrgLabelOption) Validate() error {
+	aw, err := regexp.MatchString("^#?[0-9,a-f,A-F]{6}$", opt.Color)
+	if err != nil {
+		return err
+	}
+	if !aw {
+		return fmt.Errorf("invalid color format")
+	}
+	if len(strings.TrimSpace(opt.Name)) == 0 {
+		return fmt.Errorf("empty name not allowed")
+	}
+	return nil
+}
+
+// CreateOrgLabel creates a new label under an organization
+func (c *Client) CreateOrgLabel(orgName string, opt CreateOrgLabelOption) (*Label, *Response, error) {
+	if err := escapeValidatePathSegments(&orgName); err != nil {
+		return nil, nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	label := new(Label)
+	resp, err := c.getParsedResponse("POST", fmt.Sprintf("/orgs/%s/labels", orgName), jsonHeader, bytes.NewReader(body), label)
+	return label, resp, err
+}
+
+// GetOrgLabel get one label of organization by org it
+func (c *Client) GetOrgLabel(orgName string, labelID int64) (*Label, *Response, error) {
+	if err := escapeValidatePathSegments(&orgName); err != nil {
+		return nil, nil, err
+	}
+	label := new(Label)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/orgs/%s/labels/%d", orgName, labelID), nil, nil, label)
+	return label, resp, err
+}
+
+type EditOrgLabelOption struct {
+	// New name of the label
+	Name *string `json:"name"`
+	// New color of the label in hex format without #
+	Color *string `json:"color"`
+	// New description of the label
+	Description *string `json:"description"`
+	// Whether this is an exclusive label
+	Exclusive *bool `json:"exclusive,omitempty"`
+}
+
+// EditOrgLabel edits an existing org-level label by ID
+func (c *Client) EditOrgLabel(orgName string, labelID int64, opt EditOrgLabelOption) (*Label, *Response, error) {
+	if err := escapeValidatePathSegments(&orgName); err != nil {
+		return nil, nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	label := new(Label)
+	resp, err := c.getParsedResponse("PATCH", fmt.Sprintf("/orgs/%s/labels/%d", orgName, labelID), jsonHeader, bytes.NewReader(body), label)
+	return label, resp, err
+}
+
+// DeleteOrgLabel deletes a org label by ID
+func (c *Client) DeleteOrgLabel(orgName string, labelID int64) (*Response, error) {
+	if err := escapeValidatePathSegments(&orgName); err != nil {
+		return nil, err
+	}
+	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/orgs/%s/labels/%d", orgName, labelID), jsonHeader, nil)
+	return resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/org_member.go
+++ b/vendor/code.gitea.io/sdk/gitea/org_member.go
@@ -15,8 +15,7 @@ func (c *Client) DeleteOrgMembership(org, user string) (*Response, error) {
 	if err := escapeValidatePathSegments(&org, &user); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/orgs/%s/members/%s", org, user), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/orgs/%s/members/%s", org, user), nil, nil)
 }
 
 // ListOrgMembershipOption list OrgMembership options

--- a/vendor/code.gitea.io/sdk/gitea/org_social.go
+++ b/vendor/code.gitea.io/sdk/gitea/org_social.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// UpdateOrgAvatar updates the organization's avatar
+func (c *Client) UpdateOrgAvatar(org string, opt UpdateUserAvatarOption) (*Response, error) {
+	if err := escapeValidatePathSegments(&org); err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("POST",
+		fmt.Sprintf("/orgs/%s/avatar", org),
+		jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// DeleteOrgAvatar deletes the organization's avatar
+func (c *Client) DeleteOrgAvatar(org string) (*Response, error) {
+	if err := escapeValidatePathSegments(&org); err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("DELETE",
+		fmt.Sprintf("/orgs/%s/avatar", org),
+		jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// RenameOrgOption options for renaming an organization
+type RenameOrgOption struct {
+	NewName string `json:"new_name"`
+}
+
+// RenameOrg renames an organization
+func (c *Client) RenameOrg(org string, opt RenameOrgOption) (*Response, error) {
+	if err := escapeValidatePathSegments(&org); err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("POST",
+		fmt.Sprintf("/orgs/%s/rename", org),
+		jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// ListOrgActivityFeedsOptions options for listing organization activity feeds
+type ListOrgActivityFeedsOptions struct {
+	ListOptions
+	Date string `json:"date,omitempty"`
+}
+
+// ListOrgActivityFeeds lists the organization's activity feeds
+func (c *Client) ListOrgActivityFeeds(org string, opt ListOrgActivityFeedsOptions) ([]*Activity, *Response, error) {
+	if err := escapeValidatePathSegments(&org); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+
+	link, _ := url.Parse(fmt.Sprintf("/orgs/%s/activities/feeds", org))
+	query := opt.getURLQuery()
+	if opt.Date != "" {
+		query.Add("date", opt.Date)
+	}
+	link.RawQuery = query.Encode()
+
+	activities := make([]*Activity, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &activities)
+	return activities, resp, err
+}
+
+// ListTeamActivityFeedsOptions options for listing team activity feeds
+type ListTeamActivityFeedsOptions struct {
+	ListOptions
+	Date string `json:"date,omitempty"`
+}
+
+// ListTeamActivityFeeds lists the team's activity feeds
+func (c *Client) ListTeamActivityFeeds(teamID int64, opt ListTeamActivityFeedsOptions) ([]*Activity, *Response, error) {
+	opt.setDefaults()
+
+	link, _ := url.Parse(fmt.Sprintf("/teams/%d/activities/feeds", teamID))
+	query := opt.getURLQuery()
+	if opt.Date != "" {
+		query.Add("date", opt.Date)
+	}
+	link.RawQuery = query.Encode()
+
+	activities := make([]*Activity, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &activities)
+	return activities, resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/org_team.go
+++ b/vendor/code.gitea.io/sdk/gitea/org_team.go
@@ -202,14 +202,12 @@ func (c *Client) EditTeam(id int64, opt EditTeamOption) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PATCH", fmt.Sprintf("/teams/%d", id), jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("PATCH", fmt.Sprintf("/teams/%d", id), jsonHeader, bytes.NewReader(body))
 }
 
 // DeleteTeam deletes a team of an organization
 func (c *Client) DeleteTeam(id int64) (*Response, error) {
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/teams/%d", id), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/teams/%d", id), nil, nil)
 }
 
 // ListTeamMembersOptions options for listing team's members
@@ -240,8 +238,7 @@ func (c *Client) AddTeamMember(id int64, user string) (*Response, error) {
 	if err := escapeValidatePathSegments(&user); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PUT", fmt.Sprintf("/teams/%d/members/%s", id, user), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("PUT", fmt.Sprintf("/teams/%d/members/%s", id, user), nil, nil)
 }
 
 // RemoveTeamMember removes a member from a team
@@ -249,8 +246,7 @@ func (c *Client) RemoveTeamMember(id int64, user string) (*Response, error) {
 	if err := escapeValidatePathSegments(&user); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/teams/%d/members/%s", id, user), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/teams/%d/members/%s", id, user), nil, nil)
 }
 
 // ListTeamRepositoriesOptions options for listing team's repositories
@@ -271,8 +267,7 @@ func (c *Client) AddTeamRepository(id int64, org, repo string) (*Response, error
 	if err := escapeValidatePathSegments(&org, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PUT", fmt.Sprintf("/teams/%d/repos/%s/%s", id, org, repo), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("PUT", fmt.Sprintf("/teams/%d/repos/%s/%s", id, org, repo), nil, nil)
 }
 
 // RemoveTeamRepository removes a repository from a team
@@ -280,6 +275,5 @@ func (c *Client) RemoveTeamRepository(id int64, org, repo string) (*Response, er
 	if err := escapeValidatePathSegments(&org, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/teams/%d/repos/%s/%s", id, org, repo), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/teams/%d/repos/%s/%s", id, org, repo), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/package.go
+++ b/vendor/code.gitea.io/sdk/gitea/package.go
@@ -78,8 +78,7 @@ func (c *Client) DeletePackage(owner, packageType, name, version string) (*Respo
 	if err := escapeValidatePathSegments(&owner, &packageType, &name, &version); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/packages/%s/%s/%s/%s", owner, packageType, name, version), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/packages/%s/%s/%s/%s", owner, packageType, name, version), nil, nil)
 }
 
 // ListPackageFiles lists the files within a package
@@ -90,4 +89,30 @@ func (c *Client) ListPackageFiles(owner, packageType, name, version string) ([]*
 	packageFiles := make([]*PackageFile, 0)
 	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/packages/%s/%s/%s/%s/files", owner, packageType, name, version), nil, nil, &packageFiles)
 	return packageFiles, resp, err
+}
+
+// GetLatestPackage gets the details of the latest version of a package
+func (c *Client) GetLatestPackage(owner, packageType, name string) (*Package, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &packageType, &name); err != nil {
+		return nil, nil, err
+	}
+	foundPackage := new(Package)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/packages/%s/%s/%s/-/latest", owner, packageType, name), nil, nil, foundPackage)
+	return foundPackage, resp, err
+}
+
+// LinkPackage links a package to a repository
+func (c *Client) LinkPackage(owner, packageType, name, repoName string) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &packageType, &name, &repoName); err != nil {
+		return nil, err
+	}
+	return c.doRequestWithStatusHandle("POST", fmt.Sprintf("/packages/%s/%s/%s/-/link/%s", owner, packageType, name, repoName), nil, nil)
+}
+
+// UnlinkPackage unlinks a package from a repository
+func (c *Client) UnlinkPackage(owner, packageType, name string) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &packageType, &name); err != nil {
+		return nil, err
+	}
+	return c.doRequestWithStatusHandle("POST", fmt.Sprintf("/packages/%s/%s/%s/-/unlink", owner, packageType, name), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/pull.go
+++ b/vendor/code.gitea.io/sdk/gitea/pull.go
@@ -36,6 +36,7 @@ type PullRequest struct {
 	Assignee  *User      `json:"assignee"`
 	Assignees []*User    `json:"assignees"`
 	State     StateType  `json:"state"`
+	Draft     bool       `json:"draft"`
 	IsLocked  bool       `json:"is_locked"`
 	Comments  int        `json:"comments"`
 
@@ -149,15 +150,17 @@ func (c *Client) GetPullRequest(owner, repo string, index int64) (*PullRequest, 
 
 // CreatePullRequestOption options when creating a pull request
 type CreatePullRequestOption struct {
-	Head      string     `json:"head"`
-	Base      string     `json:"base"`
-	Title     string     `json:"title"`
-	Body      string     `json:"body"`
-	Assignee  string     `json:"assignee"`
-	Assignees []string   `json:"assignees"`
-	Milestone int64      `json:"milestone"`
-	Labels    []int64    `json:"labels"`
-	Deadline  *time.Time `json:"due_date"`
+	Head          string     `json:"head"`
+	Base          string     `json:"base"`
+	Title         string     `json:"title"`
+	Body          string     `json:"body"`
+	Assignee      string     `json:"assignee"`
+	Assignees     []string   `json:"assignees"`
+	Reviewers     []string   `json:"reviewers"`
+	TeamReviewers []string   `json:"team_reviewers"`
+	Milestone     int64      `json:"milestone"`
+	Labels        []int64    `json:"labels"`
+	Deadline      *time.Time `json:"due_date"`
 }
 
 // CreatePullRequest create pull request with options
@@ -179,7 +182,7 @@ func (c *Client) CreatePullRequest(owner, repo string, opt CreatePullRequestOpti
 // EditPullRequestOption options when modify pull request
 type EditPullRequestOption struct {
 	Title               string     `json:"title"`
-	Body                string     `json:"body"`
+	Body                *string    `json:"body"`
 	Base                string     `json:"base"`
 	Assignee            string     `json:"assignee"`
 	Assignees           []string   `json:"assignees"`

--- a/vendor/code.gitea.io/sdk/gitea/pull_review.go
+++ b/vendor/code.gitea.io/sdk/gitea/pull_review.go
@@ -202,8 +202,7 @@ func (c *Client) DeletePullReview(owner, repo string, index, id int64) (*Respons
 		return nil, err
 	}
 
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews/%d", owner, repo, index, id), jsonHeader, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews/%d", owner, repo, index, id), jsonHeader, nil)
 }
 
 // CreatePullReview create a review to an pull request
@@ -265,10 +264,9 @@ func (c *Client) CreateReviewRequests(owner, repo string, index int64, opt PullR
 		return nil, err
 	}
 
-	_, resp, err := c.getResponse("POST",
+	return c.doRequestWithStatusHandle("POST",
 		fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, index),
 		jsonHeader, bytes.NewReader(body))
-	return resp, err
 }
 
 // DeleteReviewRequests delete review requests to an pull request
@@ -284,10 +282,9 @@ func (c *Client) DeleteReviewRequests(owner, repo string, index int64, opt PullR
 		return nil, err
 	}
 
-	_, resp, err := c.getResponse("DELETE",
+	return c.doRequestWithStatusHandle("DELETE",
 		fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, index),
 		jsonHeader, bytes.NewReader(body))
-	return resp, err
 }
 
 // DismissPullReview dismiss a review for a pull request
@@ -303,10 +300,9 @@ func (c *Client) DismissPullReview(owner, repo string, index, id int64, opt Dism
 		return nil, err
 	}
 
-	_, resp, err := c.getResponse("POST",
+	return c.doRequestWithStatusHandle("POST",
 		fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews/%d/dismissals", owner, repo, index, id),
 		jsonHeader, bytes.NewReader(body))
-	return resp, err
 }
 
 // UnDismissPullReview cancel to dismiss a review for a pull request
@@ -318,8 +314,7 @@ func (c *Client) UnDismissPullReview(owner, repo string, index, id int64) (*Resp
 		return nil, err
 	}
 
-	_, resp, err := c.getResponse("POST",
+	return c.doRequestWithStatusHandle("POST",
 		fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews/%d/undismissals", owner, repo, index, id),
 		jsonHeader, nil)
-	return resp, err
 }

--- a/vendor/code.gitea.io/sdk/gitea/release.go
+++ b/vendor/code.gitea.io/sdk/gitea/release.go
@@ -173,10 +173,9 @@ func (c *Client) DeleteRelease(user, repo string, id int64) (*Response, error) {
 	if err := escapeValidatePathSegments(&user, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE",
+	return c.doRequestWithStatusHandle("DELETE",
 		fmt.Sprintf("/repos/%s/%s/releases/%d", user, repo, id),
 		nil, nil)
-	return resp, err
 }
 
 // DeleteReleaseByTag deletes a release frm a repository by tag
@@ -187,10 +186,9 @@ func (c *Client) DeleteReleaseByTag(user, repo, tag string) (*Response, error) {
 	if err := c.checkServerVersionGreaterThanOrEqual(version1_14_0); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE",
+	return c.doRequestWithStatusHandle("DELETE",
 		fmt.Sprintf("/repos/%s/%s/releases/tags/%s", user, repo, tag),
 		nil, nil)
-	return resp, err
 }
 
 // fallbackGetReleaseByTag is fallback for old gitea installations ( < 1.13.0 )

--- a/vendor/code.gitea.io/sdk/gitea/repo.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -259,10 +260,10 @@ func (opt *SearchRepoOptions) QueryEncode() string {
 
 	// Repo Attributes
 	if opt.IsPrivate != nil {
-		query.Add("is_private", fmt.Sprintf("%v", opt.IsPrivate))
+		query.Add("is_private", fmt.Sprintf("%t", *opt.IsPrivate))
 	}
 	if opt.IsArchived != nil {
-		query.Add("archived", fmt.Sprintf("%v", opt.IsArchived))
+		query.Add("archived", fmt.Sprintf("%t", *opt.IsArchived))
 	}
 	if opt.ExcludeTemplate {
 		query.Add("template", "false")
@@ -506,8 +507,7 @@ func (c *Client) DeleteRepo(owner, repo string) (*Response, error) {
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s", owner, repo), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s", owner, repo), nil, nil)
 }
 
 // MirrorSync adds a mirrored repository to the mirror sync queue.
@@ -515,8 +515,7 @@ func (c *Client) MirrorSync(owner, repo string) (*Response, error) {
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("POST", fmt.Sprintf("/repos/%s/%s/mirror-sync", owner, repo), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("POST", fmt.Sprintf("/repos/%s/%s/mirror-sync", owner, repo), nil, nil)
 }
 
 // GetRepoLanguages return language stats of a repo
@@ -575,4 +574,47 @@ func (c *Client) GetArchiveReader(owner, repo, ref string, ext ArchiveType) (io.
 	}
 
 	return resp.Body, resp, nil
+}
+
+// UpdateRepoAvatarOption options for updating repository avatar
+type UpdateRepoAvatarOption struct {
+	Image string `json:"image"` // base64 encoded image
+}
+
+// UpdateRepoAvatar updates a repository's avatar
+func (c *Client) UpdateRepoAvatar(owner, repo string, opt UpdateRepoAvatarOption) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("POST",
+		fmt.Sprintf("/repos/%s/%s/avatar", owner, repo),
+		jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// DeleteRepoAvatar deletes a repository's avatar
+func (c *Client) DeleteRepoAvatar(owner, repo string) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("DELETE",
+		fmt.Sprintf("/repos/%s/%s/avatar", owner, repo),
+		jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
 }

--- a/vendor/code.gitea.io/sdk/gitea/repo_action.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_action.go
@@ -42,6 +42,25 @@ func (c *Client) ListRepoActionSecret(user, repo string, opt ListRepoActionSecre
 	return secrets, resp, err
 }
 
+// ListRepoActionVariableOption lists RepoActionVariable options
+type ListRepoActionVariableOption struct {
+	ListOptions
+}
+
+// ListRepoActionVariable lists a repository's action variables
+func (c *Client) ListRepoActionVariable(user, repo string, opt ListRepoActionVariableOption) ([]*RepoActionVariable, *Response, error) {
+	if err := escapeValidatePathSegments(&user, &repo); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+	variables := make([]*RepoActionVariable, 0, opt.PageSize)
+
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/actions/variables", user, repo))
+	link.RawQuery = opt.getURLQuery().Encode()
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &variables)
+	return variables, resp, err
+}
+
 // CreateRepoActionSecret creates a secret for the specified repository in the Gitea Actions.
 // It takes the organization name and the secret options as parameters.
 // The function returns the HTTP response and an error, if any.
@@ -84,8 +103,7 @@ func (c *Client) DeleteRepoActionSecret(user, repo, secretName string) (*Respons
 		return nil, err
 	}
 
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/actions/secrets/%s", user, repo, secretName), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/actions/secrets/%s", user, repo, secretName), nil, nil)
 }
 
 // GetRepoActionVariable returns a repository variable in the Gitea Actions.
@@ -117,8 +135,7 @@ func (c *Client) CreateRepoActionVariable(user, repo, variableName, value string
 		return nil, err
 	}
 
-	_, resp, err := c.getResponse("POST", fmt.Sprintf("/repos/%s/%s/actions/variables/%s", user, repo, variableName), jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("POST", fmt.Sprintf("/repos/%s/%s/actions/variables/%s", user, repo, variableName), jsonHeader, bytes.NewReader(body))
 }
 
 // UpdateRepoActionVariable updates a repository variable in the Gitea Actions.
@@ -139,8 +156,7 @@ func (c *Client) UpdateRepoActionVariable(user, repo, variableName, value string
 		return nil, err
 	}
 
-	_, resp, err := c.getResponse("PUT", fmt.Sprintf("/repos/%s/%s/actions/variables/%s", user, repo, variableName), jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("PUT", fmt.Sprintf("/repos/%s/%s/actions/variables/%s", user, repo, variableName), jsonHeader, bytes.NewReader(body))
 }
 
 // DeleteRepoActionVariable deletes a repository variable in the Gitea Actions.
@@ -151,6 +167,5 @@ func (c *Client) DeleteRepoActionVariable(user, reponame, variableName string) (
 		return nil, err
 	}
 
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/actions/variables/%s", user, reponame, variableName), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/actions/variables/%s", user, reponame, variableName), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/repo_branch_protection.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_branch_protection.go
@@ -168,6 +168,5 @@ func (c *Client) DeleteBranchProtection(owner, repo, name string) (*Response, er
 	if err := c.checkServerVersionGreaterThanOrEqual(version1_12_0); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/branch_protections/%s", owner, repo, name), jsonHeader, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/branch_protections/%s", owner, repo, name), jsonHeader, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/repo_collaborator.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_collaborator.go
@@ -122,8 +122,7 @@ func (c *Client) AddCollaborator(user, repo, collaborator string, opt AddCollabo
 	if err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PUT", fmt.Sprintf("/repos/%s/%s/collaborators/%s", user, repo, collaborator), jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("PUT", fmt.Sprintf("/repos/%s/%s/collaborators/%s", user, repo, collaborator), jsonHeader, bytes.NewReader(body))
 }
 
 // DeleteCollaborator remove a collaborator from a repository
@@ -131,9 +130,8 @@ func (c *Client) DeleteCollaborator(user, repo, collaborator string) (*Response,
 	if err := escapeValidatePathSegments(&user, &repo, &collaborator); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE",
+	return c.doRequestWithStatusHandle("DELETE",
 		fmt.Sprintf("/repos/%s/%s/collaborators/%s", user, repo, collaborator), nil, nil)
-	return resp, err
 }
 
 // GetReviewers return all users that can be requested to review in this repo

--- a/vendor/code.gitea.io/sdk/gitea/repo_file.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_file.go
@@ -126,7 +126,11 @@ func (c *Client) GetFile(owner, repo, ref, filepath string, resolveLFS ...bool) 
 	if reader == nil {
 		return nil, resp, err
 	}
-	defer reader.Close()
+	defer func() {
+		if closeErr := reader.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
 
 	data, err2 := io.ReadAll(reader)
 	if err2 != nil {

--- a/vendor/code.gitea.io/sdk/gitea/repo_file_ext.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_file_ext.go
@@ -1,0 +1,136 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+)
+
+// ContentsExtResponse contains extended information about a repo's contents
+type ContentsExtResponse struct {
+	DirContents  []*ContentsResponse `json:"dir_contents,omitempty"`
+	FileContents *ContentsResponse   `json:"file_contents,omitempty"`
+}
+
+// GetContentsExtOptions options for getting extended contents
+type GetContentsExtOptions struct {
+	// The name of the commit/branch/tag. Default to the repository's default branch
+	Ref string `json:"ref,omitempty"`
+	// Comma-separated includes options: file_content, lfs_metadata, commit_metadata, commit_message
+	Includes string `json:"includes,omitempty"`
+}
+
+// GetContentsExt gets extended file metadata and/or content from a repository
+// The extended "contents" API, to get file metadata and/or content, or list a directory
+func (c *Client) GetContentsExt(owner, repo, filepath string, opt GetContentsExtOptions) (*ContentsExtResponse, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+
+	// filepath doesn't need escaping since it's already part of the path
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/contents-ext/%s", owner, repo, filepath))
+	query := link.Query()
+
+	if opt.Ref != "" {
+		query.Add("ref", opt.Ref)
+	}
+	if opt.Includes != "" {
+		query.Add("includes", opt.Includes)
+	}
+
+	link.RawQuery = query.Encode()
+
+	result := new(ContentsExtResponse)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, result)
+	return result, resp, err
+}
+
+// GetEditorConfig gets the EditorConfig definitions of a file in a repository
+func (c *Client) GetEditorConfig(owner, repo, filepath string, ref ...string) ([]byte, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/editorconfig/%s", owner, repo, filepath))
+
+	if len(ref) > 0 && ref[0] != "" {
+		query := link.Query()
+		query.Add("ref", ref[0])
+		link.RawQuery = query.Encode()
+	}
+
+	resp, err := c.doRequest("GET", link.String(), nil, nil)
+	if err != nil {
+		return nil, resp, err
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	data, err := io.ReadAll(resp.Body)
+	return data, resp, err
+}
+
+// GetRawFileOrLFS gets a file or its LFS object from a repository
+// This endpoint resolves LFS pointers and returns actual LFS objects
+func (c *Client) GetRawFileOrLFS(owner, repo, filepath string, ref ...string) ([]byte, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/media/%s", owner, repo, filepath))
+
+	if len(ref) > 0 && ref[0] != "" {
+		query := link.Query()
+		query.Add("ref", ref[0])
+		link.RawQuery = query.Encode()
+	}
+
+	resp, err := c.doRequest("GET", link.String(), nil, nil)
+	if err != nil {
+		return nil, resp, err
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	data, err := io.ReadAll(resp.Body)
+	return data, resp, err
+}
+
+// GetRawFile gets a file from a repository
+// Unlike GetRawFileOrLFS, this does NOT resolve LFS pointers
+func (c *Client) GetRawFile(owner, repo, filepath string, ref ...string) ([]byte, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/raw/%s", owner, repo, filepath))
+
+	if len(ref) > 0 && ref[0] != "" {
+		query := link.Query()
+		query.Add("ref", ref[0])
+		link.RawQuery = query.Encode()
+	}
+
+	resp, err := c.doRequest("GET", link.String(), nil, nil)
+	if err != nil {
+		return nil, resp, err
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	data, err := io.ReadAll(resp.Body)
+	return data, resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/repo_git_notes.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_git_notes.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// Note represents a git note
+type Note struct {
+	Message string  `json:"message"`
+	Commit  *Commit `json:"commit"`
+}
+
+// GetRepoNoteOptions options for getting a note
+type GetRepoNoteOptions struct {
+	// include verification for every commit (disable for speedup, default 'true')
+	Verification *bool `json:"verification,omitempty"`
+	// include a list of affected files for every commit (disable for speedup, default 'true')
+	Files *bool `json:"files,omitempty"`
+}
+
+// GetRepoNote gets a note corresponding to a single commit from a repository
+func (c *Client) GetRepoNote(owner, repo, sha string, opt GetRepoNoteOptions) (*Note, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo, &sha); err != nil {
+		return nil, nil, err
+	}
+
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/git/notes/%s", owner, repo, sha))
+	query := link.Query()
+
+	if opt.Verification != nil {
+		if *opt.Verification {
+			query.Add("verification", "true")
+		} else {
+			query.Add("verification", "false")
+		}
+	}
+
+	if opt.Files != nil {
+		if *opt.Files {
+			query.Add("files", "true")
+		} else {
+			query.Add("files", "false")
+		}
+	}
+
+	link.RawQuery = query.Encode()
+
+	note := new(Note)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &note)
+	return note, resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/repo_key.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_key.go
@@ -86,6 +86,5 @@ func (c *Client) DeleteDeployKey(owner, repo string, keyID int64) (*Response, er
 	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/keys/%d", owner, repo, keyID), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/keys/%d", owner, repo, keyID), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/repo_label.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_label.go
@@ -1,0 +1,150 @@
+// Copyright 2016 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Label a label to an issue or a pr
+type Label struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+	// example: 00aabb
+	Color       string `json:"color"`
+	Description string `json:"description"`
+	Exclusive   bool   `json:"exclusive"`
+	URL         string `json:"url"`
+}
+
+// ListLabelsOptions options for listing repository's labels
+type ListLabelsOptions struct {
+	ListOptions
+}
+
+// ListRepoLabels list labels of one repository
+func (c *Client) ListRepoLabels(owner, repo string, opt ListLabelsOptions) ([]*Label, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+	labels := make([]*Label, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/labels?%s", owner, repo, opt.getURLQuery().Encode()), nil, nil, &labels)
+	return labels, resp, err
+}
+
+// GetRepoLabel get one label of repository by repo it
+func (c *Client) GetRepoLabel(owner, repo string, id int64) (*Label, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	label := new(Label)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/labels/%d", owner, repo, id), nil, nil, label)
+	return label, resp, err
+}
+
+// CreateLabelOption options for creating a label
+type CreateLabelOption struct {
+	Name string `json:"name"`
+	// example: #00aabb
+	Color       string `json:"color"`
+	Description string `json:"description"`
+	Exclusive   bool   `json:"exclusive"`
+}
+
+// Validate the CreateLabelOption struct
+func (opt CreateLabelOption) Validate() error {
+	aw, err := regexp.MatchString("^#?[0-9,a-f,A-F]{6}$", opt.Color)
+	if err != nil {
+		return err
+	}
+	if !aw {
+		return fmt.Errorf("invalid color format")
+	}
+	if len(strings.TrimSpace(opt.Name)) == 0 {
+		return fmt.Errorf("empty name not allowed")
+	}
+	return nil
+}
+
+// CreateLabel create one label of repository
+func (c *Client) CreateLabel(owner, repo string, opt CreateLabelOption) (*Label, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	if err := opt.Validate(); err != nil {
+		return nil, nil, err
+	}
+	if len(opt.Color) == 6 {
+		if err := c.checkServerVersionGreaterThanOrEqual(version1_12_0); err != nil {
+			opt.Color = "#" + opt.Color
+		}
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	label := new(Label)
+	resp, err := c.getParsedResponse("POST",
+		fmt.Sprintf("/repos/%s/%s/labels", owner, repo),
+		jsonHeader, bytes.NewReader(body), label)
+	return label, resp, err
+}
+
+// EditLabelOption options for editing a label
+type EditLabelOption struct {
+	Name        *string `json:"name"`
+	Color       *string `json:"color"`
+	Description *string `json:"description"`
+	Exclusive   *bool   `json:"exclusive"`
+}
+
+// Validate the EditLabelOption struct
+func (opt EditLabelOption) Validate() error {
+	if opt.Color != nil {
+		aw, err := regexp.MatchString("^#?[0-9,a-f,A-F]{6}$", *opt.Color)
+		if err != nil {
+			return err
+		}
+		if !aw {
+			return fmt.Errorf("invalid color format")
+		}
+	}
+	if opt.Name != nil {
+		if len(strings.TrimSpace(*opt.Name)) == 0 {
+			return fmt.Errorf("empty name not allowed")
+		}
+	}
+	return nil
+}
+
+// EditLabel modify one label with options
+func (c *Client) EditLabel(owner, repo string, id int64, opt EditLabelOption) (*Label, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	if err := opt.Validate(); err != nil {
+		return nil, nil, err
+	}
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	label := new(Label)
+	resp, err := c.getParsedResponse("PATCH", fmt.Sprintf("/repos/%s/%s/labels/%d", owner, repo, id), jsonHeader, bytes.NewReader(body), label)
+	return label, resp, err
+}
+
+// DeleteLabel delete one label of repository by id
+func (c *Client) DeleteLabel(owner, repo string, id int64) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, err
+	}
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/labels/%d", owner, repo, id), nil, nil)
+}

--- a/vendor/code.gitea.io/sdk/gitea/repo_migrate.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_migrate.go
@@ -55,15 +55,15 @@ type MigrateRepoOption struct {
 func (opt *MigrateRepoOption) Validate(c *Client) error {
 	// check user options
 	if len(opt.CloneAddr) == 0 {
-		return fmt.Errorf("CloneAddr required")
+		return fmt.Errorf("clone addr required")
 	}
 	if len(opt.RepoName) == 0 {
-		return fmt.Errorf("RepoName required")
+		return fmt.Errorf("repo name required")
 	} else if len(opt.RepoName) > 100 {
-		return fmt.Errorf("RepoName to long")
+		return fmt.Errorf("repo name too long")
 	}
 	if len(opt.Description) > 2048 {
-		return fmt.Errorf("Description to long")
+		return fmt.Errorf("description too long")
 	}
 	switch opt.Service {
 	case GitServiceGithub:

--- a/vendor/code.gitea.io/sdk/gitea/repo_mirror.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_mirror.go
@@ -43,3 +43,34 @@ func (c *Client) PushMirrors(user, repo string, opt CreatePushMirrorOption) (*Pu
 	resp, err := c.getParsedResponse("POST", fmt.Sprintf("/repos/%s/%s/push_mirrors", user, repo), jsonHeader, bytes.NewReader(body), &pm)
 	return pm, resp, err
 }
+
+// ListPushMirrors gets all push mirrors of a repository
+func (c *Client) ListPushMirrors(user, repo string, opt ListOptions) ([]*PushMirrorResponse, *Response, error) {
+	if err := escapeValidatePathSegments(&user, &repo); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+	pms := make([]*PushMirrorResponse, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/push_mirrors?%s", user, repo, opt.getURLQuery().Encode()),
+		nil, nil, &pms)
+	return pms, resp, err
+}
+
+// GetPushMirrorByRemoteName get a push mirror of the repository by remote name
+func (c *Client) GetPushMirrorByRemoteName(user, repo, remoteName string) (*PushMirrorResponse, *Response, error) {
+	if err := escapeValidatePathSegments(&user, &repo, &remoteName); err != nil {
+		return nil, nil, err
+	}
+	pm := new(PushMirrorResponse)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/push_mirrors/%s", user, repo, remoteName), nil, nil, &pm)
+	return pm, resp, err
+}
+
+// DeletePushMirror deletes a push mirror from a repository by remote name
+func (c *Client) DeletePushMirror(user, repo, remoteName string) (*Response, error) {
+	if err := escapeValidatePathSegments(&user, &repo, &remoteName); err != nil {
+		return nil, err
+	}
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/push_mirrors/%s", user, repo, remoteName), nil, nil)
+}

--- a/vendor/code.gitea.io/sdk/gitea/repo_refs.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_refs.go
@@ -76,3 +76,13 @@ func (c *Client) GetRepoRefs(user, repo, ref string) ([]*Reference, *Response, e
 
 	return nil, resp, fmt.Errorf("unmarshalling failed for both single and multiple refs: %s and %s", refErr, refsErr)
 }
+
+// ListAllGitRefs gets all refs from a repository without filtering
+func (c *Client) ListAllGitRefs(owner, repo string) ([]*Reference, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	refs := make([]*Reference, 0, 10)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo), nil, nil, &refs)
+	return refs, resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/repo_stars.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_stars.go
@@ -47,7 +47,7 @@ func (c *Client) IsRepoStarring(user, repo string) (bool, *Response, error) {
 	if err := escapeValidatePathSegments(&user, &repo); err != nil {
 		return false, nil, err
 	}
-	_, resp, err := c.getResponse("GET", fmt.Sprintf("/user/starred/%s/%s", user, repo), jsonHeader, nil)
+	resp, err := c.doRequestWithStatusHandle("GET", fmt.Sprintf("/user/starred/%s/%s", user, repo), jsonHeader, nil)
 	if resp != nil {
 		switch resp.StatusCode {
 		case http.StatusNotFound:
@@ -66,7 +66,7 @@ func (c *Client) StarRepo(user, repo string) (*Response, error) {
 	if err := escapeValidatePathSegments(&user, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PUT", fmt.Sprintf("/user/starred/%s/%s", user, repo), jsonHeader, nil)
+	resp, err := c.doRequestWithStatusHandle("PUT", fmt.Sprintf("/user/starred/%s/%s", user, repo), jsonHeader, nil)
 	if resp != nil {
 		switch resp.StatusCode {
 		case http.StatusNoContent:
@@ -83,7 +83,7 @@ func (c *Client) UnStarRepo(user, repo string) (*Response, error) {
 	if err := escapeValidatePathSegments(&user, &repo); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/user/starred/%s/%s", user, repo), jsonHeader, nil)
+	resp, err := c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/user/starred/%s/%s", user, repo), jsonHeader, nil)
 	if resp != nil {
 		switch resp.StatusCode {
 		case http.StatusNoContent:

--- a/vendor/code.gitea.io/sdk/gitea/repo_tag.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_tag.go
@@ -123,8 +123,7 @@ func (c *Client) DeleteTag(user, repo, tag string) (*Response, error) {
 	if err := c.checkServerVersionGreaterThanOrEqual(version1_14_0); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE",
+	return c.doRequestWithStatusHandle("DELETE",
 		fmt.Sprintf("/repos/%s/%s/tags/%s", user, repo, tag),
 		nil, nil)
-	return resp, err
 }

--- a/vendor/code.gitea.io/sdk/gitea/repo_tag_protection.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_tag_protection.go
@@ -120,6 +120,5 @@ func (c *Client) DeleteTagProtection(owner, repo string, id int64) (*Response, e
 		return nil, err
 	}
 
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/tag_protections/%d", owner, repo, id), jsonHeader, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/tag_protections/%d", owner, repo, id), jsonHeader, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/repo_team.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_team.go
@@ -30,8 +30,7 @@ func (c *Client) AddRepoTeam(user, repo, team string) (*Response, error) {
 	if err := escapeValidatePathSegments(&user, &repo, &team); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PUT", fmt.Sprintf("/repos/%s/%s/teams/%s", user, repo, team), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("PUT", fmt.Sprintf("/repos/%s/%s/teams/%s", user, repo, team), nil, nil)
 }
 
 // RemoveRepoTeam delete a team from a repository
@@ -42,8 +41,7 @@ func (c *Client) RemoveRepoTeam(user, repo, team string) (*Response, error) {
 	if err := escapeValidatePathSegments(&user, &repo, &team); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/teams/%s", user, repo, team), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/teams/%s", user, repo, team), nil, nil)
 }
 
 // CheckRepoTeam check if team is assigned to repo by name and return it.

--- a/vendor/code.gitea.io/sdk/gitea/repo_topics.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_topics.go
@@ -45,8 +45,7 @@ func (c *Client) SetRepoTopics(user, repo string, list []string) (*Response, err
 	if err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PUT", fmt.Sprintf("/repos/%s/%s/topics", user, repo), jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("PUT", fmt.Sprintf("/repos/%s/%s/topics", user, repo), jsonHeader, bytes.NewReader(body))
 }
 
 // AddRepoTopic adds a topic to a repo's topics list
@@ -54,8 +53,7 @@ func (c *Client) AddRepoTopic(user, repo, topic string) (*Response, error) {
 	if err := escapeValidatePathSegments(&user, &repo, &topic); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PUT", fmt.Sprintf("/repos/%s/%s/topics/%s", user, repo, topic), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("PUT", fmt.Sprintf("/repos/%s/%s/topics/%s", user, repo, topic), nil, nil)
 }
 
 // DeleteRepoTopic deletes a topic from repo's topics list
@@ -63,6 +61,5 @@ func (c *Client) DeleteRepoTopic(user, repo, topic string) (*Response, error) {
 	if err := escapeValidatePathSegments(&user, &repo, &topic); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/topics/%s", user, repo, topic), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/repos/%s/%s/topics/%s", user, repo, topic), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/repo_wiki.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_wiki.go
@@ -1,0 +1,164 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// WikiPage represents a wiki page
+type WikiPage struct {
+	Title         string      `json:"title"`
+	ContentBase64 string      `json:"content_base64"`
+	CommitCount   int64       `json:"commit_count"`
+	Sidebar       string      `json:"sidebar"`
+	Footer        string      `json:"footer"`
+	HTMLURL       string      `json:"html_url"`
+	SubURL        string      `json:"sub_url"`
+	LastCommit    *WikiCommit `json:"last_commit,omitempty"`
+}
+
+// WikiPageMetaData represents metadata for a wiki page (without content)
+type WikiPageMetaData struct {
+	Title      string      `json:"title"`
+	HTMLURL    string      `json:"html_url"`
+	SubURL     string      `json:"sub_url"`
+	LastCommit *WikiCommit `json:"last_commit,omitempty"`
+}
+
+// WikiCommit represents a wiki commit/revision
+type WikiCommit struct {
+	ID       string      `json:"sha"`
+	Message  string      `json:"message"`
+	Author   *CommitUser `json:"author,omitempty"`
+	Commiter *CommitUser `json:"commiter,omitempty"`
+}
+
+// WikiCommitList represents a list of wiki commits
+type WikiCommitList struct {
+	WikiCommits []*WikiCommit `json:"commits"`
+	Count       int64         `json:"count"`
+}
+
+// CreateWikiPageOptions options for creating or editing a wiki page
+type CreateWikiPageOptions struct {
+	Title         string `json:"title,omitempty"`
+	ContentBase64 string `json:"content_base64,omitempty"`
+	Message       string `json:"message,omitempty"`
+}
+
+// ListWikiPagesOptions options for listing wiki pages
+type ListWikiPagesOptions struct {
+	ListOptions
+}
+
+// ListWikiPageRevisionsOptions options for listing wiki page revisions
+type ListWikiPageRevisionsOptions struct {
+	Page int `json:"page,omitempty"`
+}
+
+// CreateWikiPage creates a new wiki page
+func (c *Client) CreateWikiPage(owner, repo string, opt CreateWikiPageOptions) (*WikiPage, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	page := new(WikiPage)
+	resp, err := c.getParsedResponse("POST",
+		fmt.Sprintf("/repos/%s/%s/wiki/new", owner, repo),
+		jsonHeader, bytes.NewReader(body), &page)
+	return page, resp, err
+}
+
+// GetWikiPage gets a wiki page by name
+func (c *Client) GetWikiPage(owner, repo, pageName string) (*WikiPage, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo, &pageName); err != nil {
+		return nil, nil, err
+	}
+
+	page := new(WikiPage)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/wiki/page/%s", owner, repo, pageName),
+		jsonHeader, nil, &page)
+	return page, resp, err
+}
+
+// EditWikiPage edits an existing wiki page
+func (c *Client) EditWikiPage(owner, repo, pageName string, opt CreateWikiPageOptions) (*WikiPage, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo, &pageName); err != nil {
+		return nil, nil, err
+	}
+
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	page := new(WikiPage)
+	resp, err := c.getParsedResponse("PATCH",
+		fmt.Sprintf("/repos/%s/%s/wiki/page/%s", owner, repo, pageName),
+		jsonHeader, bytes.NewReader(body), &page)
+	return page, resp, err
+}
+
+// DeleteWikiPage deletes a wiki page
+func (c *Client) DeleteWikiPage(owner, repo, pageName string) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo, &pageName); err != nil {
+		return nil, err
+	}
+
+	status, resp, err := c.getStatusCode("DELETE",
+		fmt.Sprintf("/repos/%s/%s/wiki/page/%s", owner, repo, pageName),
+		jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// ListWikiPages lists all wiki pages in a repository
+func (c *Client) ListWikiPages(owner, repo string, opt ListWikiPagesOptions) ([]*WikiPageMetaData, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/wiki/pages", owner, repo))
+	link.RawQuery = opt.getURLQuery().Encode()
+
+	pages := make([]*WikiPageMetaData, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &pages)
+	return pages, resp, err
+}
+
+// GetWikiPageRevisions gets all revisions of a wiki page
+func (c *Client) GetWikiPageRevisions(owner, repo, pageName string, opt ListWikiPageRevisionsOptions) (*WikiCommitList, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &repo, &pageName); err != nil {
+		return nil, nil, err
+	}
+
+	link, _ := url.Parse(fmt.Sprintf("/repos/%s/%s/wiki/revisions/%s", owner, repo, pageName))
+	if opt.Page > 0 {
+		query := link.Query()
+		query.Add("page", fmt.Sprintf("%d", opt.Page))
+		link.RawQuery = query.Encode()
+	}
+
+	commitList := new(WikiCommitList)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &commitList)
+	return commitList, resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/secret.go
+++ b/vendor/code.gitea.io/sdk/gitea/secret.go
@@ -11,6 +11,8 @@ type Secret struct {
 	Name string `json:"name"`
 	// the secret's data
 	Data string `json:"data"`
+	// the secret's description
+	Description string `json:"description"`
 	// Date and Time of secret creation
 	Created time.Time `json:"created_at"`
 }

--- a/vendor/code.gitea.io/sdk/gitea/user_app.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_app.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"time"
 )
 
 // AccessTokenScope represents the scope for an access token.
@@ -71,6 +72,8 @@ type AccessToken struct {
 	Token          string             `json:"sha1"`
 	TokenLastEight string             `json:"token_last_eight"`
 	Scopes         []AccessTokenScope `json:"scopes"`
+	Created        time.Time          `json:"created_at,omitempty"`
+	Updated        time.Time          `json:"last_used_at,omitempty"`
 }
 
 // ListAccessTokensOptions options for listing a users's access tokens
@@ -138,6 +141,5 @@ func (c *Client) DeleteAccessToken(value interface{}) (*Response, error) {
 		return nil, fmt.Errorf("only string and int64 supported")
 	}
 
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/users/%s/tokens/%s", url.PathEscape(username), url.PathEscape(token)), jsonHeader, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/users/%s/tokens/%s", url.PathEscape(username), url.PathEscape(token)), jsonHeader, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/user_block.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_block.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// ListUserBlocksOptions options for listing user blocks
+type ListUserBlocksOptions struct {
+	ListOptions
+}
+
+// ListMyBlocks lists users blocked by the authenticated user
+func (c *Client) ListMyBlocks(opt ListUserBlocksOptions) ([]*User, *Response, error) {
+	opt.setDefaults()
+
+	link, _ := url.Parse("/user/blocks")
+	link.RawQuery = opt.getURLQuery().Encode()
+
+	users := make([]*User, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &users)
+	return users, resp, err
+}
+
+// CheckUserBlock checks if a user is blocked by the authenticated user
+func (c *Client) CheckUserBlock(username string) (bool, *Response, error) {
+	if err := escapeValidatePathSegments(&username); err != nil {
+		return false, nil, err
+	}
+	status, resp, err := c.getStatusCode("GET",
+		fmt.Sprintf("/user/blocks/%s", username),
+		jsonHeader, nil)
+	if err != nil {
+		return false, resp, err
+	}
+	return status == http.StatusNoContent, resp, nil
+}
+
+// BlockUser blocks a user
+func (c *Client) BlockUser(username string) (*Response, error) {
+	if err := escapeValidatePathSegments(&username); err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("PUT",
+		fmt.Sprintf("/user/blocks/%s", username),
+		jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// UnblockUser unblocks a user
+func (c *Client) UnblockUser(username string) (*Response, error) {
+	if err := escapeValidatePathSegments(&username); err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("DELETE",
+		fmt.Sprintf("/user/blocks/%s", username),
+		jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}

--- a/vendor/code.gitea.io/sdk/gitea/user_email.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_email.go
@@ -15,6 +15,8 @@ type Email struct {
 	Email    string `json:"email"`
 	Verified bool   `json:"verified"`
 	Primary  bool   `json:"primary"`
+	UserID   int64  `json:"user_id,omitempty"`
+	Username string `json:"username,omitempty"`
 }
 
 // ListEmailsOptions options for listing current's user emails
@@ -59,6 +61,5 @@ func (c *Client) DeleteEmail(opt DeleteEmailOption) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", "/user/emails", jsonHeader, bytes.NewReader(body))
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", "/user/emails", jsonHeader, bytes.NewReader(body))
 }

--- a/vendor/code.gitea.io/sdk/gitea/user_ext.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_ext.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// UserHeatmapData represents the data needed to create a heatmap
+type UserHeatmapData struct {
+	Timestamp     int64 `json:"timestamp"`
+	Contributions int64 `json:"contributions"`
+}
+
+// GetUserHeatmap gets a user's heatmap data
+func (c *Client) GetUserHeatmap(username string) ([]*UserHeatmapData, *Response, error) {
+	if err := escapeValidatePathSegments(&username); err != nil {
+		return nil, nil, err
+	}
+
+	heatmap := make([]*UserHeatmapData, 0, 365)
+	resp, err := c.getParsedResponse("GET",
+		fmt.Sprintf("/users/%s/heatmap", username),
+		jsonHeader, nil, &heatmap)
+	return heatmap, resp, err
+}
+
+// ListUserActivityFeedsOptions options for listing user activity feeds
+type ListUserActivityFeedsOptions struct {
+	ListOptions
+	OnlyPerformedBy bool   `json:"only-performed-by,omitempty"`
+	Date            string `json:"date,omitempty"`
+}
+
+// ListUserActivityFeeds lists a user's activity feeds
+func (c *Client) ListUserActivityFeeds(username string, opt ListUserActivityFeedsOptions) ([]*Activity, *Response, error) {
+	if err := escapeValidatePathSegments(&username); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+
+	link, _ := url.Parse(fmt.Sprintf("/users/%s/activities/feeds", username))
+	query := opt.getURLQuery()
+	if opt.OnlyPerformedBy {
+		query.Add("only-performed-by", "true")
+	}
+	if opt.Date != "" {
+		query.Add("date", opt.Date)
+	}
+	link.RawQuery = query.Encode()
+
+	activities := make([]*Activity, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &activities)
+	return activities, resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/user_follow.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_follow.go
@@ -60,7 +60,7 @@ func (c *Client) IsFollowing(target string) (bool, *Response) {
 		// ToDo return err
 		return false, nil
 	}
-	_, resp, err := c.getResponse("GET", fmt.Sprintf("/user/following/%s", target), nil, nil)
+	resp, err := c.doRequestWithStatusHandle("GET", fmt.Sprintf("/user/following/%s", target), nil, nil)
 	return err == nil, resp
 }
 
@@ -70,7 +70,7 @@ func (c *Client) IsUserFollowing(user, target string) (bool, *Response) {
 		// ToDo return err
 		return false, nil
 	}
-	_, resp, err := c.getResponse("GET", fmt.Sprintf("/users/%s/following/%s", user, target), nil, nil)
+	resp, err := c.doRequestWithStatusHandle("GET", fmt.Sprintf("/users/%s/following/%s", user, target), nil, nil)
 	return err == nil, resp
 }
 
@@ -79,7 +79,7 @@ func (c *Client) Follow(target string) (*Response, error) {
 	if err := escapeValidatePathSegments(&target); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("PUT", fmt.Sprintf("/user/following/%s", target), nil, nil)
+	resp, err := c.doRequestWithStatusHandle("PUT", fmt.Sprintf("/user/following/%s", target), nil, nil)
 	return resp, err
 }
 
@@ -88,6 +88,6 @@ func (c *Client) Unfollow(target string) (*Response, error) {
 	if err := escapeValidatePathSegments(&target); err != nil {
 		return nil, err
 	}
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/user/following/%s", target), nil, nil)
+	resp, err := c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/user/following/%s", target), nil, nil)
 	return resp, err
 }

--- a/vendor/code.gitea.io/sdk/gitea/user_gpgkey.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_gpgkey.go
@@ -84,6 +84,35 @@ func (c *Client) CreateGPGKey(opt CreateGPGKeyOption) (*GPGKey, *Response, error
 
 // DeleteGPGKey delete GPG key with key id
 func (c *Client) DeleteGPGKey(keyID int64) (*Response, error) {
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/user/gpg_keys/%d", keyID), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/user/gpg_keys/%d", keyID), nil, nil)
+}
+
+// GetGPGKeyVerificationToken gets a verification token for adding a GPG key.
+// Returns the token as a plain string (API returns text/plain, not JSON).
+// The user should sign this token with their GPG key and submit via VerifyGPGKey.
+func (c *Client) GetGPGKeyVerificationToken() (string, *Response, error) {
+	body, resp, err := c.getResponse("GET", "/user/gpg_key_token", nil, nil)
+	return string(body), resp, err
+}
+
+// VerifyGPGKeyOption options for verifying a GPG key
+type VerifyGPGKeyOption struct {
+	// KeyID is the GPG key ID to verify
+	KeyID string `json:"key_id"`
+	// Signature is the ASCII-armored signature of the verification token
+	Signature string `json:"armored_signature"`
+}
+
+// VerifyGPGKey verifies a GPG key by submitting a signed verification token.
+// First call GetGPGKeyVerificationToken to get the token, sign it with the GPG key,
+// then call this with the key ID and armored signature.
+func (c *Client) VerifyGPGKey(opt VerifyGPGKeyOption) (*GPGKey, *Response, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	key := new(GPGKey)
+	resp, err := c.getParsedResponse("POST", "/user/gpg_key_verify",
+		jsonHeader, bytes.NewReader(body), key)
+	return key, resp, err
 }

--- a/vendor/code.gitea.io/sdk/gitea/user_key.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_key.go
@@ -19,6 +19,7 @@ type PublicKey struct {
 	Title       string    `json:"title,omitempty"`
 	Fingerprint string    `json:"fingerprint,omitempty"`
 	Created     time.Time `json:"created_at,omitempty"`
+	Updated     time.Time `json:"last_used_at,omitempty"`
 	Owner       *User     `json:"user,omitempty"`
 	ReadOnly    bool      `json:"read_only,omitempty"`
 	KeyType     string    `json:"key_type,omitempty"`
@@ -78,6 +79,5 @@ func (c *Client) CreatePublicKey(opt CreateKeyOption) (*PublicKey, *Response, er
 
 // DeletePublicKey delete public key with key id
 func (c *Client) DeletePublicKey(keyID int64) (*Response, error) {
-	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/user/keys/%d", keyID), nil, nil)
-	return resp, err
+	return c.doRequestWithStatusHandle("DELETE", fmt.Sprintf("/user/keys/%d", keyID), nil, nil)
 }

--- a/vendor/code.gitea.io/sdk/gitea/user_search.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_search.go
@@ -17,6 +17,7 @@ type searchUsersResponse struct {
 type SearchUsersOption struct {
 	ListOptions
 	KeyWord string
+	UID     int64
 }
 
 // QueryEncode turns options into querystring argument
@@ -30,6 +31,9 @@ func (opt *SearchUsersOption) QueryEncode() string {
 	}
 	if len(opt.KeyWord) > 0 {
 		query.Add("q", opt.KeyWord)
+	}
+	if opt.UID > 0 {
+		query.Add("uid", fmt.Sprintf("%d", opt.UID))
 	}
 	return query.Encode()
 }

--- a/vendor/code.gitea.io/sdk/gitea/user_social.go
+++ b/vendor/code.gitea.io/sdk/gitea/user_social.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// UpdateUserAvatarOption options for updating user avatar
+type UpdateUserAvatarOption struct {
+	Image string `json:"image"` // base64 encoded image
+}
+
+// UpdateUserAvatar updates the authenticated user's avatar
+func (c *Client) UpdateUserAvatar(opt UpdateUserAvatarOption) (*Response, error) {
+	body, err := json.Marshal(&opt)
+	if err != nil {
+		return nil, err
+	}
+	status, resp, err := c.getStatusCode("POST", "/user/avatar",
+		jsonHeader, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}
+
+// DeleteUserAvatar deletes the authenticated user's avatar
+func (c *Client) DeleteUserAvatar() (*Response, error) {
+	status, resp, err := c.getStatusCode("DELETE", "/user/avatar", jsonHeader, nil)
+	if err != nil {
+		return resp, err
+	}
+	if status != http.StatusNoContent {
+		return resp, fmt.Errorf("unexpected status: %d", status)
+	}
+	return resp, nil
+}

--- a/vendor/code.gitea.io/sdk/gitea/version.go
+++ b/vendor/code.gitea.io/sdk/gitea/version.go
@@ -71,6 +71,7 @@ var (
 	version1_17_0 = version.Must(version.NewVersion("1.17.0"))
 	version1_22_0 = version.Must(version.NewVersion("1.22.0"))
 	version1_23_0 = version.Must(version.NewVersion("1.23.0"))
+	version1_25_0 = version.Must(version.NewVersion("1.25.0"))
 )
 
 // ErrUnknownVersion is an unknown version from the API

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/gitea/pr.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/gitea/pr.go
@@ -97,7 +97,7 @@ func (s *pullService) Update(ctx context.Context, repo string, number int, input
 	namespace, name := scm.Split(repo)
 	in := gitea.EditPullRequestOption{
 		Title: input.Title,
-		Body:  input.Body,
+		Body:  &input.Body,
 		Base:  input.Base,
 	}
 	out, resp, err := s.client.GiteaClient.EditPullRequest(namespace, name, int64(number), in)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -44,8 +44,8 @@ cloud.google.com/go/kms/internal
 cloud.google.com/go/longrunning
 cloud.google.com/go/longrunning/autogen
 cloud.google.com/go/longrunning/autogen/longrunningpb
-# code.gitea.io/sdk/gitea v0.21.0
-## explicit; go 1.23
+# code.gitea.io/sdk/gitea v0.23.0
+## explicit; go 1.23.0
 code.gitea.io/sdk/gitea
 # fortio.org/safecast v1.2.0
 ## explicit; go 1.20


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Bump gitea SDK to v0.23.0 (instead of v0.24.1 from #9666 which requires go 1.26).

**Changes:**
- Bump `code.gitea.io/sdk/gitea` v0.21.0 → v0.23.0
- Fix vendored `jenkins-x/go-scm` for `EditPullRequestOption.Body` type change (`string` → `*string`)

**Why v0.23.0 instead of v0.24.1?**
- v0.24.0+ requires `go 1.26` in go.mod, which breaks the CI golangci-lint (built with go 1.25)
- The go 1.26 bump is planned for after the 1.12 release (early May)
- v0.23.0 stays on go 1.25 while still being a meaningful upgrade

Supersedes #9666

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string \"action required\" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```