### PR TITLE
feat(tracing): add spans to timeout and cancellation code paths

### DIFF
--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -28,6 +28,8 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -73,6 +75,9 @@ func init() {
 }
 
 func cancelCustomRun(ctx context.Context, runName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "cancelCustomRun",
+		trace.WithAttributes(attribute.String("customRun.name", runName)))
+	defer span.End()
 	_, err := clientSet.TektonV1beta1().CustomRuns(namespace).Patch(ctx, runName, types.JSONPatchType, cancelCustomRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
 		// The resource may have been deleted in the meanwhile, but we should
@@ -83,6 +88,9 @@ func cancelCustomRun(ctx context.Context, runName string, namespace string, clie
 }
 
 func cancelTaskRun(ctx context.Context, taskRunName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "cancelTaskRun",
+		trace.WithAttributes(attribute.String("taskRun.name", taskRunName)))
+	defer span.End()
 	_, err := clientSet.TektonV1().TaskRuns(namespace).Patch(ctx, taskRunName, types.JSONPatchType, cancelTaskRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
 		// The resource may have been deleted in the meanwhile, but we should
@@ -98,6 +106,9 @@ func cancelTaskRun(ctx context.Context, taskRunName string, namespace string, cl
 
 // cancelPipelineRun marks the PipelineRun as cancelled and any resolved TaskRun(s) too.
 func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface) error {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "cancelPipelineRun",
+		trace.WithAttributes(attribute.String("pipelineRun.name", pr.Name)))
+	defer span.End()
 	errs := cancelPipelineTaskRuns(ctx, logger, pr, clientSet)
 
 	// If we successfully cancelled all the TaskRuns and Runs, we can consider the PipelineRun cancelled.
@@ -133,6 +144,12 @@ func cancelPipelineTaskRuns(ctx context.Context, logger *zap.SugaredLogger, pr *
 
 // cancelPipelineTaskRunsForTaskNames patches `TaskRun`s and `Run`s for the given task names, or all if no task names are given, with canceled status
 func cancelPipelineTaskRunsForTaskNames(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface, taskNames sets.String) []string {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "cancelPipelineTaskRunsForTaskNames",
+		trace.WithAttributes(
+			attribute.String("pipelineRun.name", pr.Name),
+			attribute.Int("taskNames.count", taskNames.Len()),
+		))
+	defer span.End()
 	errs := []string{}
 
 	trNames, customRunNames, err := getChildObjectsFromPRStatusForTaskNames(ctx, pr.Status, taskNames)
@@ -190,6 +207,9 @@ func getChildObjectsFromPRStatusForTaskNames(ctx context.Context, prs v1.Pipelin
 
 // gracefullyCancelPipelineRun marks any non-final resolved TaskRun(s) as cancelled and runs finally.
 func gracefullyCancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface) error {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "gracefullyCancelPipelineRun",
+		trace.WithAttributes(attribute.String("pipelineRun.name", pr.Name)))
+	defer span.End()
 	errs := cancelPipelineTaskRuns(ctx, logger, pr, clientSet)
 
 	// If we successfully cancelled all the TaskRuns and Runs, we can proceed with the PipelineRun reconciliation to trigger finally.

--- a/pkg/reconciler/pipelinerun/timeout.go
+++ b/pkg/reconciler/pipelinerun/timeout.go
@@ -25,6 +25,8 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -71,6 +73,9 @@ func init() {
 
 // timeoutPipelineRun marks the PipelineRun as timed out and any resolved TaskRun(s) too.
 func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface) error {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "timeoutPipelineRun",
+		trace.WithAttributes(attribute.String("pipelineRun.name", pr.Name)))
+	defer span.End()
 	errs := timeoutPipelineTasks(ctx, logger, pr, clientSet)
 
 	// If we successfully timed out all the TaskRuns and Runs, we can consider the PipelineRun timed out.
@@ -93,6 +98,9 @@ func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.P
 }
 
 func timeoutCustomRun(ctx context.Context, customRunName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "timeoutCustomRun",
+		trace.WithAttributes(attribute.String("customRun.name", customRunName)))
+	defer span.End()
 	_, err := clientSet.TektonV1beta1().CustomRuns(namespace).Patch(ctx, customRunName, types.JSONPatchType, timeoutCustomRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
 		return nil
@@ -101,6 +109,9 @@ func timeoutCustomRun(ctx context.Context, customRunName string, namespace strin
 }
 
 func timeoutTaskRun(ctx context.Context, taskRunName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "timeoutTaskRun",
+		trace.WithAttributes(attribute.String("taskRun.name", taskRunName)))
+	defer span.End()
 	_, err := clientSet.TektonV1().TaskRuns(namespace).Patch(ctx, taskRunName, types.JSONPatchType, timeoutTaskRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
 		return nil
@@ -115,6 +126,12 @@ func timeoutPipelineTasks(ctx context.Context, logger *zap.SugaredLogger, pr *v1
 
 // timeoutPipelineTasksForTaskNames patches `TaskRun`s and `Run`s for the given task names, or all if no task names are given, with canceled status and appropriate message
 func timeoutPipelineTasksForTaskNames(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface, taskNames sets.String) []string {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "timeoutPipelineTasksForTaskNames",
+		trace.WithAttributes(
+			attribute.String("pipelineRun.name", pr.Name),
+			attribute.Int("taskNames.count", taskNames.Len()),
+		))
+	defer span.End()
 	errs := []string{}
 
 	trNames, customRunNames, err := getChildObjectsFromPRStatusForTaskNames(ctx, pr.Status, taskNames)


### PR DESCRIPTION
Refs #9783 (part of umbrella #9701).

Cancellation and timeout of a PipelineRun patch N child TaskRuns and CustomRuns in sequence, but the standalone helpers in `pkg/reconciler/pipelinerun/cancel.go` and `pkg/reconciler/pipelinerun/timeout.go` had zero OTel instrumentation. When a run timed out, the trace ended at the reconciler span with no visibility into which children were patched or how long each patch took.

## Changes

Wraps the following functions with `trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start` / `span.End`, using the tracer provider already attached to the incoming context by the reconciler's root span:

- `cancel.go`: `cancelPipelineRun`, `gracefullyCancelPipelineRun`, `cancelPipelineTaskRunsForTaskNames`, `cancelTaskRun`, `cancelCustomRun`
- `timeout.go`: `timeoutPipelineRun`, `timeoutPipelineTasksForTaskNames`, `timeoutTaskRun`, `timeoutCustomRun`

## Span attributes

- Top-level spans (`cancelPipelineRun`, `gracefullyCancelPipelineRun`, `timeoutPipelineRun`) record `pipelineRun.name`.
- Fan-out helpers (`cancelPipelineTaskRunsForTaskNames`, `timeoutPipelineTasksForTaskNames`) additionally record `taskNames.count` so "cancel all vs cancel subset" is visible.
- Per-child spans record the `taskRun.name` or `customRun.name` they patched, which is what the issue called out as "which children were patched, how long each patch took".

`defer span.End()` is used throughout; error recording on spans is out of scope here (umbrella #9701 tracks that as a separate bullet).

## Verification

- `go build ./pkg/reconciler/pipelinerun/...`
- `go vet ./pkg/reconciler/pipelinerun/...`
- `gofmt -l pkg/reconciler/pipelinerun/cancel.go pkg/reconciler/pipelinerun/timeout.go` (clean)
- `go test ./pkg/reconciler/pipelinerun/... -run 'TestCancelPipelineRun|TestTimeoutPipelineRun'` (pass)