### PR TITLE
Add SSRF protection to HTTP resolver by blocking private/internal IPs

### DIFF
--- a/config/resolvers/http-resolver-config.yaml
+++ b/config/resolvers/http-resolver-config.yaml
@@ -24,3 +24,7 @@ metadata:
 data:
   # The maximum amount of time the http resolver will wait for a response from the server.
   fetch-timeout: "1m"
+  # Controls whether the HTTP resolver blocks requests to private, loopback,
+  # link-local, and unspecified IP addresses (SSRF protection). Set to "false"
+  # to allow requests to internal/private network addresses (e.g. internal registries).
+  # block-private-ips: "true"

--- a/config/resolvers/http-resolver-config.yaml
+++ b/config/resolvers/http-resolver-config.yaml
@@ -24,3 +24,8 @@ metadata:
 data:
   # The maximum amount of time the http resolver will wait for a response from the server.
   fetch-timeout: "1m"
+  # Controls whether the HTTP resolver blocks requests to private, loopback,
+  # link-local, carrier-grade NAT (RFC 6598), multicast, and unspecified IP
+  # addresses (SSRF protection). Set to "false" to allow requests to
+  # internal/private network addresses (e.g. internal registries).
+  # block-private-ips: "true"

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -40,7 +40,7 @@ installation.
 
 ## Configuring built-in remote Task and Pipeline resolution
 
-Four remote resolvers are currently provided as part of the Tekton Pipelines installation.
+Five remote resolvers are currently provided as part of the Tekton Pipelines installation.
 By default, these remote resolvers are enabled. Each resolver can be disabled by setting
 the appropriate feature flag in the `resolvers-feature-flags` ConfigMap in the `tekton-pipelines-resolvers`
 namespace:
@@ -52,6 +52,8 @@ namespace:
 1. [The `hub` resolver](./hub-resolver.md), disabled by setting the `enable-hub-resolver`
    feature flag to `false`.
 1. [The `cluster` resolver](./cluster-resolver.md), disabled by setting the `enable-cluster-resolver`
+   feature flag to `false`.
+1. [The `http` resolver](./http-resolver.md), disabled by setting the `enable-http-resolver`
    feature flag to `false`.
 
 ## Configuring CloudEvents notifications

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -41,7 +41,7 @@ installation.
 
 ## Configuring built-in remote Task and Pipeline resolution
 
-Four remote resolvers are currently provided as part of the Tekton Pipelines installation.
+Five remote resolvers are currently provided as part of the Tekton Pipelines installation.
 By default, these remote resolvers are enabled. Each resolver can be disabled by setting
 the appropriate feature flag in the `resolvers-feature-flags` ConfigMap in the `tekton-pipelines-resolvers`
 namespace:
@@ -53,6 +53,8 @@ namespace:
 1. [The `hub` resolver](./hub-resolver.md), disabled by setting the `enable-hub-resolver`
    feature flag to `false`.
 1. [The `cluster` resolver](./cluster-resolver.md), disabled by setting the `enable-cluster-resolver`
+   feature flag to `false`.
+1. [The `http` resolver](./http-resolver.md), disabled by setting the `enable-http-resolver`
    feature flag to `false`.
 
 ## Configuring CloudEvents notifications

--- a/docs/http-resolver.md
+++ b/docs/http-resolver.md
@@ -54,6 +54,7 @@ for the name, namespace and defaults that the resolver ships with.
 | Option Name                 | Description                                          | Example Values         |
 |-----------------------------|------------------------------------------------------|------------------------|
 | `fetch-timeout`              | The maximum time any fetching of URL resolution may take. **Note**: a global maximum timeout of 1 minute is currently enforced on _all_ resolution requests. | `1m`, `2s`, `700ms`                                              |
+| `block-private-ips`          | Controls whether the HTTP resolver blocks requests to private, loopback, link-local, and unspecified IP addresses (SSRF protection). Defaults to `"true"`. **Note**: if you are fetching resources from internal/private network addresses (e.g. cluster-internal registries or services), you must set this to `"false"` or those requests will be rejected after upgrading. | `"true"`, `"false"` |
 
 ## Usage
 

--- a/docs/http-resolver.md
+++ b/docs/http-resolver.md
@@ -54,6 +54,7 @@ for the name, namespace and defaults that the resolver ships with.
 | Option Name                 | Description                                          | Example Values         |
 |-----------------------------|------------------------------------------------------|------------------------|
 | `fetch-timeout`              | The maximum time any fetching of URL resolution may take. **Note**: a global maximum timeout of 1 minute is currently enforced on _all_ resolution requests. | `1m`, `2s`, `700ms`                                              |
+| `block-private-ips`          | Controls whether the HTTP resolver blocks requests to private, loopback, link-local, carrier-grade NAT (RFC 6598), multicast, and unspecified IP addresses (SSRF protection). Defaults to `"true"`. **Note**: if you are fetching resources from internal/private network addresses (e.g. cluster-internal registries or services), you must set this to `"false"` or those requests will be rejected after upgrading. | `"true"`, `"false"` |
 
 ## Usage
 

--- a/pkg/remoteresolution/resolver/http/resolver_test.go
+++ b/pkg/remoteresolution/resolver/http/resolver_test.go
@@ -358,7 +358,9 @@ func TestResolverReconcileBasicAuth(t *testing.T) {
 				p.url = svr.URL
 			}
 			request := createRequest(p)
-			cfg := make(map[string]string)
+			cfg := map[string]string{
+				resolutionframework.BlockPrivateIPsConfigKey: "false",
+			}
 			d := test.Data{
 				ConfigMaps: []*corev1.ConfigMap{{
 					ObjectMeta: metav1.ObjectMeta{
@@ -468,7 +470,8 @@ func toParams(m map[string]string) []pipelinev1.Param {
 
 func contextWithConfig(timeout string) context.Context {
 	config := map[string]string{
-		httpresolution.TimeoutKey: timeout,
+		httpresolution.TimeoutKey:                    timeout,
+		resolutionframework.BlockPrivateIPsConfigKey: "false",
 	}
 	return resolutionframework.InjectResolverConfigToContext(context.Background(), config)
 }

--- a/pkg/resolution/resolver/framework/ssrf.go
+++ b/pkg/resolution/resolver/framework/ssrf.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const BlockPrivateIPsConfigKey = "block-private-ips"
+
+var cgnatPrefix = netip.MustParsePrefix("100.64.0.0/10")
+
+// restrictedTransport is a package-level singleton so all callers share
+// one connection pool instead of leaking a new pool per request.
+var restrictedTransport = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   BlockPrivateNetworkControl,
+	}).DialContext,
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+}
+
+type RestrictedAddrError struct {
+	Addr   string
+	Reason string
+}
+
+func (e *RestrictedAddrError) Error() string {
+	return fmt.Sprintf("address %s is blocked: %s", e.Addr, e.Reason)
+}
+
+func isBlockedIP(addr netip.Addr) (bool, string) {
+	addr = addr.Unmap()
+	if !addr.IsValid() {
+		return true, "invalid IP address"
+	}
+	if addr.IsUnspecified() {
+		return true, "unspecified address"
+	}
+	if addr.IsLoopback() {
+		return true, "loopback address"
+	}
+	if addr.IsPrivate() {
+		return true, "RFC1918/RFC4193 private address"
+	}
+	if addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() {
+		return true, "link-local address"
+	}
+	if addr.IsMulticast() {
+		return true, "multicast address"
+	}
+	if cgnatPrefix.Contains(addr) {
+		return true, "RFC6598 CGNAT address"
+	}
+	return false, ""
+}
+
+// BlockPrivateNetworkControl is a net.Dialer.Control callback that rejects
+// connections to private, loopback, link-local, multicast, CGNAT, and
+// unspecified addresses. It runs after DNS resolution and before connect(2).
+func BlockPrivateNetworkControl(network, address string, _ syscall.RawConn) error {
+	switch network {
+	case "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6": //nolint:goconst
+	default:
+		return &RestrictedAddrError{Addr: address, Reason: "unsupported network " + network}
+	}
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return &RestrictedAddrError{Addr: address, Reason: err.Error()}
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return &RestrictedAddrError{Addr: address, Reason: "address is not a literal IP after resolution"}
+	}
+	if blocked, reason := isBlockedIP(addr); blocked {
+		return &RestrictedAddrError{Addr: address, Reason: reason}
+	}
+	return nil
+}
+
+// RestrictedHTTPTransport returns the shared *http.Transport whose dialer
+// rejects connections to private network address classes. The transport is
+// a package-level singleton — all callers share one connection pool.
+func RestrictedHTTPTransport() *http.Transport {
+	return restrictedTransport
+}
+
+// BlockPrivateIPs reports whether the resolver should refuse to dial
+// private network addresses. Reads BlockPrivateIPsConfigKey from the
+// resolver-scoped ConfigMap attached to ctx.
+func BlockPrivateIPs(ctx context.Context) bool {
+	conf := GetResolverConfigFromContext(ctx)
+	if conf == nil {
+		return true
+	}
+	v, ok := conf[BlockPrivateIPsConfigKey]
+	if !ok {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "false", "0", "no", "off": //nolint:goconst
+		return false
+	default:
+		return true
+	}
+}
+
+// ResolverHTTPTransport returns the transport a resolver should use for
+// outbound HTTP requests. When BlockPrivateIPs(ctx) is true, connections
+// to private/loopback/link-local/CGNAT addresses are refused.
+func ResolverHTTPTransport(ctx context.Context) http.RoundTripper {
+	if BlockPrivateIPs(ctx) {
+		return RestrictedHTTPTransport()
+	}
+	return http.DefaultTransport
+}

--- a/pkg/resolution/resolver/framework/ssrf.go
+++ b/pkg/resolution/resolver/framework/ssrf.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const BlockPrivateIPsConfigKey = "block-private-ips"
+
+var cgnatPrefix = netip.MustParsePrefix("100.64.0.0/10")
+
+// restrictedTransport is a package-level singleton so all callers share
+// one connection pool instead of leaking a new pool per request.
+var restrictedTransport = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   BlockPrivateNetworkControl,
+	}).DialContext,
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+}
+
+type RestrictedAddrError struct {
+	Addr   string
+	Reason string
+}
+
+func (e *RestrictedAddrError) Error() string {
+	return fmt.Sprintf("address %s is blocked: %s", e.Addr, e.Reason)
+}
+
+func isBlockedIP(addr netip.Addr) (bool, string) {
+	addr = addr.Unmap()
+	if !addr.IsValid() {
+		return true, "invalid IP address"
+	}
+	if addr.IsUnspecified() {
+		return true, "unspecified address"
+	}
+	if addr.IsLoopback() {
+		return true, "loopback address"
+	}
+	if addr.IsPrivate() {
+		return true, "RFC1918/RFC4193 private address"
+	}
+	if addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() {
+		return true, "link-local address"
+	}
+	if addr.IsMulticast() {
+		return true, "multicast address"
+	}
+	if cgnatPrefix.Contains(addr) {
+		return true, "RFC6598 CGNAT address"
+	}
+	return false, ""
+}
+
+// BlockPrivateNetworkControl is a net.Dialer.Control callback that rejects
+// connections to private, loopback, link-local, multicast, CGNAT, and
+// unspecified addresses.
+//
+// net.Dialer resolves the dial target to a concrete IP before it ever calls
+// Control: for a hostname target, Dial first resolves the name to a list of
+// IP addresses (net.Resolver), then attempts each one in turn via
+// dialSingle/dialSerial, and Control is invoked with that already-resolved
+// "ip:port" string immediately before connect(2) is issued on that same
+// socket. So by the time this function runs, `address` is always a literal
+// IP:port — never a bare hostname — and the IP that was validated here is
+// exactly the IP that gets connected to, with no re-resolution in between.
+// That is what makes this approach both compatible with hostname-based URLs
+// and resistant to DNS rebinding (see TestBlockPrivateNetworkControlOverRealDial
+// in ssrf_test.go for an end-to-end demonstration).
+//
+// If `address` is ever not a literal IP (e.g. because some other caller
+// wires this callback into a dialer that does not pre-resolve the address),
+// the connection is rejected rather than allowed through unchecked.
+func BlockPrivateNetworkControl(network, address string, _ syscall.RawConn) error {
+	switch network {
+	case "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6": //nolint:goconst
+	default:
+		return &RestrictedAddrError{Addr: address, Reason: "unsupported network " + network}
+	}
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return &RestrictedAddrError{Addr: address, Reason: err.Error()}
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return &RestrictedAddrError{Addr: address, Reason: "address is not a literal IP after resolution"}
+	}
+	if blocked, reason := isBlockedIP(addr); blocked {
+		return &RestrictedAddrError{Addr: address, Reason: reason}
+	}
+	return nil
+}
+
+// RestrictedHTTPTransport returns the shared *http.Transport whose dialer
+// rejects connections to private network address classes. The transport is
+// a package-level singleton — all callers share one connection pool.
+func RestrictedHTTPTransport() *http.Transport {
+	return restrictedTransport
+}
+
+// BlockPrivateIPs reports whether the resolver should refuse to dial
+// private network addresses. Reads BlockPrivateIPsConfigKey from the
+// resolver-scoped ConfigMap attached to ctx.
+func BlockPrivateIPs(ctx context.Context) bool {
+	conf := GetResolverConfigFromContext(ctx)
+	if conf == nil {
+		return true
+	}
+	v, ok := conf[BlockPrivateIPsConfigKey]
+	if !ok {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "false", "0", "no", "off": //nolint:goconst
+		return false
+	default:
+		return true
+	}
+}
+
+// ResolverHTTPTransport returns the transport a resolver should use for
+// outbound HTTP requests. When BlockPrivateIPs(ctx) is true, connections
+// to private/loopback/link-local/CGNAT addresses are refused.
+func ResolverHTTPTransport(ctx context.Context) http.RoundTripper {
+	if BlockPrivateIPs(ctx) {
+		return RestrictedHTTPTransport()
+	}
+	return http.DefaultTransport
+}

--- a/pkg/resolution/resolver/framework/ssrf_test.go
+++ b/pkg/resolution/resolver/framework/ssrf_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/netip"
+	"testing"
+)
+
+func TestIsBlockedIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		blocked bool
+	}{
+		// Loopback
+		{name: "loopback IPv4", ip: "127.0.0.1", blocked: true},
+		{name: "loopback IPv4 other", ip: "127.0.0.2", blocked: true},
+		{name: "loopback IPv6", ip: "::1", blocked: true},
+
+		// Private RFC 1918
+		{name: "private 10.x", ip: "10.0.0.1", blocked: true},
+		{name: "private 172.16.x", ip: "172.16.0.1", blocked: true},
+		{name: "private 192.168.x", ip: "192.168.1.1", blocked: true},
+
+		// Private IPv6
+		{name: "private IPv6 fc00", ip: "fc00::1", blocked: true},
+		{name: "private IPv6 fd00", ip: "fd00::1", blocked: true},
+
+		// Link-local (includes cloud metadata)
+		{name: "cloud metadata", ip: "169.254.169.254", blocked: true},
+		{name: "link-local IPv4", ip: "169.254.1.1", blocked: true},
+		{name: "link-local IPv6", ip: "fe80::1", blocked: true},
+
+		// Unspecified
+		{name: "unspecified IPv4", ip: "0.0.0.0", blocked: true},
+		{name: "unspecified IPv6", ip: "::", blocked: true},
+
+		// Multicast
+		{name: "multicast IPv4", ip: "224.0.0.1", blocked: true},
+		{name: "multicast IPv6", ip: "ff02::1", blocked: true},
+
+		// Carrier-grade NAT (RFC 6598)
+		{name: "CGNAT start", ip: "100.64.0.1", blocked: true},
+		{name: "CGNAT end", ip: "100.127.255.254", blocked: true},
+
+		// IPv4-mapped IPv6 bypass attempts
+		{name: "mapped loopback", ip: "::ffff:127.0.0.1", blocked: true},
+		{name: "mapped metadata", ip: "::ffff:169.254.169.254", blocked: true},
+		{name: "mapped private", ip: "::ffff:10.0.0.1", blocked: true},
+
+		// Allowed public IPs
+		{name: "public DNS 8.8.8.8", ip: "8.8.8.8", blocked: false},
+		{name: "public DNS 1.1.1.1", ip: "1.1.1.1", blocked: false},
+		{name: "public IP", ip: "142.250.80.46", blocked: false},
+		{name: "public IPv6", ip: "2607:f8b0:4004:800::200e", blocked: false},
+		{name: "100.63 not cgnat", ip: "100.63.0.1", blocked: false},
+		{name: "100.128 not cgnat", ip: "100.128.0.1", blocked: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			addr := netip.MustParseAddr(tc.ip)
+			blocked, _ := isBlockedIP(addr)
+			if blocked != tc.blocked {
+				t.Errorf("isBlockedIP(%s) = %v, want %v", tc.ip, blocked, tc.blocked)
+			}
+		})
+	}
+}
+
+func TestBlockPrivateNetworkControl(t *testing.T) {
+	cases := []struct {
+		name    string
+		network string
+		address string
+		blocked bool
+	}{
+		{name: "ipv4 loopback", network: "tcp", address: "127.0.0.1:80", blocked: true},
+		{name: "ipv4 loopback range", network: "tcp", address: "127.5.4.3:443", blocked: true},
+		{name: "ipv4 rfc1918 10.x", network: "tcp", address: "10.0.0.1:80", blocked: true},
+		{name: "ipv4 rfc1918 172.16", network: "tcp", address: "172.16.0.5:80", blocked: true},
+		{name: "ipv4 rfc1918 192.168", network: "tcp", address: "192.168.1.1:80", blocked: true},
+		{name: "ipv4 link-local 169.254", network: "tcp", address: "169.254.169.254:80", blocked: true},
+		{name: "ipv4 unspecified", network: "tcp", address: "0.0.0.0:80", blocked: true},
+		{name: "ipv4 multicast", network: "tcp", address: "224.0.0.1:80", blocked: true},
+		{name: "ipv4 cgnat 100.64", network: "tcp", address: "100.64.0.1:80", blocked: true},
+		{name: "ipv4 cgnat 100.127", network: "tcp", address: "100.127.255.254:80", blocked: true},
+		{name: "ipv6 loopback", network: "tcp", address: "[::1]:80", blocked: true},
+		{name: "ipv6 ula fd00", network: "tcp", address: "[fd00::1]:80", blocked: true},
+		{name: "ipv6 link-local fe80", network: "tcp", address: "[fe80::1]:80", blocked: true},
+		{name: "ipv6 unspecified", network: "tcp", address: "[::]:80", blocked: true},
+		{name: "non-IP host", network: "tcp", address: "example.com:80", blocked: true},
+		{name: "bad network", network: "unix", address: "/var/run/sock:0", blocked: true},
+		{name: "missing port", network: "tcp", address: "1.1.1.1", blocked: true},
+
+		{name: "public ipv4", network: "tcp", address: "1.1.1.1:443", blocked: false},
+		{name: "public ipv4 second", network: "tcp", address: "8.8.8.8:443", blocked: false},
+		{name: "public ipv6", network: "tcp", address: "[2606:4700:4700::1111]:443", blocked: false},
+		{name: "udp public", network: "udp", address: "8.8.4.4:53", blocked: false},
+		{name: "100.63 not cgnat", network: "tcp", address: "100.63.0.1:80", blocked: false},
+		{name: "100.128 not cgnat", network: "tcp", address: "100.128.0.1:80", blocked: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := BlockPrivateNetworkControl(tc.network, tc.address, nil)
+			gotBlocked := err != nil
+			if gotBlocked != tc.blocked {
+				t.Fatalf("blocked = %v want %v (err=%v)", gotBlocked, tc.blocked, err)
+			}
+			if err != nil {
+				var be *RestrictedAddrError
+				if !errors.As(err, &be) {
+					t.Fatalf("expected *RestrictedAddrError, got %T: %v", err, err)
+				}
+			}
+		})
+	}
+}
+
+func TestBlockPrivateIPs(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]string
+		want   bool
+	}{
+		{name: "nil config", config: nil, want: true},
+		{name: "key absent", config: map[string]string{}, want: true},
+		{name: "true", config: map[string]string{BlockPrivateIPsConfigKey: "true"}, want: true},
+		{name: "True", config: map[string]string{BlockPrivateIPsConfigKey: "True"}, want: true},
+		{name: "yes", config: map[string]string{BlockPrivateIPsConfigKey: "yes"}, want: true},
+		{name: "typo", config: map[string]string{BlockPrivateIPsConfigKey: "fals"}, want: true},
+		{name: "false", config: map[string]string{BlockPrivateIPsConfigKey: "false"}, want: false},
+		{name: "False", config: map[string]string{BlockPrivateIPsConfigKey: "False"}, want: false},
+		{name: "FALSE", config: map[string]string{BlockPrivateIPsConfigKey: "FALSE"}, want: false},
+		{name: "0", config: map[string]string{BlockPrivateIPsConfigKey: "0"}, want: false},
+		{name: "no", config: map[string]string{BlockPrivateIPsConfigKey: "no"}, want: false},
+		{name: "No", config: map[string]string{BlockPrivateIPsConfigKey: "No"}, want: false},
+		{name: "off", config: map[string]string{BlockPrivateIPsConfigKey: "off"}, want: false},
+		{name: "Off", config: map[string]string{BlockPrivateIPsConfigKey: "Off"}, want: false},
+		{name: "false with spaces", config: map[string]string{BlockPrivateIPsConfigKey: " false "}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.config != nil {
+				ctx = InjectResolverConfigToContext(ctx, tc.config)
+			}
+			got := BlockPrivateIPs(ctx)
+			if got != tc.want {
+				t.Errorf("BlockPrivateIPs() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolverHTTPTransport(t *testing.T) {
+	t.Run("blocking enabled returns restricted transport", func(t *testing.T) {
+		ctx := InjectResolverConfigToContext(context.Background(), map[string]string{})
+		transport := ResolverHTTPTransport(ctx)
+		if transport == http.DefaultTransport {
+			t.Fatal("expected restricted transport, got http.DefaultTransport")
+		}
+		if _, ok := transport.(*http.Transport); !ok {
+			t.Fatalf("expected *http.Transport, got %T", transport)
+		}
+	})
+
+	t.Run("blocking disabled returns default transport", func(t *testing.T) {
+		ctx := InjectResolverConfigToContext(context.Background(), map[string]string{
+			BlockPrivateIPsConfigKey: "false",
+		})
+		transport := ResolverHTTPTransport(ctx)
+		if transport != http.DefaultTransport {
+			t.Fatal("expected http.DefaultTransport when blocking is disabled")
+		}
+	})
+}
+
+func TestRestrictedHTTPTransport(t *testing.T) {
+	tr := RestrictedHTTPTransport()
+	if tr == nil {
+		t.Fatal("nil transport")
+	}
+	if tr.DialContext == nil {
+		t.Fatal("expected DialContext to be installed")
+	}
+}

--- a/pkg/resolution/resolver/framework/ssrf_test.go
+++ b/pkg/resolution/resolver/framework/ssrf_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+)
+
+func TestIsBlockedIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		blocked bool
+	}{
+		// Loopback
+		{name: "loopback IPv4", ip: "127.0.0.1", blocked: true},
+		{name: "loopback IPv4 other", ip: "127.0.0.2", blocked: true},
+		{name: "loopback IPv6", ip: "::1", blocked: true},
+
+		// Private RFC 1918
+		{name: "private 10.x", ip: "10.0.0.1", blocked: true},
+		{name: "private 172.16.x", ip: "172.16.0.1", blocked: true},
+		{name: "private 192.168.x", ip: "192.168.1.1", blocked: true},
+
+		// Private IPv6
+		{name: "private IPv6 fc00", ip: "fc00::1", blocked: true},
+		{name: "private IPv6 fd00", ip: "fd00::1", blocked: true},
+
+		// Link-local (includes cloud metadata)
+		{name: "cloud metadata", ip: "169.254.169.254", blocked: true},
+		{name: "link-local IPv4", ip: "169.254.1.1", blocked: true},
+		{name: "link-local IPv6", ip: "fe80::1", blocked: true},
+
+		// Unspecified
+		{name: "unspecified IPv4", ip: "0.0.0.0", blocked: true},
+		{name: "unspecified IPv6", ip: "::", blocked: true},
+
+		// Multicast
+		{name: "multicast IPv4", ip: "224.0.0.1", blocked: true},
+		{name: "multicast IPv6", ip: "ff02::1", blocked: true},
+
+		// Carrier-grade NAT (RFC 6598)
+		{name: "CGNAT start", ip: "100.64.0.1", blocked: true},
+		{name: "CGNAT end", ip: "100.127.255.254", blocked: true},
+
+		// IPv4-mapped IPv6 bypass attempts
+		{name: "mapped loopback", ip: "::ffff:127.0.0.1", blocked: true},
+		{name: "mapped metadata", ip: "::ffff:169.254.169.254", blocked: true},
+		{name: "mapped private", ip: "::ffff:10.0.0.1", blocked: true},
+
+		// Allowed public IPs
+		{name: "public DNS 8.8.8.8", ip: "8.8.8.8", blocked: false},
+		{name: "public DNS 1.1.1.1", ip: "1.1.1.1", blocked: false},
+		{name: "public IP", ip: "142.250.80.46", blocked: false},
+		{name: "public IPv6", ip: "2607:f8b0:4004:800::200e", blocked: false},
+		{name: "100.63 not cgnat", ip: "100.63.0.1", blocked: false},
+		{name: "100.128 not cgnat", ip: "100.128.0.1", blocked: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			addr := netip.MustParseAddr(tc.ip)
+			blocked, _ := isBlockedIP(addr)
+			if blocked != tc.blocked {
+				t.Errorf("isBlockedIP(%s) = %v, want %v", tc.ip, blocked, tc.blocked)
+			}
+		})
+	}
+}
+
+func TestBlockPrivateNetworkControl(t *testing.T) {
+	cases := []struct {
+		name    string
+		network string
+		address string
+		blocked bool
+	}{
+		{name: "ipv4 loopback", network: "tcp", address: "127.0.0.1:80", blocked: true},
+		{name: "ipv4 loopback range", network: "tcp", address: "127.5.4.3:443", blocked: true},
+		{name: "ipv4 rfc1918 10.x", network: "tcp", address: "10.0.0.1:80", blocked: true},
+		{name: "ipv4 rfc1918 172.16", network: "tcp", address: "172.16.0.5:80", blocked: true},
+		{name: "ipv4 rfc1918 192.168", network: "tcp", address: "192.168.1.1:80", blocked: true},
+		{name: "ipv4 link-local 169.254", network: "tcp", address: "169.254.169.254:80", blocked: true},
+		{name: "ipv4 unspecified", network: "tcp", address: "0.0.0.0:80", blocked: true},
+		{name: "ipv4 multicast", network: "tcp", address: "224.0.0.1:80", blocked: true},
+		{name: "ipv4 cgnat 100.64", network: "tcp", address: "100.64.0.1:80", blocked: true},
+		{name: "ipv4 cgnat 100.127", network: "tcp", address: "100.127.255.254:80", blocked: true},
+		{name: "ipv6 loopback", network: "tcp", address: "[::1]:80", blocked: true},
+		{name: "ipv6 ula fd00", network: "tcp", address: "[fd00::1]:80", blocked: true},
+		{name: "ipv6 link-local fe80", network: "tcp", address: "[fe80::1]:80", blocked: true},
+		{name: "ipv6 unspecified", network: "tcp", address: "[::]:80", blocked: true},
+		{name: "non-IP host", network: "tcp", address: "example.com:80", blocked: true},
+		{name: "bad network", network: "unix", address: "/var/run/sock:0", blocked: true},
+		{name: "missing port", network: "tcp", address: "1.1.1.1", blocked: true},
+
+		{name: "public ipv4", network: "tcp", address: "1.1.1.1:443", blocked: false},
+		{name: "public ipv4 second", network: "tcp", address: "8.8.8.8:443", blocked: false},
+		{name: "public ipv6", network: "tcp", address: "[2606:4700:4700::1111]:443", blocked: false},
+		{name: "udp public", network: "udp", address: "8.8.4.4:53", blocked: false},
+		{name: "100.63 not cgnat", network: "tcp", address: "100.63.0.1:80", blocked: false},
+		{name: "100.128 not cgnat", network: "tcp", address: "100.128.0.1:80", blocked: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := BlockPrivateNetworkControl(tc.network, tc.address, nil)
+			gotBlocked := err != nil
+			if gotBlocked != tc.blocked {
+				t.Fatalf("blocked = %v want %v (err=%v)", gotBlocked, tc.blocked, err)
+			}
+			if err != nil {
+				var be *RestrictedAddrError
+				if !errors.As(err, &be) {
+					t.Fatalf("expected *RestrictedAddrError, got %T: %v", err, err)
+				}
+			}
+		})
+	}
+}
+
+// TestBlockPrivateNetworkControlOverRealDial exercises BlockPrivateNetworkControl
+// through an actual net.Dialer/http.Transport dial, using hostnames rather than
+// literal IPs. This confirms that net.Dialer resolves the hostname before
+// Control ever runs, so Control always sees a literal "ip:port" — the same IP
+// that connect(2) is about to be issued against — and hostname-based URLs are
+// not rejected outright.
+func TestBlockPrivateNetworkControlOverRealDial(t *testing.T) {
+	dial := (&net.Dialer{Control: BlockPrivateNetworkControl}).DialContext
+
+	t.Run("hostname resolving to loopback is blocked", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		_, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+		if err != nil {
+			t.Fatalf("failed to split test server address: %v", err)
+		}
+
+		client := &http.Client{Transport: &http.Transport{DialContext: dial}}
+		resp, err := client.Get("http://localhost:" + port + "/") //nolint:noctx
+		if err == nil {
+			resp.Body.Close()
+			t.Fatal("expected dial to localhost to be blocked, got success")
+		}
+		var restrictedErr *RestrictedAddrError
+		if !errors.As(err, &restrictedErr) {
+			t.Fatalf("expected error to wrap *RestrictedAddrError, got %v", err)
+		}
+	})
+
+	t.Run("hostname resolving to a public IP is not rejected by Control", func(t *testing.T) {
+		// example.com resolves to public IPs, so Control must allow the dial
+		// through; any remaining error must not be a *RestrictedAddrError.
+		conn, err := dial(context.Background(), "tcp", "example.com:80")
+		if err != nil {
+			var restrictedErr *RestrictedAddrError
+			if errors.As(err, &restrictedErr) {
+				t.Fatalf("dial to public hostname was blocked by SSRF guard: %v", err)
+			}
+			t.Skipf("dial to example.com failed for a reason unrelated to the SSRF guard (likely no network access in test env): %v", err)
+			return
+		}
+		conn.Close()
+	})
+}
+
+func TestBlockPrivateIPs(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]string
+		want   bool
+	}{
+		{name: "nil config", config: nil, want: true},
+		{name: "key absent", config: map[string]string{}, want: true},
+		{name: "true", config: map[string]string{BlockPrivateIPsConfigKey: "true"}, want: true},
+		{name: "True", config: map[string]string{BlockPrivateIPsConfigKey: "True"}, want: true},
+		{name: "yes", config: map[string]string{BlockPrivateIPsConfigKey: "yes"}, want: true},
+		{name: "typo", config: map[string]string{BlockPrivateIPsConfigKey: "fals"}, want: true},
+		{name: "false", config: map[string]string{BlockPrivateIPsConfigKey: "false"}, want: false},
+		{name: "False", config: map[string]string{BlockPrivateIPsConfigKey: "False"}, want: false},
+		{name: "FALSE", config: map[string]string{BlockPrivateIPsConfigKey: "FALSE"}, want: false},
+		{name: "0", config: map[string]string{BlockPrivateIPsConfigKey: "0"}, want: false},
+		{name: "no", config: map[string]string{BlockPrivateIPsConfigKey: "no"}, want: false},
+		{name: "No", config: map[string]string{BlockPrivateIPsConfigKey: "No"}, want: false},
+		{name: "off", config: map[string]string{BlockPrivateIPsConfigKey: "off"}, want: false},
+		{name: "Off", config: map[string]string{BlockPrivateIPsConfigKey: "Off"}, want: false},
+		{name: "false with spaces", config: map[string]string{BlockPrivateIPsConfigKey: " false "}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.config != nil {
+				ctx = InjectResolverConfigToContext(ctx, tc.config)
+			}
+			got := BlockPrivateIPs(ctx)
+			if got != tc.want {
+				t.Errorf("BlockPrivateIPs() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolverHTTPTransport(t *testing.T) {
+	t.Run("blocking enabled returns restricted transport", func(t *testing.T) {
+		ctx := InjectResolverConfigToContext(context.Background(), map[string]string{})
+		transport := ResolverHTTPTransport(ctx)
+		if transport == http.DefaultTransport {
+			t.Fatal("expected restricted transport, got http.DefaultTransport")
+		}
+		if _, ok := transport.(*http.Transport); !ok {
+			t.Fatalf("expected *http.Transport, got %T", transport)
+		}
+	})
+
+	t.Run("blocking disabled returns default transport", func(t *testing.T) {
+		ctx := InjectResolverConfigToContext(context.Background(), map[string]string{
+			BlockPrivateIPsConfigKey: "false",
+		})
+		transport := ResolverHTTPTransport(ctx)
+		if transport != http.DefaultTransport {
+			t.Fatal("expected http.DefaultTransport when blocking is disabled")
+		}
+	})
+}
+
+func TestRestrictedHTTPTransport(t *testing.T) {
+	tr := RestrictedHTTPTransport()
+	if tr == nil {
+		t.Fatal("nil transport")
+	}
+	if tr.DialContext == nil {
+		t.Fatal("expected DialContext to be installed")
+	}
+}

--- a/pkg/resolution/resolver/http/resolver.go
+++ b/pkg/resolution/resolver/http/resolver.go
@@ -212,8 +212,10 @@ func makeHttpClient(ctx context.Context) (*http.Client, error) {
 			return nil, fmt.Errorf("error parsing timeout value %s: %w", v, err)
 		}
 	}
+
 	return &http.Client{
-		Timeout: timeout,
+		Timeout:   timeout,
+		Transport: framework.ResolverHTTPTransport(ctx),
 	}, nil
 }
 

--- a/pkg/resolution/resolver/http/resolver_test.go
+++ b/pkg/resolution/resolver/http/resolver_test.go
@@ -411,7 +411,9 @@ func TestResolverReconcileBasicAuth(t *testing.T) {
 				p.url = svr.URL
 			}
 			request := createRequest(p)
-			cfg := make(map[string]string)
+			cfg := map[string]string{
+				framework.BlockPrivateIPsConfigKey: "false",
+			}
 			d := test.Data{
 				ConfigMaps: []*corev1.ConfigMap{{
 					ObjectMeta: metav1.ObjectMeta{
@@ -515,6 +517,14 @@ func toParams(m map[string]string) []pipelinev1.Param {
 
 func contextWithConfig(timeout string) context.Context {
 	config := map[string]string{
+		TimeoutKey:                         timeout,
+		framework.BlockPrivateIPsConfigKey: "false",
+	}
+	return framework.InjectResolverConfigToContext(context.Background(), config)
+}
+
+func contextWithBlockingConfig(timeout string) context.Context {
+	config := map[string]string{
 		TimeoutKey: timeout,
 	}
 	return framework.InjectResolverConfigToContext(context.Background(), config)
@@ -528,6 +538,118 @@ func checkExpectedErr(t *testing.T, expectedErr, actualErr error) {
 	if d := cmp.Diff(expectedErr.Error(), actualErr.Error()); d != "" {
 		t.Fatalf("expected err '%v' but got '%v'", expectedErr, actualErr)
 	}
+}
+
+func TestMakeHTTPClientBlockPrivateIPs(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         map[string]string
+		expectBlocking bool
+	}{
+		{
+			name:           "default (key absent) blocks private IPs",
+			config:         map[string]string{TimeoutKey: "1m"},
+			expectBlocking: true,
+		},
+		{
+			name:           "explicit true blocks private IPs",
+			config:         map[string]string{TimeoutKey: "1m", framework.BlockPrivateIPsConfigKey: "true"},
+			expectBlocking: true,
+		},
+		{
+			name:           "false disables blocking",
+			config:         map[string]string{TimeoutKey: "1m", framework.BlockPrivateIPsConfigKey: "false"},
+			expectBlocking: false,
+		},
+		{
+			name:           "invalid value treated as true",
+			config:         map[string]string{TimeoutKey: "1m", framework.BlockPrivateIPsConfigKey: "yes"},
+			expectBlocking: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := framework.InjectResolverConfigToContext(context.Background(), tc.config)
+			client, err := makeHttpClient(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			hasCustomTransport := client.Transport != http.DefaultTransport && client.Transport != nil
+			if hasCustomTransport != tc.expectBlocking {
+				t.Errorf("custom Transport set = %v, want %v", hasCustomTransport, tc.expectBlocking)
+			}
+		})
+	}
+}
+
+func TestFetchHttpResourceBlockedIP(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	}))
+	defer svr.Close()
+
+	params := map[string]string{UrlParam: svr.URL}
+	logger, _ := zap.NewDevelopment()
+
+	t.Run("blocking enabled rejects loopback", func(t *testing.T) {
+		ctx := contextWithBlockingConfig(defaultHttpTimeoutValue)
+		_, err := FetchHttpResource(ctx, params, nil, logger.Sugar())
+		if err == nil {
+			t.Fatal("expected error when fetching from loopback with blocking enabled")
+		}
+		if !strings.Contains(err.Error(), "is blocked") {
+			t.Fatalf("expected SSRF error but got: %v", err)
+		}
+	})
+
+	t.Run("blocking disabled allows loopback", func(t *testing.T) {
+		ctx := contextWithConfig(defaultHttpTimeoutValue)
+		result, err := FetchHttpResource(ctx, params, nil, logger.Sugar())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(result.Data()) != "ok" {
+			t.Fatalf("expected 'ok' but got %q", string(result.Data()))
+		}
+	})
+}
+
+func TestFetchHttpResourceRedirectToBlocked(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "redirected")
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	params := map[string]string{UrlParam: redirector.URL}
+	logger, _ := zap.NewDevelopment()
+
+	t.Run("redirect to loopback blocked", func(t *testing.T) {
+		ctx := contextWithBlockingConfig(defaultHttpTimeoutValue)
+		_, err := FetchHttpResource(ctx, params, nil, logger.Sugar())
+		if err == nil {
+			t.Fatal("expected error when redirect targets loopback with blocking enabled")
+		}
+		if !strings.Contains(err.Error(), "is blocked") {
+			t.Fatalf("expected SSRF error but got: %v", err)
+		}
+	})
+
+	t.Run("redirect to loopback allowed when disabled", func(t *testing.T) {
+		ctx := contextWithConfig(defaultHttpTimeoutValue)
+		result, err := FetchHttpResource(ctx, params, nil, logger.Sugar())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(result.Data()) != "redirected" {
+			t.Fatalf("expected 'redirected' but got %q", string(result.Data()))
+		}
+	})
 }
 
 func TestCompareSHA(t *testing.T) {


### PR DESCRIPTION
  
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Fixes #9602 
This PR adds defense-in-depth IP filtering to `makeHttpClient()`:
- Custom `http.Transport` with a `DialContext` that resolves the target hostname and rejects connections to private, loopback, link-local, CGNAT, and unspecified IP addresses
- DNS rebinding prevention — the resolved IP is used directly for connection, so a hostname that resolves to a public IP during validation cannot resolve to a private IP during connection
- `block-private-ips` config key in `http-resolver-config` ConfigMap, defaulting to `"true"`. Administrators who need the resolver to reach internal registries can set it to `"false"`

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add SSRF protection to HTTP resolver via a shared framework guard (framework/ssrf.go). The HTTP resolver now blocks requests to private, loopback, link-local, CGNAT, and unspecified IP addresses by default using a net.Dialer.Control callback that runs after DNS resolution and before connect(2), preventing DNS rebinding attacks. Configure `block-private-ips: "false"` in the `http-resolver-config` ConfigMap to allow internal requests. Action required: if your HTTP resolver fetches resources from internal/private network addresses (e.g. cluster-internal registries or services), you must set this option or those requests will be rejected after upgrading.
```
