### PR TITLE
docs: clarify retry-count/task.retries only work with taskSpec, not taskRef

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1263,6 +1263,10 @@ taskSpec:
 **Note:** Every `PipelineTask` can only access its own `retries` and `retry-count`. These
 values aren't accessible for other `PipelineTask`s.
 
+> **Note:** `$(context.task.retry-count)` and `$(context.task.retries)` are only supported
+> with inline `taskSpec` definitions. They are **not** supported when using `taskRef`
+> to reference an external Task.
+
 ## Using `Results`
 
 Tasks can emit [`Results`](tasks.md#emitting-results) when they execute. A Pipeline can use these


### PR DESCRIPTION
Fixes #7063

The `retries` and `retry-count` variable substitutions section in the docs uses a `taskSpec` (inline) example without mentioning that these variables are not supported with `taskRef`.

This PR adds a clear note explaining that `$(context.task.retry-count)` and `$(context.task.retries)` are only supported with inline `taskSpec` definitions and are **not** supported when using `taskRef` to reference an external Task.

/kind documentation

```release-note
NONE
```