### PR TITLE
feat(tracing): add spans to pipelinerun cancel & timeout

### DIFF
--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -28,6 +28,9 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -72,33 +75,65 @@ func init() {
 	}
 }
 
-func cancelCustomRun(ctx context.Context, runName string, namespace string, clientSet clientset.Interface) error {
+func cancelCustomRun(ctx context.Context, tp trace.TracerProvider, runName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := tp.Tracer(TracerName).Start(ctx, "cancelCustomRun",
+		trace.WithAttributes(
+			attribute.String("customrun.name", runName),
+			attribute.String("customrun.namespace", namespace),
+		))
+	defer span.End()
+
 	_, err := clientSet.TektonV1beta1().CustomRuns(namespace).Patch(ctx, runName, types.JSONPatchType, cancelCustomRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
 		// The resource may have been deleted in the meanwhile, but we should
 		// still be able to cancel the PipelineRun
+		span.SetAttributes(attribute.Bool("customrun.not_found", true))
 		return nil
+	}
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
 	}
 	return err
 }
 
-func cancelTaskRun(ctx context.Context, taskRunName string, namespace string, clientSet clientset.Interface) error {
+func cancelTaskRun(ctx context.Context, tp trace.TracerProvider, taskRunName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := tp.Tracer(TracerName).Start(ctx, "cancelTaskRun",
+		trace.WithAttributes(
+			attribute.String("taskrun.name", taskRunName),
+			attribute.String("taskrun.namespace", namespace),
+		))
+	defer span.End()
+
 	_, err := clientSet.TektonV1().TaskRuns(namespace).Patch(ctx, taskRunName, types.JSONPatchType, cancelTaskRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
 		// The resource may have been deleted in the meanwhile, but we should
 		// still be able to cancel the PipelineRun
+		span.SetAttributes(attribute.Bool("taskrun.not_found", true))
 		return nil
 	}
 	if pipelineErrors.IsImmutableTaskRunSpecError(err) {
 		// The TaskRun may have completed and the spec field is immutable, we should ignore this error.
+		span.SetAttributes(attribute.Bool("taskrun.spec_immutable", true))
 		return nil
+	}
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
 	}
 	return err
 }
 
 // cancelPipelineRun marks the PipelineRun as cancelled and any resolved TaskRun(s) too.
-func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface) error {
-	errs := cancelPipelineTaskRuns(ctx, logger, pr, clientSet)
+func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, tp trace.TracerProvider, pr *v1.PipelineRun, clientSet clientset.Interface) error {
+	ctx, span := tp.Tracer(TracerName).Start(ctx, "cancelPipelineRun",
+		trace.WithAttributes(
+			attribute.String("pipelinerun.name", pr.Name),
+			attribute.String("pipelinerun.namespace", pr.Namespace),
+		))
+	defer span.End()
+
+	errs := cancelPipelineTaskRuns(ctx, logger, tp, pr, clientSet)
 
 	// If we successfully cancelled all the TaskRuns and Runs, we can consider the PipelineRun cancelled.
 	if len(errs) == 0 {
@@ -112,6 +147,8 @@ func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.Pi
 		})
 		// update pr completed time
 		pr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+
+		span.SetAttributes(attribute.String("pipelinerun.cancel_result", "success"))
 	} else {
 		e := strings.Join(errs, "\n")
 		// Indicate that we failed to cancel the PipelineRun
@@ -121,18 +158,29 @@ func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.Pi
 			Reason:  v1.PipelineRunReasonCouldntCancel.String(),
 			Message: fmt.Sprintf("PipelineRun %q was cancelled but had errors trying to cancel TaskRuns and/or Runs: %s", pr.Name, e),
 		})
-		return fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		combinedErr := fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		span.SetStatus(codes.Error, combinedErr.Error())
+		span.RecordError(combinedErr)
+		return combinedErr
 	}
 	return nil
 }
 
 // cancelPipelineTaskRuns patches `TaskRun` and `Run` with canceled status
-func cancelPipelineTaskRuns(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface) []string {
-	return cancelPipelineTaskRunsForTaskNames(ctx, logger, pr, clientSet, sets.NewString())
+func cancelPipelineTaskRuns(ctx context.Context, logger *zap.SugaredLogger, tp trace.TracerProvider, pr *v1.PipelineRun, clientSet clientset.Interface) []string {
+	return cancelPipelineTaskRunsForTaskNames(ctx, logger, tp, pr, clientSet, sets.NewString())
 }
 
 // cancelPipelineTaskRunsForTaskNames patches `TaskRun`s and `Run`s for the given task names, or all if no task names are given, with canceled status
-func cancelPipelineTaskRunsForTaskNames(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface, taskNames sets.String) []string {
+func cancelPipelineTaskRunsForTaskNames(ctx context.Context, logger *zap.SugaredLogger, tp trace.TracerProvider, pr *v1.PipelineRun, clientSet clientset.Interface, taskNames sets.String) []string {
+	ctx, span := tp.Tracer(TracerName).Start(ctx, "cancelPipelineTaskRunsForTaskNames",
+		trace.WithAttributes(
+			attribute.String("pipelinerun.name", pr.Name),
+			attribute.String("pipelinerun.namespace", pr.Namespace),
+			attribute.Int("tasknames.filter_count", taskNames.Len()),
+		))
+	defer span.End()
+
 	errs := []string{}
 
 	trNames, customRunNames, err := getChildObjectsFromPRStatusForTaskNames(ctx, pr.Status, taskNames)
@@ -140,10 +188,15 @@ func cancelPipelineTaskRunsForTaskNames(ctx context.Context, logger *zap.Sugared
 		errs = append(errs, err.Error())
 	}
 
+	span.SetAttributes(
+		attribute.Int("taskruns.count", len(trNames)),
+		attribute.Int("customruns.count", len(customRunNames)),
+	)
+
 	for _, taskRunName := range trNames {
 		logger.Infof("cancelling TaskRun %s", taskRunName)
 
-		if err := cancelTaskRun(ctx, taskRunName, pr.Namespace, clientSet); err != nil {
+		if err := cancelTaskRun(ctx, tp, taskRunName, pr.Namespace, clientSet); err != nil {
 			errs = append(errs, fmt.Errorf("failed to patch TaskRun `%s` with cancellation: %w", taskRunName, err).Error())
 			continue
 		}
@@ -152,10 +205,16 @@ func cancelPipelineTaskRunsForTaskNames(ctx context.Context, logger *zap.Sugared
 	for _, runName := range customRunNames {
 		logger.Infof("cancelling CustomRun %s", runName)
 
-		if err := cancelCustomRun(ctx, runName, pr.Namespace, clientSet); err != nil {
+		if err := cancelCustomRun(ctx, tp, runName, pr.Namespace, clientSet); err != nil {
 			errs = append(errs, fmt.Errorf("failed to patch CustomRun `%s` with cancellation: %w", runName, err).Error())
 			continue
 		}
+	}
+
+	if len(errs) > 0 {
+		combined := strings.Join(errs, "; ")
+		span.SetStatus(codes.Error, combined)
+		span.RecordError(fmt.Errorf("%s", combined))
 	}
 	return errs
 }
@@ -189,8 +248,16 @@ func getChildObjectsFromPRStatusForTaskNames(ctx context.Context, prs v1.Pipelin
 }
 
 // gracefullyCancelPipelineRun marks any non-final resolved TaskRun(s) as cancelled and runs finally.
-func gracefullyCancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface) error {
-	errs := cancelPipelineTaskRuns(ctx, logger, pr, clientSet)
+func gracefullyCancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, tp trace.TracerProvider, pr *v1.PipelineRun, clientSet clientset.Interface) error {
+	ctx, span := tp.Tracer(TracerName).Start(ctx, "gracefullyCancelPipelineRun",
+		trace.WithAttributes(
+			attribute.String("pipelinerun.name", pr.Name),
+			attribute.String("pipelinerun.namespace", pr.Namespace),
+			attribute.Bool("pipelinerun.graceful", true),
+		))
+	defer span.End()
+
+	errs := cancelPipelineTaskRuns(ctx, logger, tp, pr, clientSet)
 
 	// If we successfully cancelled all the TaskRuns and Runs, we can proceed with the PipelineRun reconciliation to trigger finally.
 	if len(errs) > 0 {
@@ -202,7 +269,11 @@ func gracefullyCancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger,
 			Reason:  v1.PipelineRunReasonCouldntCancel.String(),
 			Message: fmt.Sprintf("PipelineRun %q was cancelled but had errors trying to cancel TaskRuns and/or Runs: %s", pr.Name, e),
 		})
-		return fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		combinedErr := fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		span.SetStatus(codes.Error, combinedErr.Error())
+		span.RecordError(combinedErr)
+		return combinedErr
 	}
+	span.SetAttributes(attribute.String("pipelinerun.cancel_result", "success_will_run_finally"))
 	return nil
 }

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -28,6 +28,7 @@ import (
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
+	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -308,7 +309,7 @@ func TestCancelPipelineRun(t *testing.T) {
 			defer cancel()
 			c, _ := test.SeedTestData(t, ctx, d)
 
-			err := cancelPipelineRun(ctx, logtesting.TestLogger(t), tc.pipelineRun, c.Pipeline)
+			err := cancelPipelineRun(ctx, logtesting.TestLogger(t), trace.NewNoopTracerProvider(), tc.pipelineRun, c.Pipeline)
 			if tc.wantErr {
 				if err == nil {
 					t.Error("expected an error, but did not get one")

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -206,7 +206,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 	// before and it kept failing. One reason that can happen is exceeding etcd request size limit. Finishing it early
 	// makes sure the request size is manageable
 	if !pr.IsDone() && pr.HasTimedOutForALongTime(ctx, c.Clock) && !pr.IsTimeoutConditionSet() {
-		if err := timeoutPipelineRun(ctx, logger, pr, c.PipelineClientSet); err != nil {
+		if err := timeoutPipelineRun(ctx, logger, c.tracerProvider, pr, c.PipelineClientSet); err != nil {
 			return err
 		}
 		if err := c.finishReconcileUpdateEmitEvents(ctx, pr, before, nil); err != nil {
@@ -261,7 +261,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 
 	// If the pipelinerun is cancelled, cancel tasks and update status
 	if pr.IsCancelled() {
-		err := cancelPipelineRun(ctx, logger, pr, c.PipelineClientSet)
+		err := cancelPipelineRun(ctx, logger, c.tracerProvider, pr, c.PipelineClientSet)
 		return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
 	}
 
@@ -836,7 +836,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	// check if pipeline run is gracefully cancelled and there are active pipeline task runs, which require cancelling
 	if pr.IsGracefullyCancelled() && pipelineRunFacts.IsRunning() {
 		// If the pipelinerun is cancelled, cancel tasks, but run finally
-		err := gracefullyCancelPipelineRun(ctx, logger, pr, c.PipelineClientSet)
+		err := gracefullyCancelPipelineRun(ctx, logger, c.tracerProvider, pr, c.PipelineClientSet)
 		if err != nil {
 			// failed to cancel tasks, maybe retry would help (don't return permanent error)
 			return err
@@ -902,7 +902,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 			}
 			if tasksToTimeOut.Len() > 0 {
 				logger.Debugf("PipelineRun tasks timeout of %s reached, cancelling tasks", tasksTimeout)
-				errs := timeoutPipelineTasksForTaskNames(ctx, logger, pr, c.PipelineClientSet, tasksToTimeOut)
+				errs := timeoutPipelineTasksForTaskNames(ctx, logger, c.tracerProvider, pr, c.PipelineClientSet, tasksToTimeOut)
 				if len(errs) > 0 {
 					errString := strings.Join(errs, "\n")
 					logger.Errorf("Failed to timeout tasks for PipelineRun %s/%s: %s", pr.Namespace, pr.Name, errString)
@@ -919,7 +919,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 		}
 		if tasksToTimeOut.Len() > 0 {
 			logger.Debugf("PipelineRun finally timeout of %s reached, cancelling finally tasks", finallyTimeout)
-			errs := timeoutPipelineTasksForTaskNames(ctx, logger, pr, c.PipelineClientSet, tasksToTimeOut)
+			errs := timeoutPipelineTasksForTaskNames(ctx, logger, c.tracerProvider, pr, c.PipelineClientSet, tasksToTimeOut)
 			if len(errs) > 0 {
 				errString := strings.Join(errs, "\n")
 				logger.Errorf("Failed to timeout finally tasks for PipelineRun %s/%s: %s", pr.Namespace, pr.Name, errString)
@@ -937,7 +937,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 
 	// If the pipelinerun has timed out, mark tasks as timed out and update status
 	if pr.HasTimedOut(ctx, c.Clock) {
-		if err := timeoutPipelineRun(ctx, logger, pr, c.PipelineClientSet); err != nil {
+		if err := timeoutPipelineRun(ctx, logger, c.tracerProvider, pr, c.PipelineClientSet); err != nil {
 			return err
 		}
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -62,6 +62,7 @@ import (
 	"go.opentelemetry.io/otel"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/trace"
 	"gomodules.xyz/jsonpatch/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16783,7 +16784,7 @@ spec:
 		t.Errorf("Expected one CustomRuns in status, but found %d", customrunsCount)
 	}
 
-	err := cancelPipelineRun(prt.TestAssets.Ctx, logtesting.TestLogger(t), pr, clients.Pipeline)
+	err := cancelPipelineRun(prt.TestAssets.Ctx, logtesting.TestLogger(t), trace.NewNoopTracerProvider(), pr, clients.Pipeline)
 	if err != nil {
 		t.Fatalf("Error found: %v", err)
 	}

--- a/pkg/reconciler/pipelinerun/timeout.go
+++ b/pkg/reconciler/pipelinerun/timeout.go
@@ -25,6 +25,9 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -70,8 +73,15 @@ func init() {
 }
 
 // timeoutPipelineRun marks the PipelineRun as timed out and any resolved TaskRun(s) too.
-func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface) error {
-	errs := timeoutPipelineTasks(ctx, logger, pr, clientSet)
+func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, tp trace.TracerProvider, pr *v1.PipelineRun, clientSet clientset.Interface) error {
+	ctx, span := tp.Tracer(TracerName).Start(ctx, "timeoutPipelineRun",
+		trace.WithAttributes(
+			attribute.String("pipelinerun.name", pr.Name),
+			attribute.String("pipelinerun.namespace", pr.Namespace),
+		))
+	defer span.End()
+
+	errs := timeoutPipelineTasks(ctx, logger, tp, pr, clientSet)
 
 	// If we successfully timed out all the TaskRuns and Runs, we can consider the PipelineRun timed out.
 	if len(errs) == 0 {
@@ -87,34 +97,74 @@ func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.P
 			Reason:  v1.PipelineRunReasonCouldntTimeOut.String(),
 			Message: fmt.Sprintf("PipelineRun %q was timed out but had errors trying to time out TaskRuns and/or Runs: %s", pr.Name, e),
 		})
-		return fmt.Errorf("error(s) from timing out TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		combinedErr := fmt.Errorf("error(s) from timing out TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		span.SetStatus(codes.Error, combinedErr.Error())
+		span.RecordError(combinedErr)
+		return combinedErr
 	}
 	return nil
 }
 
-func timeoutCustomRun(ctx context.Context, customRunName string, namespace string, clientSet clientset.Interface) error {
+func timeoutCustomRun(ctx context.Context, tp trace.TracerProvider, customRunName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := tp.Tracer(TracerName).Start(ctx, "timeoutCustomRun",
+		trace.WithAttributes(
+			attribute.String("customrun.name", customRunName),
+			attribute.String("customrun.namespace", namespace),
+		))
+	defer span.End()
+
 	_, err := clientSet.TektonV1beta1().CustomRuns(namespace).Patch(ctx, customRunName, types.JSONPatchType, timeoutCustomRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
+		span.SetAttributes(attribute.Bool("customrun.not_found", true))
 		return nil
+	}
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
 	}
 	return err
 }
 
-func timeoutTaskRun(ctx context.Context, taskRunName string, namespace string, clientSet clientset.Interface) error {
+func timeoutTaskRun(ctx context.Context, tp trace.TracerProvider, taskRunName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := tp.Tracer(TracerName).Start(ctx, "timeoutTaskRun",
+		trace.WithAttributes(
+			attribute.String("taskrun.name", taskRunName),
+			attribute.String("taskrun.namespace", namespace),
+		))
+	defer span.End()
+
 	_, err := clientSet.TektonV1().TaskRuns(namespace).Patch(ctx, taskRunName, types.JSONPatchType, timeoutTaskRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
+		span.SetAttributes(attribute.Bool("taskrun.not_found", true))
 		return nil
+	}
+	if pipelineErrors.IsImmutableTaskRunSpecError(err) {
+		// The TaskRun may have completed and the spec field is immutable, we should ignore this error.
+		span.SetAttributes(attribute.Bool("taskrun.spec_immutable", true))
+		return nil
+	}
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
 	}
 	return err
 }
 
 // timeoutPipelineTaskRuns patches `TaskRun` and `Run` with canceled status and an appropriate message
-func timeoutPipelineTasks(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface) []string {
-	return timeoutPipelineTasksForTaskNames(ctx, logger, pr, clientSet, sets.NewString())
+func timeoutPipelineTasks(ctx context.Context, logger *zap.SugaredLogger, tp trace.TracerProvider, pr *v1.PipelineRun, clientSet clientset.Interface) []string {
+	return timeoutPipelineTasksForTaskNames(ctx, logger, tp, pr, clientSet, sets.NewString())
 }
 
 // timeoutPipelineTasksForTaskNames patches `TaskRun`s and `Run`s for the given task names, or all if no task names are given, with canceled status and appropriate message
-func timeoutPipelineTasksForTaskNames(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface, taskNames sets.String) []string {
+func timeoutPipelineTasksForTaskNames(ctx context.Context, logger *zap.SugaredLogger, tp trace.TracerProvider, pr *v1.PipelineRun, clientSet clientset.Interface, taskNames sets.String) []string {
+	ctx, span := tp.Tracer(TracerName).Start(ctx, "timeoutPipelineTasksForTaskNames",
+		trace.WithAttributes(
+			attribute.String("pipelinerun.name", pr.Name),
+			attribute.String("pipelinerun.namespace", pr.Namespace),
+			attribute.Int("tasknames.filter_count", taskNames.Len()),
+		))
+	defer span.End()
+
 	errs := []string{}
 
 	trNames, customRunNames, err := getChildObjectsFromPRStatusForTaskNames(ctx, pr.Status, taskNames)
@@ -122,10 +172,15 @@ func timeoutPipelineTasksForTaskNames(ctx context.Context, logger *zap.SugaredLo
 		errs = append(errs, err.Error())
 	}
 
+	span.SetAttributes(
+		attribute.Int("taskruns.count", len(trNames)),
+		attribute.Int("customruns.count", len(customRunNames)),
+	)
+
 	for _, taskRunName := range trNames {
 		logger.Infof("patching TaskRun %s for timeout", taskRunName)
 
-		if err := timeoutTaskRun(ctx, taskRunName, pr.Namespace, clientSet); err != nil {
+		if err := timeoutTaskRun(ctx, tp, taskRunName, pr.Namespace, clientSet); err != nil {
 			if pipelineErrors.IsImmutableTaskRunSpecError(err) {
 				// The TaskRun may have completed and the spec field is immutable, we should ignore this error.
 				continue
@@ -138,10 +193,16 @@ func timeoutPipelineTasksForTaskNames(ctx context.Context, logger *zap.SugaredLo
 	for _, custonRunName := range customRunNames {
 		logger.Infof("patching CustomRun %s for timeout", custonRunName)
 
-		if err := timeoutCustomRun(ctx, custonRunName, pr.Namespace, clientSet); err != nil {
+		if err := timeoutCustomRun(ctx, tp, custonRunName, pr.Namespace, clientSet); err != nil {
 			errs = append(errs, fmt.Errorf("failed to patch CustomRun `%s` with timeout: %w", custonRunName, err).Error())
 			continue
 		}
+	}
+
+	if len(errs) > 0 {
+		combined := strings.Join(errs, "; ")
+		span.SetStatus(codes.Error, combined)
+		span.RecordError(fmt.Errorf("%s", combined))
 	}
 	return errs
 }

--- a/pkg/reconciler/pipelinerun/timeout_test.go
+++ b/pkg/reconciler/pipelinerun/timeout_test.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/tektoncd/pipeline/pkg/pipelinerunmetrics/fake" // Make sure the pipelinerunmetrics are setup
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
+	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
@@ -256,7 +257,7 @@ func TestTimeoutPipelineRun(t *testing.T) {
 			defer cancel()
 			c, _ := test.SeedTestData(t, ctx, d)
 
-			err := timeoutPipelineRun(ctx, logtesting.TestLogger(t), tc.pipelineRun, c.Pipeline)
+			err := timeoutPipelineRun(ctx, logtesting.TestLogger(t), trace.NewNoopTracerProvider(), tc.pipelineRun, c.Pipeline)
 			if tc.wantErr {
 				if err == nil {
 					t.Error("expected an error, but did not get one")

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -187,6 +187,10 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 
 	// If the TaskRun is cancelled, kill resources and update status
 	if tr.IsCancelled() {
+		span.SetAttributes(
+			attribute.String("taskrun.stop_reason", "Cancelled"),
+			attribute.String("taskrun.status_message", string(tr.Spec.StatusMessage)),
+		)
 		message := fmt.Sprintf("TaskRun %q was cancelled. %s", tr.Name, tr.Spec.StatusMessage)
 		message = appendPreviousConditionContext(before, message)
 		err := c.failTaskRun(ctx, tr, v1.TaskRunReasonCancelled, message)
@@ -202,6 +206,10 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	// Check if the TaskRun has timed out; if it is, this will set its status
 	// accordingly.
 	if tr.HasTimedOut(ctx, c.Clock) {
+		span.SetAttributes(
+			attribute.String("taskrun.stop_reason", "TimedOut"),
+			attribute.String("taskrun.timeout", tr.GetTimeout(ctx).String()),
+		)
 		// Before failing the TaskRun, ensure step statuses are populated from the pod
 		// This prevents a race condition where the timeout occurs before pod status is fetched
 		if err := c.updateStepStatusesFromPod(ctx, tr); err != nil {


### PR DESCRIPTION
closes #9783

Part of umbrella #9701

PipelineRun cancellation and timeout helpers had zero OTel instrumentation, making it impossible to trace the children TaskRuns and CustomRuns.

# Changes

Add spans to the trace from the incoming `ctx` for the functions:

`pkg/reconciler/pipelinerun/cancel.go`:
- `cancelPipelineRun`
- `gracefullyCancelPipelineRun`
- `cancelPipelineTaskRunsForTaskNames`
- `cancelTaskRun`
- `cancelCustomRun`

`pkg/reconciler/pipelinerun/timeout.go`:
- `timeoutPipelineRun`
- `timeoutPipelineTasksForTaskNames`
- `timeoutTaskRun`
- `timeoutCustomRun`

Also add span attribute for `ReconcileKind` function in `pkg/reconciler/taskrun/taskrun.go` stating reason in case of a TaskRun Cancel and Timeout.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
PipelineRun Cancellation and Timeout will have Otel spans for children TaskRuns and CustomRuns.
```
