### PR TITLE
feat(tracing): add spans to TaskRun validation functions

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -552,27 +552,43 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1.TaskRun) (*v1.TaskSpec,
 		Kind:     resources.GetTaskKind(tr),
 	}
 
-	if err := validateTaskSpecRequestResources(taskSpec); err != nil {
+	if err := func() error {
+		_, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "validateTaskSpecRequestResources")
+		defer span.End()
+		return validateTaskSpecRequestResources(taskSpec)
+	}(); err != nil {
 		logger.Errorf("TaskRun %s taskSpec request resources are invalid: %v", tr.Name, err)
 		tr.Status.MarkResourceFailed(v1.TaskRunReasonFailedValidation, err)
 		return nil, nil, controller.NewPermanentError(err)
 	}
 
-	if err := ValidateResolvedTask(ctx, tr.Spec.Params, &v1.Matrix{}, rtr); err != nil {
+	if err := func() error {
+		spanCtx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "ValidateResolvedTask")
+		defer span.End()
+		return ValidateResolvedTask(spanCtx, tr.Spec.Params, &v1.Matrix{}, rtr)
+	}(); err != nil {
 		logger.Errorf("TaskRun %q resources are invalid: %v", tr.Name, err)
 		tr.Status.MarkResourceFailed(v1.TaskRunReasonFailedValidation, err)
 		return nil, nil, controller.NewPermanentError(err)
 	}
 
 	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableParamEnum {
-		if err := ValidateEnumParam(ctx, tr.Spec.Params, rtr.TaskSpec.Params); err != nil {
+		if err := func() error {
+			spanCtx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "ValidateEnumParam")
+			defer span.End()
+			return ValidateEnumParam(spanCtx, tr.Spec.Params, rtr.TaskSpec.Params)
+		}(); err != nil {
 			logger.Errorf("TaskRun %q Param Enum validation failed: %v", tr.Name, err)
 			tr.Status.MarkResourceFailed(v1.TaskRunReasonInvalidParamValue, err)
 			return nil, nil, controller.NewPermanentError(err)
 		}
 	}
 
-	if err := resources.ValidateParamArrayIndex(rtr.TaskSpec, tr.Spec.Params); err != nil {
+	if err := func() error {
+		_, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "ValidateParamArrayIndex")
+		defer span.End()
+		return resources.ValidateParamArrayIndex(rtr.TaskSpec, tr.Spec.Params)
+	}(); err != nil {
 		logger.Errorf("TaskRun %q Param references are invalid: %v", tr.Name, err)
 		tr.Status.MarkResourceFailed(v1.TaskRunReasonFailedValidation, err)
 		return nil, nil, controller.NewPermanentError(err)
@@ -597,7 +613,11 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1.TaskRun) (*v1.TaskSpec,
 	} else {
 		workspaceDeclarations = taskSpec.Workspaces
 	}
-	if err := workspace.ValidateBindings(ctx, workspaceDeclarations, tr.Spec.Workspaces); err != nil {
+	if err := func() error {
+		spanCtx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "ValidateBindings")
+		defer span.End()
+		return workspace.ValidateBindings(spanCtx, workspaceDeclarations, tr.Spec.Workspaces)
+	}(); err != nil {
 		logger.Errorf("TaskRun %q workspaces are invalid: %v", tr.Name, err)
 		tr.Status.MarkResourceFailed(v1.TaskRunReasonFailedValidation, err)
 		return nil, nil, controller.NewPermanentError(err)
@@ -615,7 +635,11 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1.TaskRun) (*v1.TaskSpec,
 		}
 	}
 
-	if err := validateOverrides(taskSpec, &tr.Spec); err != nil {
+	if err := func() error {
+		_, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "validateOverrides")
+		defer span.End()
+		return validateOverrides(taskSpec, &tr.Spec)
+	}(); err != nil {
 		logger.Errorf("TaskRun %q step or sidecar overrides are invalid: %v", tr.Name, err)
 		tr.Status.MarkResourceFailed(v1.TaskRunReasonFailedValidation, err)
 		return nil, nil, controller.NewPermanentError(err)
@@ -730,7 +754,11 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1.TaskRun, rtr *resourc
 		return err
 	}
 
-	if err := validateTaskRunResults(tr, rtr.TaskSpec); err != nil {
+	if err := func() error {
+		_, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "validateTaskRunResults")
+		defer span.End()
+		return validateTaskRunResults(tr, rtr.TaskSpec)
+	}(); err != nil {
 		tr.Status.MarkResourceFailed(v1.TaskRunReasonFailedValidation, err)
 		return err
 	}


### PR DESCRIPTION
# Changes

Add OpenTelemetry child spans to the seven validation functions called during TaskRun `prepare` and `reconcile`, so each is visible as its own span under the existing `prepare` / `reconcile` parents in distributed traces. Spans are opened at the call sites in `pkg/reconciler/taskrun/taskrun.go` rather than inside the validation functions, since six of the seven targets are package-level functions that don't have access to the reconciler's tracer provider — opening spans at the call site avoids threading a tracer through signatures across `pkg/workspace` and `pkg/reconciler/taskrun/resources`.

Functions instrumented:

- In `prepare`: `validateTaskSpecRequestResources`, `ValidateResolvedTask`, `ValidateEnumParam`, `resources.ValidateParamArrayIndex`, `workspace.ValidateBindings`, `validateOverrides`.
- In `reconcile`: `validateTaskRunResults`.

Recording errors on these spans (`span.RecordError` / `span.SetStatus`) is intentionally out of scope, as it is tracked separately under umbrella #9701.

Closes #9779
Part of #9701

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps — N/A, internal instrumentation only
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed — N/A, no behavior change; existing unit tests use a noop tracer provider and continue to pass
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label (will add `/kind feature` after open)
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release — N/A

# Release Notes

```release-note
NONE
```