### PR TITLE
[cherry-pick: release-v1.9.x] Fix running_taskruns metric overcounting TaskRuns with no condition

### DIFF
--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -412,18 +412,16 @@ func (r *Recorder) RunningPipelineRuns(lister listers.PipelineRunLister) error {
 		if err_ != nil {
 			return err
 		}
-		if !pr.IsDone() && !pr.IsPending() {
+		succeedCondition := pr.Status.GetCondition(apis.ConditionSucceeded)
+		if succeedCondition != nil && succeedCondition.IsUnknown() && !pr.IsPending() {
 			countMap[pipelineRunKey]++
 			metrics.Record(ctx_, runningPRs.M(float64(countMap[pipelineRunKey])))
 			runningPipelineRuns++
-			succeedCondition := pr.Status.GetCondition(apis.ConditionSucceeded)
-			if succeedCondition != nil && succeedCondition.Status == corev1.ConditionUnknown {
-				switch succeedCondition.Reason {
-				case v1.TaskRunReasonResolvingTaskRef:
-					trsWaitResolvingTaskRef++
-				case v1.PipelineRunReasonResolvingPipelineRef.String():
-					prsWaitResolvingPipelineRef++
-				}
+			switch succeedCondition.Reason {
+			case v1.TaskRunReasonResolvingTaskRef:
+				trsWaitResolvingTaskRef++
+			case v1.PipelineRunReasonResolvingPipelineRef.String():
+				prsWaitResolvingPipelineRef++
 			}
 		} else {
 			// In case there are no running PipelineRuns for the pipelineRunKey, set the metric value to 0 to ensure

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -844,3 +844,30 @@ func getLastValueData(rows []*view.Row, wantTags map[string]string) *view.LastVa
 	}
 	return nil
 }
+
+func TestRecordRunningPipelineRunsNoCondition(t *testing.T) {
+	unregisterMetrics()
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	informer := fakepipelineruninformer.Get(ctx)
+
+	// Add a PipelineRun with no Succeeded condition (before first reconcile)
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-no-condition", Namespace: "ns"},
+		Status:     v1.PipelineRunStatus{},
+	}
+	if err := informer.Informer().GetIndexer().Add(pr); err != nil {
+		t.Fatalf("Adding PipelineRun to informer: %v", err)
+	}
+
+	ctx = getConfigContext(false)
+	metrics, err := NewRecorder(ctx)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	if err := metrics.RunningPipelineRuns(informer.Lister()); err != nil {
+		t.Errorf("RunningPipelineRuns: %v", err)
+	}
+	metricstest.CheckLastValueData(t, "running_pipelineruns", map[string]string{}, 0)
+}

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -453,25 +453,23 @@ func (r *Recorder) RunningTaskRuns(ctx context.Context, lister listers.TaskRunLi
 			trsThrottledByNode[pr.Namespace] = 0
 		}
 
-		if pr.IsDone() {
+		succeedCondition := pr.Status.GetCondition(apis.ConditionSucceeded)
+		if succeedCondition == nil || !succeedCondition.IsUnknown() {
 			continue
 		}
 		runningTrs++
 
-		succeedCondition := pr.Status.GetCondition(apis.ConditionSucceeded)
-		if succeedCondition != nil && succeedCondition.Status == corev1.ConditionUnknown {
-			switch succeedCondition.Reason {
-			case pod.ReasonExceededResourceQuota:
-				cnt := trsThrottledByQuota[pr.Namespace]
-				cnt++
-				trsThrottledByQuota[pr.Namespace] = cnt
-			case pod.ReasonExceededNodeResources:
-				cnt := trsThrottledByNode[pr.Namespace]
-				cnt++
-				trsThrottledByNode[pr.Namespace] = cnt
-			case v1.TaskRunReasonResolvingTaskRef:
-				trsWaitResolvingTaskRef++
-			}
+		switch succeedCondition.Reason {
+		case pod.ReasonExceededResourceQuota:
+			cnt := trsThrottledByQuota[pr.Namespace]
+			cnt++
+			trsThrottledByQuota[pr.Namespace] = cnt
+		case pod.ReasonExceededNodeResources:
+			cnt := trsThrottledByNode[pr.Namespace]
+			cnt++
+			trsThrottledByNode[pr.Namespace] = cnt
+		case v1.TaskRunReasonResolvingTaskRef:
+			trsWaitResolvingTaskRef++
 		}
 	}
 

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -930,3 +930,30 @@ func unregisterMetrics() {
 	r = nil
 	errRegistering = nil
 }
+
+func TestRecordRunningTaskRunsNoCondition(t *testing.T) {
+	unregisterMetrics()
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	informer := faketaskruninformer.Get(ctx)
+
+	// Add a TaskRun with no Succeeded condition (before first reconcile)
+	tr := &v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "taskrun-no-condition", Namespace: "ns"},
+		Status:     v1.TaskRunStatus{},
+	}
+	if err := informer.Informer().GetIndexer().Add(tr); err != nil {
+		t.Fatalf("Adding TaskRun to informer: %v", err)
+	}
+
+	ctx = getConfigContext(false, false)
+	metrics, err := NewRecorder(ctx)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	if err := metrics.RunningTaskRuns(ctx, informer.Lister()); err != nil {
+		t.Errorf("RunningTaskRuns: %v", err)
+	}
+	metricstest.CheckLastValueData(t, "running_taskruns", map[string]string{}, 0)
+}


### PR DESCRIPTION
This is a manual backport of #9485 to release-v1.9.x

---

Replace !tr.IsDone() with an explicit nil + ConditionUnknown check so that newly created TaskRuns (before their first reconcile) are no longer counted as running. Apply the same fix to PipelineRun metrics.

Fixes #9438

# Changes

- **taskrunmetrics**: Replace `!pr.IsDone()` with `succeedCondition == nil || !succeedCondition.IsUnknown()` guard
- **pipelinerunmetrics**: Replace `!pr.IsDone() && !pr.IsPending()` with `succeedCondition != nil && succeedCondition.IsUnknown() && !pr.IsPending()`
- Add tests for TaskRuns and PipelineRuns with no Succeeded condition

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed overcounting in the `running_taskruns` metric for `TaskRun`s with no condition set yet.
```