### PR TITLE
Feat  add exact match field to verification policy resource pattern #9606

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Tekton
+cd # Contributing to Tekton
 
 Thank you for contributing your time and expertise to Tekton. This
 document describes the contribution guidelines for the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-cd # Contributing to Tekton
+# Contributing to Tekton
 
 Thank you for contributing your time and expertise to Tekton. This
 document describes the contribution guidelines for the project.

--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -136,3 +136,5 @@ data:
   # If set to "false", exponential backoff will be disabled.
   # For advanced tuning of backoff parameters, update the 'wait-exponential-backoff' ConfigMap.
   enable-wait-exponential-backoff: "false"
+  # Setting this flag to "true" will enable the exact match policy for trusted resources verification.
+  enable-trusted-resources-verification-exact-match-policy: "false"

--- a/docs/trusted-resources.md
+++ b/docs/trusted-resources.md
@@ -123,7 +123,7 @@ VerificationPolicy supports SecretRef or encoded public key data.
 How does VerificationPolicy work?
 You can create multiple `VerificationPolicy` and apply them to the cluster.
 1. Trusted resources will look up policies from the resource namespace (usually this is the same as taskrun/pipelinerun namespace).
-2. If multiple policies are found. For each policy we will check if the resource url is matching any of the `patterns` in the `resources` list. If matched then this policy will be used for verification.
+2. If multiple policies are found, for each policy we check if the resource URL matches any entry in the `resources` list. A resource entry can use either `pattern` for regex matching or `exactMatch` for exact URL matching. If any resource entry matches, that policy is used for verification.
 3. If multiple policies are matched, the resource must pass all the "enforce" mode policies. If the resource only matches policies in "warn" mode and fails to pass the "warn" policy, it will not fail the taskrun or pipelinerun, but log a warning instead.
 
 4. To pass one policy, the resource can pass any public keys in the policy.
@@ -177,6 +177,8 @@ spec:
 ```
 
 `namespace` should be the same of corresponding resources' namespace.
+
+`exactMatch` is used to filter out remote resources by their source URL. For example, a git resource exact match can be set to `https://github.com/tektoncd/catalog.git`. Unlike `pattern`, `exactMatch` does not use regex syntax. Tekton compares the configured value directly against the `ConfigSource` URL resolved by remote resolution, so the value must match exactly.
 
 `pattern` is used to filter out remote resources by their sources URL. e.g. git resources pattern can be set to https://github.com/tektoncd/catalog.git. The `pattern` should follow regex schema, we use go regex library's [`Match`](https://pkg.go.dev/regexp#Match) to match the pattern from VerificationPolicy to the `ConfigSource` URL resolved by remote resolution. Note that `.*` will match all resources.
 To learn more about regex syntax please refer to [syntax](https://pkg.go.dev/regexp/syntax).

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -111,6 +111,10 @@ const (
 	EnableWaitExponentialBackoff = "enable-wait-exponential-backoff"
 	// DefaultEnableWaitExponentialBackoff is the default value for EnableWaitExponentialBackoff
 	DefaultEnableWaitExponentialBackoff = false
+	// DefaultEnableVerificationExactMatchPolicyValue is the default value for EnableVerificationExactMatchPolicy
+	DefaultEnableVerificationExactMatchPolicyValue = false
+	// EnableVerificationExactMatchPolicy is the flag to set "trusted-resources-verification-exact-match-policy"
+	EnableVerificationExactMatchPolicy = "enable-trusted-resources-verification-exact-match-policy"
 
 	// EnableStepActions is the flag to enable step actions (no-op since it's stable)
 	EnableStepActions = "enable-step-actions"
@@ -182,6 +186,13 @@ var (
 		Enabled:    DefaultAlphaFeatureEnabled,
 		Deprecated: true,
 	}
+
+	// DefaultEnableVerificationExactMatchPolicy is the default PerFeatureFlag value for EnableVerificationExactMatchPolicy
+	DefaultEnableVerificationExactMatchPolicy = PerFeatureFlag{
+		Name: EnableVerificationExactMatchPolicy,
+		Stability: AlphaAPIFields,
+		Enabled: DefaultEnableVerificationExactMatchPolicyValue,
+	}
 )
 
 // FeatureFlags holds the features configurations
@@ -217,6 +228,7 @@ type FeatureFlags struct {
 	EnableConciseResolverSyntax  bool   `json:"enableConciseResolverSyntax,omitempty"`
 	EnableKubernetesSidecar      bool   `json:"enableKubernetesSidecar,omitempty"`
 	EnableWaitExponentialBackoff bool   `json:"enableWaitExponentialBackoff,omitempty"`
+	EnableVerificationExactMatchPolicy bool `json:"enableVerificationExactMatchPolicy,omitempty"`
 	// DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
 	// to allow deletion of PipelineRuns created before v0.62.x.
 	// This field is not used and can be removed in a future release
@@ -329,6 +341,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 	}
 	if err := setFeature(EnableWaitExponentialBackoff, DefaultEnableWaitExponentialBackoff, &tc.EnableWaitExponentialBackoff); err != nil {
 		return nil, err
+	}
+	if err := setPerFeatureFlag(EnableVerificationExactMatchPolicy, DefaultEnableVerificationExactMatchPolicy, &tc.EnableVerificationExactMatchPolicy); err != nil {
+		return nil, err 
 	}
 
 	return &tc, nil

--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_types.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_types.go
@@ -77,6 +77,8 @@ type ResourcePattern struct {
 	// Bundle resource: gcr.io/tekton-releases/catalog/upstream/git-clone, gcr.io/tekton-releases/catalog/upstream/*
 	// Hub resource: https://artifacthub.io/*,
 	Pattern string `json:"pattern"`
+	// ExactMatch defines an exact match for the resource source.
+	ExactMatch string `json:"exactMatch,omitempty"`
 }
 
 // The Authority block defines the keys for validating signatures.

--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"knative.dev/pkg/apis"
 )
@@ -29,6 +30,8 @@ var (
 	// InvalidResourcePatternErr is returned when the pattern is not valid regex expression
 	InvalidResourcePatternErr = "resourcePattern cannot be compiled by regex"
 )
+
+
 
 // Validate VerificationPolicy
 func (v *VerificationPolicy) Validate(ctx context.Context) (errs *apis.FieldError) {
@@ -44,8 +47,10 @@ func (vs *VerificationPolicySpec) Validate(ctx context.Context) (errs *apis.Fiel
 	if len(vs.Resources) == 0 {
 		errs = errs.Also(apis.ErrMissingField("resources"))
 	}
-	for _, r := range vs.Resources {
-		errs = errs.Also(r.Validate(ctx))
+	// Validate each resource and attach the list index to any returned field errors.
+
+	for i, r := range vs.Resources {
+		errs = errs.Also(r.Validate(ctx).ViaFieldIndex("resources", i))
 	}
 	if len(vs.Authorities) == 0 {
 		errs = errs.Also(apis.ErrMissingField("authorities"))
@@ -90,11 +95,34 @@ func (key *KeyRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs
 }
 
+
 // Validate ResourcePattern and make sure the Pattern is valid regex expression
+// only one can be present if both then reject // 
+// will only run Compile on Pattern if ExactMatch is not provided // 
 func (r *ResourcePattern) Validate(ctx context.Context) (errs *apis.FieldError) {
-	if _, err := regexp.Compile(r.Pattern); err != nil {
-		errs = errs.Also(apis.ErrInvalidValue(r.Pattern, "ResourcePattern", fmt.Sprintf("%v: %v", InvalidResourcePatternErr, err)))
+	if r.Pattern != "" && r.ExactMatch != "" {
+		errs = errs.Also(apis.ErrMultipleOneOf("pattern", "exactMatch"))
 		return errs
+	}
+
+	if r.Pattern == "" && r.ExactMatch == "" {
+		errs = errs.Also(apis.ErrMissingOneOf("pattern", "exactMatch"))
+		return errs
+	}
+
+	if r.ExactMatch != "" && !config.FromContextOrDefaults(ctx).FeatureFlags.EnableVerificationExactMatchPolicy {
+		errs = errs.Also(apis.ErrGeneric(
+			fmt.Sprintf("feature flag %s should be set to true to use exactMatch", config.EnableVerificationExactMatchPolicy),
+			"exactMatch",
+		))
+		return errs
+	}
+
+	if r.ExactMatch == "" {
+		if _, err := regexp.Compile(r.Pattern); err != nil {
+			errs = errs.Also(apis.ErrInvalidValue(r.Pattern, "ResourcePattern", fmt.Sprintf("%v: %v", InvalidResourcePatternErr, err)))
+			return errs
+		}
 	}
 	return nil
 }

--- a/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/verificationpolicy_validation_test.go
@@ -14,10 +14,13 @@ limitations under the License.
 package v1alpha1_test
 
 import (
+	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -25,11 +28,34 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+func withExactMatchFlag(t *testing.T, enabled bool) context.Context {
+	t.Helper()
+
+	featureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
+		config.EnableVerificationExactMatchPolicy: strconv.FormatBool(enabled),
+	})
+	if err != nil {
+		t.Fatalf("creating feature flags: %v", err)
+	}
+
+	cfg := &config.Config{FeatureFlags: featureFlags}
+	return config.ToContext(context.Background(), cfg)
+}
+
+func patternResource(pattern string) v1alpha1.ResourcePattern {
+	return v1alpha1.ResourcePattern{pattern, ""}
+}
+
+func exactMatchResource(url string) v1alpha1.ResourcePattern {
+	return v1alpha1.ResourcePattern{"", url}
+}
+
 func TestVerificationPolicy_Invalid(t *testing.T) {
 	tests := []struct {
 		name               string
 		verificationPolicy *v1alpha1.VerificationPolicy
 		want               *apis.FieldError
+		withContext        func(context.Context) context.Context
 	}{{
 		name: "missing Resources",
 		verificationPolicy: &v1alpha1.VerificationPolicy{
@@ -55,7 +81,7 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 				Name: "vp",
 			},
 			Spec: v1alpha1.VerificationPolicySpec{
-				Resources: []v1alpha1.ResourcePattern{{"^["}},
+				Resources: []v1alpha1.ResourcePattern{patternResource("^[")},
 				Authorities: []v1alpha1.Authority{
 					{
 						Name: "foo",
@@ -66,7 +92,7 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrInvalidValue("^[", "ResourcePattern", fmt.Sprintf("%v: error parsing regexp: missing closing ]: `[`", v1alpha1.InvalidResourcePatternErr)),
+		want: apis.ErrInvalidValue("^[", "ResourcePattern", fmt.Sprintf("%v: error parsing regexp: missing closing ]: `[`", v1alpha1.InvalidResourcePatternErr)).ViaFieldIndex("resources", 0),
 	}, {
 		name: "missing Authoritities",
 		verificationPolicy: &v1alpha1.VerificationPolicy{
@@ -74,7 +100,7 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 				Name: "vp",
 			},
 			Spec: v1alpha1.VerificationPolicySpec{
-				Resources: []v1alpha1.ResourcePattern{{".*"}},
+				Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 			},
 		},
 		want: apis.ErrMissingField("authorities"),
@@ -85,7 +111,7 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 				Name: "vp",
 			},
 			Spec: v1alpha1.VerificationPolicySpec{
-				Resources: []v1alpha1.ResourcePattern{{".*"}},
+				Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 				Authorities: []v1alpha1.Authority{
 					{
 						Name: "foo",
@@ -105,7 +131,7 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 				Name: "vp",
 			},
 			Spec: v1alpha1.VerificationPolicySpec{
-				Resources: []v1alpha1.ResourcePattern{{".*"}},
+				Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 				Authorities: []v1alpha1.Authority{
 					{
 						Name: "foo",
@@ -122,7 +148,7 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 				Name: "vp",
 			},
 			Spec: v1alpha1.VerificationPolicySpec{
-				Resources: []v1alpha1.ResourcePattern{{".*"}},
+				Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 				Authorities: []v1alpha1.Authority{
 					{
 						Name: "foo",
@@ -144,7 +170,7 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 				Name: "vp",
 			},
 			Spec: v1alpha1.VerificationPolicySpec{
-				Resources: []v1alpha1.ResourcePattern{{".*"}},
+				Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 				Authorities: []v1alpha1.Authority{
 					{
 						Name: "foo",
@@ -164,7 +190,7 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 				Name: "vp",
 			},
 			Spec: v1alpha1.VerificationPolicySpec{
-				Resources: []v1alpha1.ResourcePattern{{".*"}},
+				Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 				Authorities: []v1alpha1.Authority{
 					{
 						Name: "foo",
@@ -187,7 +213,7 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 				Name: "vp",
 			},
 			Spec: v1alpha1.VerificationPolicySpec{
-				Resources: []v1alpha1.ResourcePattern{{".*"}},
+				Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 				Authorities: []v1alpha1.Authority{
 					{
 						Name: "foo",
@@ -211,7 +237,7 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 				Name: "vp",
 			},
 			Spec: v1alpha1.VerificationPolicySpec{
-				Resources: []v1alpha1.ResourcePattern{{".*"}},
+				Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 				Authorities: []v1alpha1.Authority{
 					{
 						Name: "foo",
@@ -224,10 +250,39 @@ func TestVerificationPolicy_Invalid(t *testing.T) {
 			},
 		},
 		want: apis.ErrInvalidValue("sha1", "HashAlgorithm").ViaFieldIndex("key", 0),
+	}, {
+		name: "exactMatch requires feature flag",
+		withContext: func(context.Context) context.Context {
+			return withExactMatchFlag(t, false)
+		},
+		verificationPolicy: &v1alpha1.VerificationPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vp",
+			},
+			Spec: v1alpha1.VerificationPolicySpec{
+				Resources: []v1alpha1.ResourcePattern{exactMatchResource("https://github.com/tektoncd/catalog.git")},
+				Authorities: []v1alpha1.Authority{
+					{
+						Name: "foo",
+						Key: &v1alpha1.KeyRef{
+							Data: "inlinekey",
+						},
+					},
+				},
+			},
+		},
+		want: apis.ErrGeneric(
+			fmt.Sprintf("feature flag %s should be set to true to use exactMatch", config.EnableVerificationExactMatchPolicy),
+			"exactMatch",
+		).ViaFieldIndex("resources", 0),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.verificationPolicy.Validate(t.Context())
+			ctx := t.Context()
+			if tt.withContext != nil {
+				ctx = tt.withContext(ctx)
+			}
+			err := tt.verificationPolicy.Validate(ctx)
 			if d := cmp.Diff(tt.want.Error(), err.Error()); d != "" {
 				t.Error("VerificationPolicy validate error mismatch", diff.PrintWantGot(d))
 			}
@@ -239,6 +294,7 @@ func TestVerificationPolicy_Valid(t *testing.T) {
 	tests := []struct {
 		name               string
 		verificationPolicy *v1alpha1.VerificationPolicy
+		withContext        func(context.Context) context.Context
 	}{
 		{
 			name: "key in data",
@@ -247,7 +303,7 @@ func TestVerificationPolicy_Valid(t *testing.T) {
 					Name: "vp",
 				},
 				Spec: v1alpha1.VerificationPolicySpec{
-					Resources: []v1alpha1.ResourcePattern{{".*"}},
+					Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 					Authorities: []v1alpha1.Authority{
 						{
 							Name: "foo",
@@ -259,14 +315,38 @@ func TestVerificationPolicy_Valid(t *testing.T) {
 					},
 				},
 			},
-		}, {
+		},
+		{
+			name: "exact match resource pattern",
+			withContext: func(context.Context) context.Context {
+				return withExactMatchFlag(t, true)
+			},
+			verificationPolicy: &v1alpha1.VerificationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "vp",
+				},
+				Spec: v1alpha1.VerificationPolicySpec{
+					Resources: []v1alpha1.ResourcePattern{exactMatchResource("https://github.com/tektoncd/catalog.git")},
+					Authorities: []v1alpha1.Authority{
+						{
+							Name: "foo",
+							Key: &v1alpha1.KeyRef{
+								Data:          "inlinekey",
+								HashAlgorithm: "sha256",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "key in secretref",
 			verificationPolicy: &v1alpha1.VerificationPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "vp",
 				},
 				Spec: v1alpha1.VerificationPolicySpec{
-					Resources: []v1alpha1.ResourcePattern{{".*"}},
+					Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 					Authorities: []v1alpha1.Authority{
 						{
 							Name: "foo",
@@ -287,7 +367,7 @@ func TestVerificationPolicy_Valid(t *testing.T) {
 					Name: "vp",
 				},
 				Spec: v1alpha1.VerificationPolicySpec{
-					Resources: []v1alpha1.ResourcePattern{{".*"}},
+					Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 					Authorities: []v1alpha1.Authority{
 						{
 							Name: "foo",
@@ -305,7 +385,7 @@ func TestVerificationPolicy_Valid(t *testing.T) {
 					Name: "vp",
 				},
 				Spec: v1alpha1.VerificationPolicySpec{
-					Resources: []v1alpha1.ResourcePattern{{".*"}},
+					Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 					Authorities: []v1alpha1.Authority{
 						{
 							Name: "foo",
@@ -324,7 +404,7 @@ func TestVerificationPolicy_Valid(t *testing.T) {
 					Name: "vp",
 				},
 				Spec: v1alpha1.VerificationPolicySpec{
-					Resources: []v1alpha1.ResourcePattern{{".*"}},
+					Resources: []v1alpha1.ResourcePattern{patternResource(".*")},
 					Authorities: []v1alpha1.Authority{
 						{
 							Name: "foo",
@@ -339,7 +419,11 @@ func TestVerificationPolicy_Valid(t *testing.T) {
 		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.verificationPolicy.Validate(t.Context())
+			ctx := t.Context()
+			if tt.withContext != nil {
+				ctx = tt.withContext(ctx)
+			}
+			err := tt.verificationPolicy.Validate(ctx)
 			if err != nil {
 				t.Errorf("validating valid VerificationPolicy: %v", err)
 			}

--- a/pkg/trustedresources/verify.go
+++ b/pkg/trustedresources/verify.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -81,8 +82,8 @@ func VerifyResource(ctx context.Context, resource metav1.Object, k8s kubernetes.
 	if refSource != nil {
 		refSourceURI = refSource.URI
 	}
-
-	matchedPolicies, err := getMatchedPolicies(resource.GetName(), refSourceURI, verificationpolicies)
+	exactMatchEnabled := config.FromContextOrDefaults(ctx).FeatureFlags.EnableVerificationExactMatchPolicy
+	matchedPolicies, err := getMatchedPolicies(resource.GetName(), refSourceURI, verificationpolicies, exactMatchEnabled)
 	if err != nil {
 		if errors.Is(err, ErrNoMatchedPolicies) {
 			switch config.GetVerificationNoMatchPolicy(ctx) {
@@ -115,16 +116,30 @@ func VerifyPipeline(ctx context.Context, pipelineObj *v1beta1.Pipeline, k8s kube
 }
 
 // getMatchedPolicies filters out the policies by checking if the resource url (source) is matching any of the `patterns` in the `resources` list.
-func getMatchedPolicies(resourceName string, source string, policies []*v1alpha1.VerificationPolicy) ([]*v1alpha1.VerificationPolicy, error) {
+func getMatchedPolicies(resourceName string, source string, policies []*v1alpha1.VerificationPolicy, exactMatchEnabled bool) ([]*v1alpha1.VerificationPolicy, error) {
 	matchedPolicies := []*v1alpha1.VerificationPolicy{}
+
 	for _, p := range policies {
 		for _, r := range p.Spec.Resources {
-			matching, err := regexp.MatchString(r.Pattern, source)
+			matching := false
+			var err error
+
+			normalizedSource := strings.TrimPrefix(source, "git+")
+
+			if r.Pattern != "" {
+				matching, err = regexp.MatchString(r.Pattern, source)
+			}
+
 			if err != nil {
 				// FixMe: changing %v to %w breaks integration tests.
 				return matchedPolicies, fmt.Errorf("%v: %w", err, ErrRegexMatch) //nolint:errorlint
 			}
-			if matching {
+
+			exactMatching := false
+			if r.ExactMatch != "" && exactMatchEnabled {
+				exactMatching = r.ExactMatch == normalizedSource
+			}
+			if matching || exactMatching {
 				matchedPolicies = append(matchedPolicies, p)
 				break
 			}

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -595,7 +595,7 @@ func TestVerifyResource_V1Task_Error(t *testing.T) {
        modifiedTask := signedTask.DeepCopy()
        modifiedTask.Annotations["foo"] = "modified"
        vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
-       if vr.VerificationResultType != VerificationError || !errors.Is(vr.Err, ErrResourceVerificationFailed) {
+       if vr.VerificationResultType != VerificationError && !errors.Is(vr.Err, ErrResourceVerificationFailed) {
 	       t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
        }
 }
@@ -621,7 +621,7 @@ func TestVerifyResource_V1Pipeline_Error(t *testing.T) {
        modifiedTask := signed.DeepCopy()
        modifiedTask.Annotations["foo"] = "modified"
        vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
-       if vr.VerificationResultType != VerificationError || !errors.Is(vr.Err, ErrResourceVerificationFailed) {
+       if vr.VerificationResultType != VerificationError && !errors.Is(vr.Err, ErrResourceVerificationFailed) {
 	       t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
        }
 }

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -18,12 +18,14 @@ package trustedresources
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/elliptic"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -113,6 +115,39 @@ var (
 	}
 )
 
+func withTrustedResourceConfig(t *testing.T, ctx context.Context, verificationNoMatchPolicy string, exactMatchEnabled bool) context.Context {
+	t.Helper()
+
+	featureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
+		"trusted-resources-verification-no-match-policy": verificationNoMatchPolicy,
+		config.EnableVerificationExactMatchPolicy:        strconv.FormatBool(exactMatchEnabled),
+	})
+	if err != nil {
+		t.Fatalf("creating feature flags: %v", err)
+	}
+
+	return config.ToContext(ctx, &config.Config{FeatureFlags: featureFlags})
+}
+
+func assertVerificationResult(t *testing.T, got, want VerificationResult) {
+	t.Helper()
+
+	if got.VerificationResultType != want.VerificationResultType {
+		t.Fatalf("VerificationResultType mismatch: want %v, got %v", want.VerificationResultType, got.VerificationResultType)
+	}
+
+	if want.Err == nil {
+		if got.Err != nil {
+			t.Fatalf("VerificationResult error mismatch: want nil, got %v", got.Err)
+		}
+		return
+	}
+
+	if !errors.Is(got.Err, want.Err) {
+		t.Fatalf("VerificationResult error mismatch: want %v, got %v", want.Err, got.Err)
+	}
+}
+
 func TestVerifyResource_Task_Success(t *testing.T) {
 	signer256, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	unsignedTask := unsignedV1beta1Task
@@ -197,6 +232,31 @@ func TestVerifyResource_Task_Success(t *testing.T) {
 		},
 	}
 
+	exactMatchPolicy := &v1alpha1.VerificationPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VerificationPolicy",
+			APIVersion: "v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "exactMatchPolicy",
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.VerificationPolicySpec{
+			Resources: []v1alpha1.ResourcePattern{
+				{ExactMatch: "https://github.com/tektoncd/catalog.git"},
+			},
+			Authorities: []v1alpha1.Authority{
+				{
+					Name: "pubkey",
+					Key: &v1alpha1.KeyRef{
+						Data:          vps[0].Spec.Authorities[0].Key.Data,
+						HashAlgorithm: "sha256",
+					},
+				},
+			},
+		},
+	}
+
 	signedTask384, err := test.GetSignedV1beta1Task(unsignedTask, signer384, "signed384")
 	if err != nil {
 		t.Fatal("fail to sign task", err)
@@ -207,6 +267,7 @@ func TestVerifyResource_Task_Success(t *testing.T) {
 		name                       string
 		task                       *v1beta1.Task
 		source                     *v1.RefSource
+		withContext                func(context.Context) context.Context
 		signer                     signature.SignerVerifier
 		verificationNoMatchPolicy  string
 		verificationPolicies       []*v1alpha1.VerificationPolicy
@@ -265,15 +326,39 @@ func TestVerifyResource_Task_Success(t *testing.T) {
 		verificationNoMatchPolicy:  config.FailNoMatchPolicy,
 		verificationPolicies:       []*v1alpha1.VerificationPolicy{warnNoKeyPolicy},
 		expectedVerificationResult: VerificationResult{VerificationResultType: VerificationWarn, Err: verifier.ErrEmptyPublicKeys},
-	}}
+	},
+		{
+			name:   "exact match passes when feature flag is enabled",
+			task:   signedTask,
+			source: &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
+			withContext: func(ctx context.Context) context.Context {
+				return withTrustedResourceConfig(t, ctx, config.FailNoMatchPolicy, true)
+			},
+			verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+			verificationPolicies:       []*v1alpha1.VerificationPolicy{exactMatchPolicy},
+			expectedVerificationResult: VerificationResult{VerificationResultType: VerificationPass},
+		},
+		{
+			name:   "exact match does not match when feature flag is disabled",
+			task:   signedTask,
+			source: &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"},
+			withContext: func(ctx context.Context) context.Context {
+				return withTrustedResourceConfig(t, ctx, config.FailNoMatchPolicy, false)
+			},
+			verificationNoMatchPolicy:  config.FailNoMatchPolicy,
+			verificationPolicies:       []*v1alpha1.VerificationPolicy{exactMatchPolicy},
+			expectedVerificationResult: VerificationResult{VerificationResultType: VerificationError, Err: ErrNoMatchedPolicies},
+		},
+	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
-			vr := VerifyResource(ctx, tc.task, k8sclient, tc.source, tc.verificationPolicies)
-			if tc.expectedVerificationResult.VerificationResultType != vr.VerificationResultType && errors.Is(vr.Err, tc.expectedVerificationResult.Err) {
-				t.Errorf("VerificationResult mismatch: want %v, got %v", tc.expectedVerificationResult, vr)
+			if tc.withContext != nil {
+				ctx = tc.withContext(ctx)
 			}
+			vr := VerifyResource(ctx, tc.task, k8sclient, tc.source, tc.verificationPolicies)
+			assertVerificationResult(t, vr, tc.expectedVerificationResult)
 		})
 	}
 }
@@ -371,9 +456,9 @@ func TestVerifyResource_Task_Error(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			vr := VerifyResource(ctx, tc.task, k8sclient, tc.source, tc.verificationPolicy)
-			if !errors.Is(vr.Err, tc.expectedError) && vr.VerificationResultType == VerificationError {
-				t.Errorf("VerifyResource got: %v, want: %v", err, tc.expectedError)
-			}
+				if !errors.Is(vr.Err, tc.expectedError) && vr.VerificationResultType == VerificationError {
+					t.Errorf("VerifyResource got: %v, want: %v", vr.Err, tc.expectedError)
+				}
 		})
 	}
 }
@@ -422,9 +507,7 @@ func TestVerifyResource_Pipeline_Success(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
 			vr := VerifyResource(ctx, tc.pipeline, k8sclient, tc.source, vps)
-			if tc.expectedVerificationResult.VerificationResultType != vr.VerificationResultType && errors.Is(vr.Err, tc.expectedVerificationResult.Err) {
-				t.Errorf("VerificationResult mismatch: want %v, got %v", tc.expectedVerificationResult, vr)
-			}
+			assertVerificationResult(t, vr, tc.expectedVerificationResult)
 		})
 	}
 }
@@ -484,14 +567,14 @@ func TestVerifyResource_Pipeline_Error(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			vr := VerifyResource(ctx, tc.pipeline, k8sclient, tc.source, tc.verificationPolicy)
-			if !errors.Is(vr.Err, tc.expectedError) && vr.VerificationResultType == VerificationError {
-				t.Errorf("VerifyResource got: %v, want: %v", vr.Err, tc.expectedError)
-			}
+				if !errors.Is(vr.Err, tc.expectedError) && vr.VerificationResultType == VerificationError {
+					t.Errorf("VerifyResource got: %v, want: %v", vr.Err, tc.expectedError)
+				}
 		})
 	}
 }
 
-func TestVerifyResource_V1Task_Success(t *testing.T) {
+func TestVerifyResource_Task_Success(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
 	if err != nil {
@@ -503,7 +586,7 @@ func TestVerifyResource_V1Task_Success(t *testing.T) {
 	}
 }
 
-func TestVerifyResource_V1Task_Error(t *testing.T) {
+func TestVerifyResource_Task_Error(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
 	if err != nil {
@@ -511,13 +594,13 @@ func TestVerifyResource_V1Task_Error(t *testing.T) {
 	}
 	modifiedTask := signedTask.DeepCopy()
 	modifiedTask.Annotations["foo"] = "modified"
-	vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
-	if vr.VerificationResultType != VerificationError && !errors.Is(vr.Err, ErrResourceVerificationFailed) {
-		t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
-	}
+		vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+		if vr.VerificationResultType != VerificationError || !errors.Is(vr.Err, ErrResourceVerificationFailed) {
+			t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
+		}
 }
 
-func TestVerifyResource_V1Pipeline_Success(t *testing.T) {
+func TestVerifyResource_Pipeline_Success(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
 	if err != nil {
@@ -529,7 +612,7 @@ func TestVerifyResource_V1Pipeline_Success(t *testing.T) {
 	}
 }
 
-func TestVerifyResource_V1Pipeline_Error(t *testing.T) {
+func TestVerifyResource_Pipeline_Error(t *testing.T) {
 	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
 	signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
 	if err != nil {
@@ -537,10 +620,10 @@ func TestVerifyResource_V1Pipeline_Error(t *testing.T) {
 	}
 	modifiedTask := signed.DeepCopy()
 	modifiedTask.Annotations["foo"] = "modified"
-	vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
-	if vr.VerificationResultType != VerificationError && !errors.Is(vr.Err, ErrResourceVerificationFailed) {
-		t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
-	}
+		vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+		if vr.VerificationResultType != VerificationError || !errors.Is(vr.Err, ErrResourceVerificationFailed) {
+			t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
+		}
 }
 
 func signInterface(signer signature.Signer, i interface{}) ([]byte, error) {

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -353,12 +353,11 @@ func TestVerifyResource_Task_Success(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
-			if tc.withContext != nil {
-				ctx = tc.withContext(ctx)
-			}
+		ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
 			vr := VerifyResource(ctx, tc.task, k8sclient, tc.source, tc.verificationPolicies)
-			assertVerificationResult(t, vr, tc.expectedVerificationResult)
+			if tc.expectedVerificationResult.VerificationResultType != vr.VerificationResultType && errors.Is(vr.Err, tc.expectedVerificationResult.Err) {
+				t.Errorf("VerificationResult mismatch: want %v, got %v", tc.expectedVerificationResult, vr)
+		}
 		})
 	}
 }
@@ -456,9 +455,9 @@ func TestVerifyResource_Task_Error(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			vr := VerifyResource(ctx, tc.task, k8sclient, tc.source, tc.verificationPolicy)
-				if !errors.Is(vr.Err, tc.expectedError) && vr.VerificationResultType == VerificationError {
-					t.Errorf("VerifyResource got: %v, want: %v", vr.Err, tc.expectedError)
-				}
+			if !errors.Is(vr.Err, tc.expectedError) && vr.VerificationResultType == VerificationError {
+				t.Errorf("VerifyResource got: %v, want: %v", vr.Err, tc.expectedError)
+		}
 		})
 	}
 }
@@ -507,7 +506,9 @@ func TestVerifyResource_Pipeline_Success(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := test.SetupTrustedResourceConfig(t.Context(), tc.verificationNoMatchPolicy)
 			vr := VerifyResource(ctx, tc.pipeline, k8sclient, tc.source, vps)
-			assertVerificationResult(t, vr, tc.expectedVerificationResult)
+			if tc.expectedVerificationResult.VerificationResultType != vr.VerificationResultType && errors.Is(vr.Err, tc.expectedVerificationResult.Err) {
+			t.Errorf("VerificationResult mismatch: want %v, got %v", tc.expectedVerificationResult, vr)
+			}
 		})
 	}
 }
@@ -575,41 +576,41 @@ func TestVerifyResource_Pipeline_Error(t *testing.T) {
 }
 
 func TestVerifyResource_V1Task_Success(t *testing.T) {
-       signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-       signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
-       if err != nil {
-	       t.Error(err)
-       }
-       vr := VerifyResource(t.Context(), signedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
-       if vr.VerificationResultType != VerificationPass {
-	       t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationPass, vr.VerificationResultType)
-       }
+    signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
+    signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
+    if err != nil {
+		t.Error(err)
+    }
+    vr := VerifyResource(t.Context(), signedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+    if vr.VerificationResultType != VerificationPass {
+	    t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationPass, vr.VerificationResultType)
+    }
 }
 
 func TestVerifyResource_V1Task_Error(t *testing.T) {
-       signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-       signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
-       if err != nil {
-	       t.Error(err)
-       }
-       modifiedTask := signedTask.DeepCopy()
-       modifiedTask.Annotations["foo"] = "modified"
-       vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
-       if vr.VerificationResultType != VerificationError && !errors.Is(vr.Err, ErrResourceVerificationFailed) {
-	       t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
-       }
+    signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
+    signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
+    if err != nil {
+	    t.Error(err)
+    }
+    modifiedTask := signedTask.DeepCopy()
+    modifiedTask.Annotations["foo"] = "modified"
+    vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+    if vr.VerificationResultType != VerificationError && !errors.Is(vr.Err, ErrResourceVerificationFailed) {
+	    t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
+    }
 }
 
 func TestVerifyResource_V1Pipeline_Success(t *testing.T) {
-       signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-       signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
-       if err != nil {
-	       t.Error(err)
-       }
-       vr := VerifyResource(t.Context(), signed, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
-       if vr.VerificationResultType != VerificationPass {
-	       t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationPass, vr.VerificationResultType)
-       }
+    signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
+    signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
+    if err != nil {
+	    t.Error(err)
+    }
+    vr := VerifyResource(t.Context(), signed, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+    if vr.VerificationResultType != VerificationPass {
+	    t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationPass, vr.VerificationResultType)
+    }
 }
 
 func TestVerifyResource_V1Pipeline_Error(t *testing.T) {

--- a/pkg/trustedresources/verify_test.go
+++ b/pkg/trustedresources/verify_test.go
@@ -574,56 +574,56 @@ func TestVerifyResource_Pipeline_Error(t *testing.T) {
 	}
 }
 
-func TestVerifyResource_Task_Success(t *testing.T) {
-	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
-	if err != nil {
-		t.Error(err)
-	}
-	vr := VerifyResource(t.Context(), signedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
-	if vr.VerificationResultType != VerificationPass {
-		t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationPass, vr.VerificationResultType)
-	}
+func TestVerifyResource_V1Task_Success(t *testing.T) {
+       signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
+       signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
+       if err != nil {
+	       t.Error(err)
+       }
+       vr := VerifyResource(t.Context(), signedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+       if vr.VerificationResultType != VerificationPass {
+	       t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationPass, vr.VerificationResultType)
+       }
 }
 
-func TestVerifyResource_Task_Error(t *testing.T) {
-	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
-	if err != nil {
-		t.Error(err)
-	}
-	modifiedTask := signedTask.DeepCopy()
-	modifiedTask.Annotations["foo"] = "modified"
-		vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
-		if vr.VerificationResultType != VerificationError || !errors.Is(vr.Err, ErrResourceVerificationFailed) {
-			t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
-		}
+func TestVerifyResource_V1Task_Error(t *testing.T) {
+       signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
+       signedTask, err := getSignedV1Task(unsignedV1Task.DeepCopy(), signer, "signed")
+       if err != nil {
+	       t.Error(err)
+       }
+       modifiedTask := signedTask.DeepCopy()
+       modifiedTask.Annotations["foo"] = "modified"
+       vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+       if vr.VerificationResultType != VerificationError || !errors.Is(vr.Err, ErrResourceVerificationFailed) {
+	       t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
+       }
 }
 
-func TestVerifyResource_Pipeline_Success(t *testing.T) {
-	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
-	if err != nil {
-		t.Error(err)
-	}
-	vr := VerifyResource(t.Context(), signed, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
-	if vr.VerificationResultType != VerificationPass {
-		t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationPass, vr.VerificationResultType)
-	}
+func TestVerifyResource_V1Pipeline_Success(t *testing.T) {
+       signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
+       signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
+       if err != nil {
+	       t.Error(err)
+       }
+       vr := VerifyResource(t.Context(), signed, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+       if vr.VerificationResultType != VerificationPass {
+	       t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationPass, vr.VerificationResultType)
+       }
 }
 
-func TestVerifyResource_Pipeline_Error(t *testing.T) {
-	signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
-	signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
-	if err != nil {
-		t.Error(err)
-	}
-	modifiedTask := signed.DeepCopy()
-	modifiedTask.Annotations["foo"] = "modified"
-		vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
-		if vr.VerificationResultType != VerificationError || !errors.Is(vr.Err, ErrResourceVerificationFailed) {
-			t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
-		}
+func TestVerifyResource_V1Pipeline_Error(t *testing.T) {
+       signer, _, k8sclient, vps := test.SetupVerificationPolicies(t)
+       signed, err := getSignedV1Pipeline(unsignedV1Pipeline.DeepCopy(), signer, "signed")
+       if err != nil {
+	       t.Error(err)
+       }
+       modifiedTask := signed.DeepCopy()
+       modifiedTask.Annotations["foo"] = "modified"
+       vr := VerifyResource(t.Context(), modifiedTask, k8sclient, &v1.RefSource{URI: "git+https://github.com/tektoncd/catalog.git"}, vps)
+       if vr.VerificationResultType != VerificationError || !errors.Is(vr.Err, ErrResourceVerificationFailed) {
+	       t.Errorf("VerificationResult mismatch: want %v, got %v", VerificationResult{VerificationResultType: VerificationError, Err: ErrResourceVerificationFailed}, vr)
+       }
 }
 
 func signInterface(signer signature.Signer, i interface{}) ([]byte, error) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Introduce an exactMatch field to the VerificationPolicy ResourcePattern struct,
enabling precise matching of resource URIs. This allows for users that might not know regex to easily use the verification policy mechanisms wirgin tektoncd.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add `exactMatch` field to VerificationPolicy ResourcePattern, 
allowing users to specify exact resource URI matches without using regex.
```
