### PR TITLE
feat(tracing): add spans to TaskRun notifications controller

### DIFF
--- a/pkg/reconciler/events/cloudevent/cloud_event_controller.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller.go
@@ -24,15 +24,21 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/reconciler/events/cache"
+	"go.opentelemetry.io/otel"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
 	controller "knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/events/cache"
+)
+
+const (
+	TracerName = "CloudEventController"
 )
 
 func cloudEventsSink(ctx context.Context) string {
@@ -56,6 +62,8 @@ func cloudEventsSink(ctx context.Context) string {
 // Each format sender calls dispatchCloudEvent which handles the L2 cache check,
 // goroutine dispatch, retries, and Kubernetes Event recording.
 func EmitCloudEvents(ctx context.Context, object runtime.Object) {
+	ctx, span := otel.GetTracerProvider().Tracer(TracerName).Start(ctx, "EmitCloudEvents")
+	defer span.End()
 	logger := logging.FromContext(ctx)
 	runObject, ok := object.(v1beta1.RunObject)
 	if !ok {
@@ -68,26 +76,28 @@ func EmitCloudEvents(ctx context.Context, object runtime.Object) {
 		return
 	}
 
-	// Level 1: skip if this exact condition state was already processed.
-	// One check per reconcile, before any format-specific work.
 	cacheClient := cache.Get(ctx)
+
 	wasPresent, err := cache.ContainsOrAddObject(cacheClient, runObject)
 	if err != nil {
 		logger.Warnf("failed to emit cloud events: could not check the events cache %v", err.Error())
+		span.RecordError(err)
 	}
+
 	if err != nil || wasPresent {
 		return
 	}
 
 	ctx = cloudevents.ContextWithTarget(ctx, sink)
+
 	cfg := config.FromContextOrDefaults(ctx)
 	formats := cfg.Events.Formats
+
 	if len(formats) == 0 {
-		// Belt-and-suspenders: config validation already rejects empty formats.
-		// Warn-and-skip rather than error to avoid requeue loops for a
-		// misconfiguration that cannot self-heal.
-		logger.Warnf("no event formats configured, skipping notifications for %s",
-			runObject.GetObjectMeta().GetName())
+		logger.Warnf(
+			"no event formats configured, skipping notifications for %s",
+			runObject.GetObjectMeta().GetName(),
+		)
 		return
 	}
 
@@ -96,8 +106,6 @@ func EmitCloudEvents(ctx context.Context, object runtime.Object) {
 		case config.FormatTektonV1:
 			sendTektonV1Event(ctx, runObject)
 		default:
-			// Unknown format: operator may have set a future format before
-			// updating the binary. Warn-and-skip rather than fail.
 			logger.Warnf("unknown event format %q, skipping", format)
 		}
 	}

--- a/pkg/reconciler/notifications/runtimeobject.go
+++ b/pkg/reconciler/notifications/runtimeobject.go
@@ -20,12 +20,20 @@ import (
 	"context"
 
 	bc "github.com/allegro/bigcache/v3"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/reconciler/events/cache"
-	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/events/cache"
+	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
+)
+
+const (
+	// TracerName is the name of the tracer for the notifications reconciler.
+	TracerName = "Notifications"
 )
 
 // EventClientsProvider provides read access to cloud event dependencies
@@ -36,6 +44,9 @@ type EventClientsProvider interface {
 
 // ReconcileRunObject observes a v1beta1.RunObject and triggers notifications.
 func ReconcileRunObject(ctx context.Context, e EventClientsProvider, readOnlyRun v1beta1.RunObject) pkgreconciler.Event {
+	var span trace.Span
+	ctx, span = otel.GetTracerProvider().Tracer(TracerName).Start(ctx, "ReconcileRunObject")
+	defer span.End()
 	logger := logging.FromContext(ctx)
 	ctx = cloudevent.ToContext(ctx, e.GetCloudEventsClient())
 	ctx = cache.ToContext(ctx, e.GetCacheClient())

--- a/pkg/reconciler/notifications/taskrun/reconciler.go
+++ b/pkg/reconciler/notifications/taskrun/reconciler.go
@@ -20,17 +20,31 @@ import (
 	"context"
 
 	bc "github.com/allegro/bigcache/v3"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	taskrunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/taskrun"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/notifications"
+	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
+)
+
+const (
+	// TracerName is the name of the tracer for the taskrun notifications reconciler.
+	TracerName = "TaskRunNotificationsReconciler"
 )
 
 // Reconciler implements controller.Reconciler for TaskRun resources.
 type Reconciler struct {
 	cloudEventClient cloudevent.CEClient
 	cacheClient      *bc.BigCache
+
+	// tracerProvider is used to create spans for distributed tracing.
+	tracerProvider trace.TracerProvider
 }
 
 // NewReconciler creates a new Reconciler with the given clients.
@@ -38,21 +52,44 @@ func NewReconciler(ceClient cloudevent.CEClient, cacheClient *bc.BigCache) *Reco
 	return &Reconciler{
 		cloudEventClient: ceClient,
 		cacheClient:      cacheClient,
+		tracerProvider:   otel.GetTracerProvider(),
 	}
 }
 
-func (c *Reconciler) GetCloudEventsClient() cloudevent.CEClient {
-	return c.cloudEventClient
+// GetCloudEventsClient returns the cloud event client.
+
+func (r *Reconciler) GetCloudEventsClient() cloudevent.CEClient {
+	return r.cloudEventClient
 }
 
-func (c *Reconciler) GetCacheClient() *bc.BigCache {
-	return c.cacheClient
+// GetCacheClient returns the cache client.
+func (r *Reconciler) GetCacheClient() *bc.BigCache {
+	return r.cacheClient
 }
 
 // Check that our Reconciler implements taskrunreconciler.Interface
 var _ taskrunreconciler.Interface = (*Reconciler)(nil)
 
-// ReconcileKind observes the resource conditions and triggers notifications accordingly.
-func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgreconciler.Event {
-	return notifications.ReconcileRunObject(ctx, c, tr)
+func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgreconciler.Event {
+
+	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "ReconcileKind",
+		trace.WithAttributes(
+			attribute.String("taskrun.name", tr.Name),
+			attribute.String("taskrun.namespace", tr.Namespace),
+		),
+	)
+	defer span.End()
+
+	logger := logging.FromContext(ctx)
+	logger.Infof("Reconciling TaskRun notifications for %s/%s", tr.Namespace, tr.Name)
+
+	// We pass 'r' as it satisfies the EventClientsProvider interface.
+	err := notifications.ReconcileRunObject(ctx, r, tr)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+
+	return err
 }

--- a/pkg/reconciler/notifications/taskrun/reconciler.go
+++ b/pkg/reconciler/notifications/taskrun/reconciler.go
@@ -57,7 +57,6 @@ func NewReconciler(ceClient cloudevent.CEClient, cacheClient *bc.BigCache) *Reco
 }
 
 // GetCloudEventsClient returns the cloud event client.
-
 func (r *Reconciler) GetCloudEventsClient() cloudevent.CEClient {
 	return r.cloudEventClient
 }
@@ -71,7 +70,6 @@ func (r *Reconciler) GetCacheClient() *bc.BigCache {
 var _ taskrunreconciler.Interface = (*Reconciler)(nil)
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgreconciler.Event {
-
 	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "ReconcileKind",
 		trace.WithAttributes(
 			attribute.String("taskrun.name", tr.Name),


### PR DESCRIPTION
Fixes #9781
Part of #9701

## Changes

Adds OpenTelemetry spans to the TaskRun notification reconciliation path,
giving operators visibility into CloudEvent delivery latency via distributed tracing.

Previously, no tracing existed between the reconcile trigger and the final
cloud event emission, making it impossible to correlate failures or measure
latency. This PR closes that gap by adding three linked spans that form a
complete trace from `ReconcileKind` through to `EmitCloudEvents`.

**Spans added:**

- `pkg/reconciler/notifications/taskrun/reconciler.go` — root span on
  `ReconcileKind` with `taskrun.name` and `taskrun.namespace` attributes
- `pkg/reconciler/notifications/runtimeobject.go` — child span on
  `ReconcileRunObject` (shared path; also benefits CustomRun)
- `pkg/reconciler/events/cloudevent/cloud_event_controller.go` — leaf span
  on `EmitCloudEvents` with `span.RecordError()` on network and sink failures

Follows the existing pattern in `pkg/reconciler/taskrun/taskrun.go` and
`pkg/reconciler/pipelinerun/pipelinerun.go`.

## Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

## Release Notes

```release-note
Added OpenTelemetry tracing to the TaskRun notification reconciliation path.
Spans now cover ReconcileKind, ReconcileRunObject, and EmitCloudEvents,
enabling operators to trace CloudEvent delivery latency end-to-end.
```
/kind feature