### PR TITLE
fix: mask sa-token from logs

### DIFF
--- a/cmd/entrypoint/masking_writer.go
+++ b/cmd/entrypoint/masking_writer.go
@@ -1,0 +1,109 @@
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"regexp"
+)
+
+const maskReplacment = "***"
+
+// JWT tokens always have the same structure:
+// |______ header ______|.|______ payload ________|.|______ signature ______|
+var jwtPattern = regexp.MustCompile(`eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`)
+
+type maskingWriter struct {
+	underlying    io.Writer
+	carry         []byte
+	maskTokenByte []byte
+}
+
+func newMaskingWriter(w io.Writer) *maskingWriter {
+	return &maskingWriter{
+		underlying:    w,
+		carry:         make([]byte, 0, 4096),
+		maskTokenByte: []byte(maskReplacment),
+	}
+}
+
+func (m *maskingWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	m.carry = append(m.carry, p...)
+	// Find all JWT matches in the carry buffer
+	loc := jwtPattern.FindIndex(m.carry)
+	if loc == nil {
+		// No match found. Flush everything except a trailing portion
+		// that could be the start of a JWT (starts with "eyJ").
+		safeEnd := m.safeCutPoint()
+		if safeEnd > 0 {
+			if _, err := m.underlying.Write(m.carry[:safeEnd]); err != nil {
+				return len(p), err
+			}
+			m.carry = append(m.carry[:0], m.carry[safeEnd:]...)
+		}
+		return len(p), nil
+	}
+	// Match found — flush everything before it, write the mask, keep the rest
+	var out bytes.Buffer
+	for loc != nil {
+		out.Write(m.carry[:loc[0]])
+		out.Write(m.maskTokenByte)
+		m.carry = append(m.carry[:0], m.carry[loc[1]:]...)
+		loc = jwtPattern.FindIndex(m.carry)
+	}
+	// Flush safe portion of remaining carry
+	safeEnd := m.safeCutPoint()
+	if safeEnd > 0 {
+		out.Write(m.carry[:safeEnd])
+		m.carry = append(m.carry[:0], m.carry[safeEnd:]...)
+	}
+	if out.Len() > 0 {
+		if _, err := m.underlying.Write(out.Bytes()); err != nil {
+			return len(p), err
+		}
+	}
+	return len(p), nil
+}
+
+// safeCutPoint searches for the first appearance of "eyJ" or the prefix of it.
+// Returns the index which up until it we can safely flush
+func (m *maskingWriter) safeCutPoint() int {
+	n := len(m.carry)
+	if n == 0 {
+		return 0
+	}
+	firstEyJ := bytes.Index(m.carry, []byte("eyJ"))
+	if firstEyJ != -1 {
+		return firstEyJ
+	}
+	for i := max(0, n-2); i < n; i++ {
+		tail := string(m.carry[i:])
+		if isJWTPrefix(tail) {
+			return i
+		}
+	}
+	return n
+}
+
+func isJWTPrefix(s string) bool {
+	prefix := "eyJ"
+	if len(s) > len(prefix) {
+		return false
+	}
+	return prefix[:len(s)] == s
+}
+
+func (m *maskingWriter) Flush() error {
+	if len(m.carry) == 0 {
+		return nil
+	}
+	// On flush, redact any remaining matches and write everything
+	result := jwtPattern.ReplaceAll(m.carry, m.maskTokenByte)
+	_, err := m.underlying.Write(result)
+	m.carry = m.carry[:0]
+	return err
+}

--- a/cmd/entrypoint/masking_writer_test.go
+++ b/cmd/entrypoint/masking_writer_test.go
@@ -1,0 +1,145 @@
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+const fakeJWT = "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dGVzdHNpZ25hdHVyZQ"
+
+func TestMaskingWriter(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no JWT present",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "single JWT",
+			input:    "TOKEN=" + fakeJWT + "!",
+			expected: "TOKEN=***!",
+		},
+		{
+			name:     "multiple JWTs",
+			input:    "a=" + fakeJWT + " b=" + fakeJWT,
+			expected: "a=*** b=***",
+		},
+		{
+			name:     "set -x style output",
+			input:    "+ TOKEN=" + fakeJWT + "\n+ echo done\n",
+			expected: "+ TOKEN=***\n+ echo done\n",
+		},
+		{
+			name:     "no false positive on partial eyJ",
+			input:    "eyJust some text",
+			expected: "eyJust some text",
+		},
+		{
+			name:     "JWT at end of input (no trailing char)",
+			input:    "TOKEN=" + fakeJWT,
+			expected: "TOKEN=***",
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := newMaskingWriter(&buf)
+			if _, err := w.Write([]byte(tc.input)); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatalf("unexpected flush error: %v", err)
+			}
+			if got := buf.String(); got != tc.expected {
+				t.Errorf("got %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMaskingWriterSplitAcrossWrites(t *testing.T) {
+	var buf bytes.Buffer
+	w := newMaskingWriter(&buf)
+
+	// Split the JWT across two writes — the "eyJ" start is in write #1,
+	// the rest comes in write #2
+	jwt := fakeJWT
+	splitPoint := 10 // splits in the middle of the header
+	if _, err := w.Write([]byte("prefix " + jwt[:splitPoint])); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := w.Write([]byte(jwt[splitPoint:] + " suffix")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("unexpected flush error: %v", err)
+	}
+
+	if got, want := buf.String(), "prefix *** suffix"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestMaskingWriterPartialPrefixHeldBack(t *testing.T) {
+	var buf bytes.Buffer
+	w := newMaskingWriter(&buf)
+
+	// Write ends with "ey" — should be held back in carry
+	if _, err := w.Write([]byte("some text ey")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Next write completes it as NOT a JWT
+	if _, err := w.Write([]byte("es are blue")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("unexpected flush error: %v", err)
+	}
+
+	if got, want := buf.String(), "some text eyes are blue"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestMaskingWriterMultipleWritesNoJWT(t *testing.T) {
+	var buf bytes.Buffer
+	w := newMaskingWriter(&buf)
+
+	writes := []string{"hello ", "world ", "no secrets here\n"}
+	for _, s := range writes {
+		if _, err := w.Write([]byte(s)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("unexpected flush error: %v", err)
+	}
+
+	if got, want := buf.String(), "hello world no secrets here\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestMaskingWriterFlushWithNoData(t *testing.T) {
+	var buf bytes.Buffer
+	w := newMaskingWriter(&buf)
+
+	if err := w.Flush(); err != nil {
+		t.Fatalf("unexpected flush error: %v", err)
+	}
+	if got := buf.String(); got != "" {
+		t.Errorf("expected empty output, got %q", got)
+	}
+}

--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -88,25 +88,33 @@ func (rr *realRunner) Run(ctx context.Context, args ...string) error {
 
 	// if a standard output file is specified
 	// create the log file and add to the std multi writer
+	stdoutMask := newMaskingWriter(os.Stdout)
+	defer stdoutMask.Flush()
 	if rr.stdoutPath != "" {
 		stdout, err := newStdLogWriter(rr.stdoutPath)
 		if err != nil {
 			return err
 		}
 		defer stdout.Close()
-		cmd.Stdout = io.MultiWriter(os.Stdout, stdout)
+		stdoutFileMask := newMaskingWriter(stdout)
+		defer stdoutFileMask.Flush()
+		cmd.Stdout = io.MultiWriter(stdoutMask, stdoutFileMask)
 	} else {
-		cmd.Stdout = os.Stdout
+		cmd.Stdout = stdoutMask
 	}
+	stderrMask := newMaskingWriter(os.Stderr)
+	defer stderrMask.Flush()
 	if rr.stderrPath != "" {
 		stderr, err := newStdLogWriter(rr.stderrPath)
 		if err != nil {
 			return err
 		}
 		defer stderr.Close()
-		cmd.Stderr = io.MultiWriter(os.Stderr, stderr)
+		stderrFileMask := newMaskingWriter(stderr)
+		defer stderrFileMask.Flush()
+		cmd.Stderr = io.MultiWriter(stderrMask, stderrFileMask)
 	} else {
-		cmd.Stderr = os.Stderr
+		cmd.Stderr = stderrMask
 	}
 
 	// dedicated PID group used to forward signals to


### PR DESCRIPTION
fixes #9714 (not entirely, just token masking)

The problem: When a Tekton step script uses set -x (bash debug mode), the service account JWT token gets printed to stdout as part of the shell trace. This token is then persisted in the container logs and visible via kubectl logs

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Added a streaming maskingWriter in the Tekton entrypoint that intercepts all step output (stdout and stderr) and redacts JWT tokens before they reach the container log using regex by replacing them with "***"
The maskingWriter is an io.Writer wrapper that sits between the step process and the actual output, and  detect token using the known format of a token (|______ header ______|.|______ payload ________|.|______ signature ______|)

The files include:

- **masking_writer.go** - main logic. Uses a carry buffer to ensure no token is missed if it come in 2 Writes. This is where "suspicious" bytes are at. Once we are sure bytes are clean and can be flushed to io.Writer, they move to a temporary "out" buffer and then gets flushed.

- **masking_writer_test.go** - tests several edge cases (several JWT in a single write, JWT is split between 2 writes, no JWT at all to ensure not harming current state..)

- **runner.go**- Wiring the maskingWriter to stdout. overall 4 instances (stdout, stderr, logs and terminal for each)

Current state (token is leaked to logs) when using set -x in a step:

```
` k logs token-leak-test-pod -c step-leak-token

+ cat /var/run/secrets/kubernetes.io/serviceaccount/token
Authorization: Bearer eyJhbGciOiJ...QDXNA
+ TOKEN=eyJhbGciOiJSUzI1Ni...X7QDXNA
+ echo 'Authorization: Bearer eyJhbGci...X7QDXNA' `


```
After the fix- token is masked: 


```
k logs token-leak-test-pod -c step-leak-token
+ cat /var/run/secrets/kubernetes.io/serviceaccount/token
+ TOKEN=***
+ echo 'Authorization: Bearer ***'
Authorization: Bearer ***`
```

** I tried to stay consistent with the original idea in here #9359, as I assume final implementation for the entire masking problem will be similar. 



# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Entrypoint now redacts JWT service account tokens from step stdout/stderr logs to prevent credential leakage when using `set -x` or other verbose shell logging in step scripts.
```
