### PR TITLE
feat(tracing): add spans to ResolutionRequest resource operations

### DIFF
--- a/pkg/reconciler/resolutionrequest/controller.go
+++ b/pkg/reconciler/resolutionrequest/controller.go
@@ -22,7 +22,9 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	resolutionrequestinformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	resolutionrequestreconciler "github.com/tektoncd/pipeline/pkg/client/resolution/injection/reconciler/resolution/v1beta1/resolutionrequest"
+	"github.com/tektoncd/pipeline/pkg/tracing"
 	"k8s.io/utils/clock"
+	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -33,18 +35,28 @@ import (
 func NewController(clock clock.PassiveClock) func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
+		secretInformer := secretinformer.Get(ctx)
+		tracerProvider := tracing.New(TracerName, logger.Named("tracing"))
 
-		configStore := config.NewStore(logger.Named("config-store"))
+		//nolint:contextcheck
+		configStore := config.NewStore(logger.Named("config-store"),
+			tracerProvider.OnStore(secretInformer.Lister()),
+		)
 		configStore.WatchConfigs(cmw)
 
 		r := &Reconciler{
-			clock: clock,
+			clock:          clock,
+			tracerProvider: tracerProvider,
 		}
 		impl := resolutionrequestreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
 			return controller.Options{
 				ConfigStore: configStore,
 			}
 		})
+
+		if _, err := secretInformer.Informer().AddEventHandler(controller.HandleAll(tracerProvider.Handler)); err != nil {
+			logging.FromContext(ctx).Panicf("Couldn't register Secret informer event handler: %w", err)
+		}
 
 		reqinformer := resolutionrequestinformer.Get(ctx)
 		if _, err := reqinformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue)); err != nil {

--- a/pkg/reconciler/resolutionrequest/controller.go
+++ b/pkg/reconciler/resolutionrequest/controller.go
@@ -23,7 +23,9 @@ import (
 	resolutionclient "github.com/tektoncd/pipeline/pkg/client/resolution/injection/client"
 	resolutionrequestinformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	resolutionrequestreconciler "github.com/tektoncd/pipeline/pkg/client/resolution/injection/reconciler/resolution/v1beta1/resolutionrequest"
+	"github.com/tektoncd/pipeline/pkg/tracing"
 	"k8s.io/utils/clock"
+	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -34,13 +36,19 @@ import (
 func NewController(clock clock.PassiveClock) func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
+		secretInformer := secretinformer.Get(ctx)
+		tracerProvider := tracing.New(TracerName, logger.Named("tracing"))
 
-		configStore := config.NewStore(logger.Named("config-store"))
+		//nolint:contextcheck
+		configStore := config.NewStore(logger.Named("config-store"),
+			tracerProvider.OnStore(secretInformer.Lister()),
+		)
 		configStore.WatchConfigs(cmw)
 
 		r := &Reconciler{
-			client: resolutionclient.Get(ctx),
-			clock:  clock,
+			client:         resolutionclient.Get(ctx),
+			clock:          clock,
+			tracerProvider: tracerProvider,
 		}
 		impl := resolutionrequestreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
 			return controller.Options{
@@ -50,6 +58,10 @@ func NewController(clock clock.PassiveClock) func(ctx context.Context, cmw confi
 				SkipStatusUpdates: true,
 			}
 		})
+
+		if _, err := secretInformer.Informer().AddEventHandler(controller.HandleAll(tracerProvider.Handler)); err != nil {
+			logging.FromContext(ctx).Panicf("Couldn't register Secret informer event handler: %v", err)
+		}
 
 		reqinformer := resolutionrequestinformer.Get(ctx)
 		if _, err := reqinformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue)); err != nil {

--- a/pkg/reconciler/resolutionrequest/resolutionrequest.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest.go
@@ -25,16 +25,23 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	rrreconciler "github.com/tektoncd/pipeline/pkg/client/resolution/injection/reconciler/resolution/v1beta1/resolutionrequest"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/utils/clock"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
 )
 
+// TracerName is the name of the tracer used by the ResolutionRequest reconciler.
+const TracerName = "ResolutionRequestReconciler"
+
 // Reconciler is a knative reconciler for processing ResolutionRequest
 // objects
 type Reconciler struct {
-	clock clock.PassiveClock
+	clock          clock.PassiveClock
+	tracerProvider trace.TracerProvider
 }
 
 var _ rrreconciler.Interface = (*Reconciler)(nil)
@@ -50,6 +57,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, rr *v1beta1.ResolutionRe
 		return nil
 	}
 
+	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "ReconcileKind")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("resolutionrequest.name", rr.Name),
+		attribute.String("resolutionrequest.namespace", rr.Namespace),
+	)
+
 	if rr.Status.GetCondition(apis.ConditionSucceeded) == nil {
 		rr.Status.InitializeConditions()
 	}
@@ -57,10 +71,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, rr *v1beta1.ResolutionRe
 	maximumResolutionDuration := config.FromContextOrDefaults(ctx).Defaults.DefaultMaximumResolutionTimeout
 	switch {
 	case rr.IsResolved():
+		span.SetAttributes(attribute.String("resolutionrequest.outcome", "succeeded"))
 		rr.Status.MarkSucceeded()
 	case requestDuration(rr) > maximumResolutionDuration:
+		span.SetAttributes(attribute.String("resolutionrequest.outcome", "timed-out"))
+		span.SetStatus(codes.Error, resolutioncommon.ReasonResolutionTimedOut)
 		rr.Status.MarkFailed(resolutioncommon.ReasonResolutionTimedOut, timeoutMessage(maximumResolutionDuration))
 	default:
+		span.SetAttributes(attribute.String("resolutionrequest.outcome", "in-progress"))
 		rr.Status.MarkInProgress(resolutioncommon.MessageWaitingForResolver)
 		return controller.NewRequeueAfter(maximumResolutionDuration - requestDuration(rr))
 	}

--- a/pkg/reconciler/resolutionrequest/resolutionrequest.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest.go
@@ -27,6 +27,9 @@ import (
 	resolutionclientset "github.com/tektoncd/pipeline/pkg/client/resolution/clientset/versioned"
 	rrreconciler "github.com/tektoncd/pipeline/pkg/client/resolution/injection/reconciler/resolution/v1beta1/resolutionrequest"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,13 +41,17 @@ import (
 	"knative.dev/pkg/reconciler"
 )
 
+// TracerName is the name of the tracer used by the ResolutionRequest reconciler.
+const TracerName = "ResolutionRequestReconciler"
+
 // Reconciler is a knative reconciler for processing ResolutionRequest objects.
 // It patches lifecycle-owned status fields itself and must be configured with
 // SkipStatusUpdates so generated updates do not overwrite resolver-owned fields.
 type Reconciler struct {
 	// client applies lifecycle-only status patches.
-	client resolutionclientset.Interface
-	clock  clock.PassiveClock
+	client         resolutionclientset.Interface
+	clock          clock.PassiveClock
+	tracerProvider trace.TracerProvider
 }
 
 var _ rrreconciler.Interface = (*Reconciler)(nil)
@@ -80,6 +87,13 @@ func (r *Reconciler) reconcile(ctx context.Context, rr *v1beta1.ResolutionReques
 		return nil
 	}
 
+	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "ReconcileKind")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("resolutionrequest.name", rr.Name),
+		attribute.String("resolutionrequest.namespace", rr.Namespace),
+	)
+
 	if rr.Status.GetCondition(apis.ConditionSucceeded) == nil {
 		rr.Status.InitializeConditions()
 	}
@@ -87,10 +101,14 @@ func (r *Reconciler) reconcile(ctx context.Context, rr *v1beta1.ResolutionReques
 	maximumResolutionDuration := config.FromContextOrDefaults(ctx).Defaults.DefaultMaximumResolutionTimeout
 	switch {
 	case rr.IsResolved():
+		span.SetAttributes(attribute.String("resolutionrequest.outcome", "succeeded"))
 		rr.Status.MarkSucceeded()
 	case requestDuration(rr) > maximumResolutionDuration:
+		span.SetAttributes(attribute.String("resolutionrequest.outcome", "timed-out"))
+		span.SetStatus(codes.Error, resolutioncommon.ReasonResolutionTimedOut)
 		rr.Status.MarkFailed(resolutioncommon.ReasonResolutionTimedOut, timeoutMessage(maximumResolutionDuration))
 	default:
+		span.SetAttributes(attribute.String("resolutionrequest.outcome", "in-progress"))
 		rr.Status.MarkInProgress(resolutioncommon.MessageWaitingForResolver)
 		return controller.NewRequeueAfter(maximumResolutionDuration - requestDuration(rr))
 	}

--- a/pkg/reconciler/resolutionrequest/tracing_test.go
+++ b/pkg/reconciler/resolutionrequest/tracing_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolutionrequest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clock "k8s.io/utils/clock/testing"
+)
+
+func TestReconcileKindCreatesSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	fakeClock := clock.NewFakePassiveClock(time.Now())
+	r := &Reconciler{
+		clock:          fakeClock,
+		tracerProvider: tp,
+	}
+
+	rr := &v1beta1.ResolutionRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-rr",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Now(),
+		},
+	}
+
+	_ = r.ReconcileKind(context.Background(), rr)
+
+	spans := recorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span to be recorded, got none")
+	}
+
+	var found bool
+	for _, s := range spans {
+		if s.Name() == "ReconcileKind" {
+			found = true
+			attrs := spanAttrs(s)
+			if got := attrs["resolutionrequest.name"]; got != "test-rr" {
+				t.Errorf("resolutionrequest.name: got %q, want %q", got, "test-rr")
+			}
+			if got := attrs["resolutionrequest.namespace"]; got != "default" {
+				t.Errorf("resolutionrequest.namespace: got %q, want %q", got, "default")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("ReconcileKind span not found; recorded spans: %v", endedSpanNames(spans))
+	}
+}
+
+func TestReconcileKindSpanOutcomeAttributes(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		data        string
+		wantOutcome string
+	}{{
+		name:        "succeeded",
+		data:        "cmVzb2x2ZWQ=",
+		wantOutcome: "succeeded",
+	}, {
+		name:        "in-progress",
+		data:        "",
+		wantOutcome: "in-progress",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+			r := &Reconciler{
+				clock:          clock.NewFakePassiveClock(time.Now()),
+				tracerProvider: tp,
+			}
+
+			rr := &v1beta1.ResolutionRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-rr",
+					Namespace:         "default",
+					CreationTimestamp: metav1.Now(),
+				},
+			}
+			rr.Status.Data = tc.data
+
+			_ = r.ReconcileKind(context.Background(), rr)
+
+			var outcome string
+			for _, s := range recorder.Ended() {
+				if s.Name() == "ReconcileKind" {
+					outcome = spanAttrs(s)["resolutionrequest.outcome"]
+				}
+			}
+			if outcome != tc.wantOutcome {
+				t.Errorf("resolutionrequest.outcome: got %q, want %q", outcome, tc.wantOutcome)
+			}
+		})
+	}
+}
+
+// spanAttrs converts span attributes to a string map for easy lookup.
+func spanAttrs(s sdktrace.ReadOnlySpan) map[string]string {
+	m := make(map[string]string, len(s.Attributes()))
+	for _, a := range s.Attributes() {
+		m[string(a.Key)] = a.Value.AsString()
+	}
+	return m
+}
+
+// endedSpanNames returns just the names of a slice of spans for diagnostic output.
+func endedSpanNames(spans []sdktrace.ReadOnlySpan) []string {
+	names := make([]string, len(spans))
+	for i, s := range spans {
+		names[i] = s.Name()
+	}
+	return names
+}

--- a/pkg/reconciler/resolutionrequest/tracing_test.go
+++ b/pkg/reconciler/resolutionrequest/tracing_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolutionrequest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
+	fakerrclient "github.com/tektoncd/pipeline/pkg/client/resolution/clientset/versioned/fake"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clock "k8s.io/utils/clock/testing"
+)
+
+func TestReconcileKindCreatesSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	rr := &v1beta1.ResolutionRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-rr",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Now(),
+		},
+	}
+
+	fakeClock := clock.NewFakePassiveClock(time.Now())
+	r := &Reconciler{
+		client:         fakerrclient.NewSimpleClientset(rr),
+		clock:          fakeClock,
+		tracerProvider: tp,
+	}
+
+	_ = r.ReconcileKind(context.Background(), rr)
+
+	spans := recorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span to be recorded, got none")
+	}
+
+	var found bool
+	for _, s := range spans {
+		if s.Name() == "ReconcileKind" {
+			found = true
+			attrs := spanAttrs(s)
+			if got := attrs["resolutionrequest.name"]; got != "test-rr" {
+				t.Errorf("resolutionrequest.name: got %q, want %q", got, "test-rr")
+			}
+			if got := attrs["resolutionrequest.namespace"]; got != "default" {
+				t.Errorf("resolutionrequest.namespace: got %q, want %q", got, "default")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("ReconcileKind span not found; recorded spans: %v", endedSpanNames(spans))
+	}
+}
+
+func TestReconcileKindSpanOutcomeAttributes(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		data        string
+		wantOutcome string
+	}{{
+		name:        "succeeded",
+		data:        "cmVzb2x2ZWQ=",
+		wantOutcome: "succeeded",
+	}, {
+		name:        "in-progress",
+		data:        "",
+		wantOutcome: "in-progress",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+			rr := &v1beta1.ResolutionRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-rr",
+					Namespace:         "default",
+					CreationTimestamp: metav1.Now(),
+				},
+			}
+			rr.Status.Data = tc.data
+
+			r := &Reconciler{
+				client:         fakerrclient.NewSimpleClientset(rr),
+				clock:          clock.NewFakePassiveClock(time.Now()),
+				tracerProvider: tp,
+			}
+
+			_ = r.ReconcileKind(context.Background(), rr)
+
+			var outcome string
+			for _, s := range recorder.Ended() {
+				if s.Name() == "ReconcileKind" {
+					outcome = spanAttrs(s)["resolutionrequest.outcome"]
+				}
+			}
+			if outcome != tc.wantOutcome {
+				t.Errorf("resolutionrequest.outcome: got %q, want %q", outcome, tc.wantOutcome)
+			}
+		})
+	}
+}
+
+// spanAttrs converts span attributes to a string map for easy lookup.
+func spanAttrs(s sdktrace.ReadOnlySpan) map[string]string {
+	m := make(map[string]string, len(s.Attributes()))
+	for _, a := range s.Attributes() {
+		m[string(a.Key)] = a.Value.AsString()
+	}
+	return m
+}
+
+// endedSpanNames returns just the names of a slice of spans for diagnostic output.
+func endedSpanNames(spans []sdktrace.ReadOnlySpan) []string {
+	names := make([]string, len(spans))
+	for i, s := range spans {
+		names[i] = s.Name()
+	}
+	return names
+}

--- a/pkg/remoteresolution/remote/resolution/resolver.go
+++ b/pkg/remoteresolution/remote/resolution/resolver.go
@@ -23,6 +23,9 @@ import (
 	resolution "github.com/tektoncd/pipeline/pkg/remote/resolution"
 	remoteresource "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
 	resource "github.com/tektoncd/pipeline/pkg/resolution/resource"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/kmeta"
 )
@@ -51,15 +54,30 @@ func NewResolver(requester remoteresource.Requester, owner kmeta.OwnerRefable, r
 	}
 }
 
+// TracerName is the name of the tracer used by the remote resolution Resolver.
+const TracerName = "RemoteResolutionResolver"
+
 // Get implements remote.Resolver.
 func (resolver *Resolver) Get(ctx context.Context, _, _ string) (runtime.Object, *v1.RefSource, error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "Get")
+	defer span.End()
+	span.SetAttributes(attribute.String("resolver.name", resolver.resolverName))
+
 	resolverName := remoteresource.ResolverName(resolver.resolverName)
 	req, err := buildRequest(resolver.resolverName, resolver.owner, &resolver.resolverPayload)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error building request for remote resource: %w", err)
+		wrappedErr := fmt.Errorf("error building request for remote resource: %w", err)
+		span.RecordError(wrappedErr)
+		span.SetStatus(codes.Error, wrappedErr.Error())
+		return nil, nil, wrappedErr
 	}
 	resolved, err := resolver.requester.Submit(ctx, resolverName, req)
-	return resolution.ResolvedRequest(resolved, err)
+	obj, refSource, resolveErr := resolution.ResolvedRequest(resolved, err)
+	if resolveErr != nil && resolveErr != remote.ErrRequestInProgress {
+		span.RecordError(resolveErr)
+		span.SetStatus(codes.Error, resolveErr.Error())
+	}
+	return obj, refSource, resolveErr
 }
 
 // List implements remote.Resolver but is unused for remote resolution.

--- a/pkg/remoteresolution/remote/resolution/resolver.go
+++ b/pkg/remoteresolution/remote/resolution/resolver.go
@@ -15,6 +15,7 @@ package resolution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -23,6 +24,9 @@ import (
 	resolution "github.com/tektoncd/pipeline/pkg/remote/resolution"
 	remoteresource "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
 	resource "github.com/tektoncd/pipeline/pkg/resolution/resource"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/kmeta"
 )
@@ -51,15 +55,30 @@ func NewResolver(requester remoteresource.Requester, owner kmeta.OwnerRefable, r
 	}
 }
 
+// TracerName is the name of the tracer used by the remote resolution Resolver.
+const TracerName = "RemoteResolutionResolver"
+
 // Get implements remote.Resolver.
 func (resolver *Resolver) Get(ctx context.Context, _, _ string) (runtime.Object, *v1.RefSource, error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "Get")
+	defer span.End()
+	span.SetAttributes(attribute.String("resolver.name", resolver.resolverName))
+
 	resolverName := remoteresource.ResolverName(resolver.resolverName)
 	req, err := buildRequest(resolver.resolverName, resolver.owner, &resolver.resolverPayload)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error building request for remote resource: %w", err)
+		wrappedErr := fmt.Errorf("error building request for remote resource: %w", err)
+		span.RecordError(wrappedErr)
+		span.SetStatus(codes.Error, wrappedErr.Error())
+		return nil, nil, wrappedErr
 	}
 	resolved, err := resolver.requester.Submit(ctx, resolverName, req)
-	return resolution.ResolvedRequest(resolved, err)
+	obj, refSource, resolveErr := resolution.ResolvedRequest(resolved, err)
+	if resolveErr != nil && !errors.Is(resolveErr, remote.ErrRequestInProgress) {
+		span.RecordError(resolveErr)
+		span.SetStatus(codes.Error, resolveErr.Error())
+	}
+	return obj, refSource, resolveErr
 }
 
 // List implements remote.Resolver but is unused for remote resolution.

--- a/pkg/remoteresolution/remote/resolution/resolver_tracing_test.go
+++ b/pkg/remoteresolution/remote/resolution/resolver_tracing_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	remoteresource "github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
+	"github.com/tektoncd/pipeline/pkg/resolution/common"
+	test "github.com/tektoncd/pipeline/test/remoteresolution"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testOwner() *v1beta1.PipelineRun {
+	return &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
+	}
+}
+
+// getSpan returns the span named "Get" from the recorded spans, or fails.
+func getSpan(t *testing.T, spans []sdktrace.ReadOnlySpan) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range spans {
+		if s.Name() == "Get" {
+			return s
+		}
+	}
+	t.Fatalf("Get span not found in recorded spans")
+	return nil
+}
+
+func spanHasException(s sdktrace.ReadOnlySpan) bool {
+	for _, e := range s.Events() {
+		if e.Name == "exception" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGetCreatesSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	ctx, parent := tp.Tracer("test").Start(t.Context(), "parent")
+
+	requester := &test.Requester{
+		ResolvedResource: &test.ResolvedResource{ResolvedData: pipelineBytes},
+	}
+	resolver := NewResolver(requester, testOwner(), "git", remoteresource.ResolverPayload{})
+
+	if _, _, err := resolver.Get(ctx, "foo", "bar"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parent.End()
+
+	span := getSpan(t, recorder.Ended())
+	var name string
+	for _, a := range span.Attributes() {
+		if a.Key == "resolver.name" {
+			name = a.Value.AsString()
+		}
+	}
+	if name != "git" {
+		t.Errorf("resolver.name: got %q, want %q", name, "git")
+	}
+	if span.Status().Code == codes.Error {
+		t.Errorf("expected no error status on successful Get, got %q", span.Status().Description)
+	}
+	if spanHasException(span) {
+		t.Errorf("expected no recorded error on successful Get")
+	}
+}
+
+func TestGetSpanErrorRecording(t *testing.T) {
+	genericErr := errors.New("uh oh something bad happened")
+	for _, tc := range []struct {
+		name          string
+		submitErr     error
+		wantSpanError bool
+	}{{
+		// ErrRequestInProgress is the normal async-wait signal, not a failure,
+		// so it must not be recorded as a span error (see the errors.Is guard).
+		name:          "in-progress is not a span error",
+		submitErr:     common.ErrRequestInProgress,
+		wantSpanError: false,
+	}, {
+		name:          "real error is recorded",
+		submitErr:     genericErr,
+		wantSpanError: true,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+			ctx, parent := tp.Tracer("test").Start(t.Context(), "parent")
+
+			requester := &test.Requester{SubmitErr: tc.submitErr}
+			resolver := NewResolver(requester, testOwner(), "git", remoteresource.ResolverPayload{})
+
+			_, _, _ = resolver.Get(ctx, "foo", "bar")
+			parent.End()
+
+			span := getSpan(t, recorder.Ended())
+			gotSpanError := span.Status().Code == codes.Error
+			if gotSpanError != tc.wantSpanError {
+				t.Errorf("span error status: got %v (code=%q), want %v", gotSpanError, span.Status().Code, tc.wantSpanError)
+			}
+			if got := spanHasException(span); got != tc.wantSpanError {
+				t.Errorf("span exception event: got %v, want %v", got, tc.wantSpanError)
+			}
+		})
+	}
+}

--- a/pkg/remoteresolution/resolver/framework/controller.go
+++ b/pkg/remoteresolution/resolver/framework/controller.go
@@ -20,13 +20,16 @@ import (
 	"context"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	rrclient "github.com/tektoncd/pipeline/pkg/client/resolution/injection/client"
 	rrinformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	rrcache "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
 	framework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"github.com/tektoncd/pipeline/pkg/tracing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/clock"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -49,6 +52,14 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 		kubeclientset := kubeclient.Get(ctx)
 		rrclientset := rrclient.Get(ctx)
 		rrInformer := rrinformer.Get(ctx)
+		secretInformer := secretinformer.Get(ctx)
+		tracerProvider := tracing.New("resolver-framework", logger.Named("tracing"))
+
+		//nolint:contextcheck
+		tracingConfigStore := config.NewStore(logger.Named("tracing-config-store"),
+			tracerProvider.OnStore(secretInformer.Lister()),
+		)
+		tracingConfigStore.WatchConfigs(cmw)
 
 		if err := resolver.Initialize(ctx); err != nil {
 			panic(err.Error())
@@ -60,6 +71,7 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 			resolutionRequestLister:    rrInformer.Lister(),
 			resolutionRequestClientSet: rrclientset,
 			resolver:                   resolver,
+			tracerProvider:             tracerProvider,
 		}
 
 		watchConfigChanges(ctx, r, cmw)
@@ -76,6 +88,10 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 			WorkQueueName: "TektonResolverFramework." + resolverName,
 			Logger:        logger,
 		})
+
+		if _, err := secretInformer.Informer().AddEventHandler(controller.HandleAll(tracerProvider.Handler)); err != nil {
+			logging.FromContext(ctx).Panicf("Couldn't register Secret informer event handler: %w", err)
+		}
 
 		_, err := rrInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 			FilterFunc: framework.FilterResolutionRequestsBySelector(resolver.GetSelector(ctx)),
@@ -135,5 +151,8 @@ func applyModifiersAndDefaults(ctx context.Context, r *Reconciler, modifiers []R
 
 	if r.Clock == nil {
 		r.Clock = clock.RealClock{}
+	}
+	if r.tracerProvider == nil {
+		r.tracerProvider = tracing.New("resolver-framework", logging.FromContext(ctx).Named("tracing"))
 	}
 }

--- a/pkg/remoteresolution/resolver/framework/controller.go
+++ b/pkg/remoteresolution/resolver/framework/controller.go
@@ -20,13 +20,16 @@ import (
 	"context"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	rrclient "github.com/tektoncd/pipeline/pkg/client/resolution/injection/client"
 	rrinformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	rrcache "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
 	framework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"github.com/tektoncd/pipeline/pkg/tracing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/clock"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -49,6 +52,23 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 		kubeclientset := kubeclient.Get(ctx)
 		rrclientset := rrclient.Get(ctx)
 		rrInformer := rrinformer.Get(ctx)
+		secretInformer := secretinformer.Get(ctx)
+		tracerProvider := tracing.New("resolver-framework", logger.Named("tracing"))
+
+		// Watch only the tracing configmap. Using the full pipeline config
+		// store here would also watch configmaps the resolver deployment does
+		// not install (e.g. config-wait-exponential-backoff), which crashes the
+		// remote resolver pod.
+		//nolint:contextcheck
+		tracingConfigStore := configmap.NewUntypedStore(
+			"tracing-config-store",
+			logger.Named("tracing-config-store"),
+			configmap.Constructors{
+				config.GetTracingConfigName(): config.NewTracingFromConfigMap,
+			},
+			tracerProvider.OnStore(secretInformer.Lister()),
+		)
+		tracingConfigStore.WatchConfigs(cmw)
 
 		if err := resolver.Initialize(ctx); err != nil {
 			panic(err.Error())
@@ -60,6 +80,7 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 			resolutionRequestLister:    rrInformer.Lister(),
 			resolutionRequestClientSet: rrclientset,
 			resolver:                   resolver,
+			tracerProvider:             tracerProvider,
 		}
 
 		watchConfigChanges(ctx, r, cmw)
@@ -76,6 +97,10 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 			WorkQueueName: "TektonResolverFramework." + resolverName,
 			Logger:        logger,
 		})
+
+		if _, err := secretInformer.Informer().AddEventHandler(controller.HandleAll(tracerProvider.Handler)); err != nil {
+			logging.FromContext(ctx).Panicf("Couldn't register Secret informer event handler: %v", err)
+		}
 
 		_, err := rrInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 			FilterFunc: framework.FilterResolutionRequestsBySelector(resolver.GetSelector(ctx)),
@@ -135,5 +160,8 @@ func applyModifiersAndDefaults(ctx context.Context, r *Reconciler, modifiers []R
 
 	if r.Clock == nil {
 		r.Clock = clock.RealClock{}
+	}
+	if r.tracerProvider == nil {
+		r.tracerProvider = tracing.New("resolver-framework", logging.FromContext(ctx).Named("tracing"))
 	}
 }

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -32,6 +32,9 @@ import (
 	rrcache "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -49,6 +52,9 @@ import (
 // Resolve() may take. It can be overridden by a resolver implementing
 // the framework.TimedResolution interface.
 const defaultMaximumResolutionDuration = time.Minute
+
+// TracerName is the name of the tracer used by the resolver framework reconciler.
+const TracerName = "ResolverFrameworkReconciler"
 
 // statusDataPatch is the json structure that will be PATCHed into
 // a ResolutionRequest with its data and annotations once successfully
@@ -76,7 +82,8 @@ type Reconciler struct {
 	resolutionRequestLister    rrv1beta1.ResolutionRequestLister
 	resolutionRequestClientSet rrclient.Interface
 
-	configStore *framework.ConfigStore
+	configStore    *framework.ConfigStore
+	tracerProvider trace.TracerProvider
 }
 
 var _ reconciler.LeaderAware = &Reconciler{}
@@ -106,6 +113,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return nil
 	}
 
+	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "Reconcile")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("resolver.type", r.resolver.GetName(ctx)),
+		attribute.String("resolutionrequest.name", name),
+		attribute.String("resolutionrequest.namespace", namespace),
+	)
+
 	// Inject request-scoped information into the context, such as
 	// the namespace that the request originates from and the
 	// configuration from the configmap this resolver is watching.
@@ -115,10 +130,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		ctx = r.configStore.ToContext(ctx)
 	}
 
-	return r.resolve(ctx, key, rr)
+	if resolveErr := r.resolve(ctx, key, rr); resolveErr != nil {
+		span.RecordError(resolveErr)
+		span.SetStatus(codes.Error, resolveErr.Error())
+		return resolveErr
+	}
+	return nil
 }
 
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
+	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "resolve")
+	defer span.End()
+
 	errChan := make(chan error, 1)
 	resourceChan := make(chan framework.ResolvedResource, 1)
 
@@ -142,6 +165,8 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 		var err error
 		timeoutDuration, err = timed.GetResolutionTimeout(ctx, defaultMaximumResolutionDuration, paramsMap)
 		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
 	}
@@ -152,42 +177,66 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	resolutionCtx, cancelFn := context.WithTimeout(ctx, timeoutDuration)
 	defer cancelFn()
 
+	resolverName := r.resolver.GetName(resolutionCtx)
+	tracer := r.tracerProvider.Tracer(TracerName)
+
 	go func() {
-		validationError := r.resolver.Validate(resolutionCtx, &rr.Spec)
+		validateCtx, validateSpan := tracer.Start(resolutionCtx, "validate")
+		validateSpan.SetAttributes(attribute.String("resolver.type", resolverName))
+		validationError := r.resolver.Validate(validateCtx, &rr.Spec)
 		if validationError != nil {
+			validateSpan.RecordError(validationError)
+			validateSpan.SetStatus(codes.Error, validationError.Error())
+			validateSpan.End()
 			errChan <- &resolutioncommon.InvalidRequestError{
 				ResolutionRequestKey: key,
 				Message:              validationError.Error(),
 			}
 			return
 		}
-		resource, resolveErr := r.resolver.Resolve(resolutionCtx, &rr.Spec)
+		validateSpan.End()
+
+		resolveCtx, resolveSpan := tracer.Start(resolutionCtx, "resolverResolve")
+		resolveSpan.SetAttributes(attribute.String("resolver.type", resolverName))
+		resource, resolveErr := r.resolver.Resolve(resolveCtx, &rr.Spec)
 		if resolveErr != nil {
+			resolveSpan.RecordError(resolveErr)
+			resolveSpan.SetStatus(codes.Error, resolveErr.Error())
+			resolveSpan.End()
 			errChan <- &resolutioncommon.GetResourceError{
-				ResolverName: r.resolver.GetName(resolutionCtx),
+				ResolverName: resolverName,
 				Key:          key,
 				Original:     resolveErr,
 			}
 			return
 		}
 		if err := framework.ValidateResolvedResource(resource); err != nil {
+			wrappedErr := fmt.Errorf("resolved resource validation error: %w", err)
+			resolveSpan.RecordError(wrappedErr)
+			resolveSpan.SetStatus(codes.Error, wrappedErr.Error())
+			resolveSpan.End()
 			errChan <- &resolutioncommon.GetResourceError{
-				ResolverName: r.resolver.GetName(resolutionCtx),
+				ResolverName: resolverName,
 				Key:          key,
-				Original:     fmt.Errorf("resolved resource validation error: %w", err),
+				Original:     wrappedErr,
 			}
 			return
 		}
+		resolveSpan.End()
 		resourceChan <- resource
 	}()
 
 	select {
 	case err := <-errChan:
 		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return r.OnError(ctx, rr, err)
 		}
 	case <-resolutionCtx.Done():
 		if err := resolutionCtx.Err(); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return r.OnError(ctx, rr, err)
 		}
 	case resource := <-resourceChan:
@@ -217,11 +266,16 @@ func (r *Reconciler) OnError(ctx context.Context, rr *v1beta1.ResolutionRequest,
 // errors that occur during the update process or nil if the update
 // appeared to succeed.
 func (r *Reconciler) MarkFailed(ctx context.Context, rr *v1beta1.ResolutionRequest, resolutionErr error) error {
+	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "MarkFailed")
+	defer span.End()
+
 	key := fmt.Sprintf("%s/%s", rr.Namespace, rr.Name)
 	reason, resolutionErr := resolutioncommon.ReasonError(resolutionErr)
 	latestGeneration, err := r.resolutionRequestClientSet.ResolutionV1beta1().ResolutionRequests(rr.Namespace).Get(ctx, rr.Name, metav1.GetOptions{})
 	if err != nil {
 		logging.FromContext(ctx).Warnf("error getting latest generation of resolutionrequest %q: %v", key, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	if latestGeneration.IsDone() {
@@ -231,12 +285,17 @@ func (r *Reconciler) MarkFailed(ctx context.Context, rr *v1beta1.ResolutionReque
 	_, err = r.resolutionRequestClientSet.ResolutionV1beta1().ResolutionRequests(rr.Namespace).UpdateStatus(ctx, latestGeneration, metav1.UpdateOptions{})
 	if err != nil {
 		logging.FromContext(ctx).Warnf("error marking resolutionrequest %q as failed: %v", key, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	return nil
 }
 
 func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.ResolutionRequest, resource framework.ResolvedResource) error {
+	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "writeResolvedData")
+	defer span.End()
+
 	encodedData := base64.StdEncoding.Strict().EncodeToString(resource.Data())
 	patchBytes, err := json.Marshal(map[string]statusDataPatch{
 		"status": {
@@ -248,6 +307,8 @@ func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.Resoluti
 	})
 	if err != nil {
 		logging.FromContext(ctx).Warnf("writeResolvedData error serializing resource request patch for resolution request %s:%s: %s", rr.Namespace, rr.Name, err.Error())
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return r.OnError(ctx, rr, &resolutioncommon.UpdatingRequestError{
 			ResolutionRequestKey: fmt.Sprintf("%s/%s", rr.Namespace, rr.Name),
 			Original:             fmt.Errorf("error serializing resource request patch: %w", err),
@@ -256,6 +317,8 @@ func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.Resoluti
 	_, err = r.resolutionRequestClientSet.ResolutionV1beta1().ResolutionRequests(rr.Namespace).Patch(ctx, rr.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
 	if err != nil {
 		logging.FromContext(ctx).Warnf("writeResolvedData error patching resolution request %s:%s: %s", rr.Namespace, rr.Name, err.Error())
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return r.OnError(ctx, rr, &resolutioncommon.UpdatingRequestError{
 			ResolutionRequestKey: fmt.Sprintf("%s/%s", rr.Namespace, rr.Name),
 			Original:             err,

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -32,6 +32,9 @@ import (
 	rrcache "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -49,6 +52,9 @@ import (
 // Resolve() may take. It can be overridden by a resolver implementing
 // the framework.TimedResolution interface.
 const defaultMaximumResolutionDuration = time.Minute
+
+// TracerName is the name of the tracer used by the resolver framework reconciler.
+const TracerName = "ResolverFrameworkReconciler"
 
 // statusDataPatch is the json structure that will be PATCHed into
 // a ResolutionRequest with its data and annotations once successfully
@@ -76,7 +82,8 @@ type Reconciler struct {
 	resolutionRequestLister    rrv1beta1.ResolutionRequestLister
 	resolutionRequestClientSet rrclient.Interface
 
-	configStore *framework.ConfigStore
+	configStore    *framework.ConfigStore
+	tracerProvider trace.TracerProvider
 }
 
 var _ reconciler.LeaderAware = &Reconciler{}
@@ -112,6 +119,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return nil
 	}
 
+	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "Reconcile")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("resolver.type", r.resolver.GetName(ctx)),
+		attribute.String("resolutionrequest.name", name),
+		attribute.String("resolutionrequest.namespace", namespace),
+	)
+
 	// Inject request-scoped information into the context, such as
 	// the namespace that the request originates from and the
 	// configuration from the configmap this resolver is watching.
@@ -121,10 +136,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		ctx = r.configStore.ToContext(ctx)
 	}
 
-	return r.resolve(ctx, key, rr)
+	if resolveErr := r.resolve(ctx, key, rr); resolveErr != nil {
+		span.RecordError(resolveErr)
+		span.SetStatus(codes.Error, resolveErr.Error())
+		return resolveErr
+	}
+	return nil
 }
 
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
+	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "resolve")
+	defer span.End()
+
 	errChan := make(chan error, 1)
 	resourceChan := make(chan framework.ResolvedResource, 1)
 
@@ -148,6 +171,8 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 		var err error
 		timeoutDuration, err = timed.GetResolutionTimeout(ctx, defaultMaximumResolutionDuration, paramsMap)
 		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
 	}
@@ -158,42 +183,66 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	resolutionCtx, cancelFn := context.WithTimeout(ctx, timeoutDuration)
 	defer cancelFn()
 
+	resolverName := r.resolver.GetName(resolutionCtx)
+	tracer := r.tracerProvider.Tracer(TracerName)
+
 	go func() {
-		validationError := r.resolver.Validate(resolutionCtx, &rr.Spec)
+		validateCtx, validateSpan := tracer.Start(resolutionCtx, "validate")
+		validateSpan.SetAttributes(attribute.String("resolver.type", resolverName))
+		validationError := r.resolver.Validate(validateCtx, &rr.Spec)
 		if validationError != nil {
+			validateSpan.RecordError(validationError)
+			validateSpan.SetStatus(codes.Error, validationError.Error())
+			validateSpan.End()
 			errChan <- &resolutioncommon.InvalidRequestError{
 				ResolutionRequestKey: key,
 				Message:              validationError.Error(),
 			}
 			return
 		}
-		resource, resolveErr := r.resolver.Resolve(resolutionCtx, &rr.Spec)
+		validateSpan.End()
+
+		resolveCtx, resolveSpan := tracer.Start(resolutionCtx, "resolverResolve")
+		resolveSpan.SetAttributes(attribute.String("resolver.type", resolverName))
+		resource, resolveErr := r.resolver.Resolve(resolveCtx, &rr.Spec)
 		if resolveErr != nil {
+			resolveSpan.RecordError(resolveErr)
+			resolveSpan.SetStatus(codes.Error, resolveErr.Error())
+			resolveSpan.End()
 			errChan <- &resolutioncommon.GetResourceError{
-				ResolverName: r.resolver.GetName(resolutionCtx),
+				ResolverName: resolverName,
 				Key:          key,
 				Original:     resolveErr,
 			}
 			return
 		}
 		if err := framework.ValidateResolvedResource(resource); err != nil {
+			wrappedErr := fmt.Errorf("resolved resource validation error: %w", err)
+			resolveSpan.RecordError(wrappedErr)
+			resolveSpan.SetStatus(codes.Error, wrappedErr.Error())
+			resolveSpan.End()
 			errChan <- &resolutioncommon.GetResourceError{
-				ResolverName: r.resolver.GetName(resolutionCtx),
+				ResolverName: resolverName,
 				Key:          key,
-				Original:     fmt.Errorf("resolved resource validation error: %w", err),
+				Original:     wrappedErr,
 			}
 			return
 		}
+		resolveSpan.End()
 		resourceChan <- resource
 	}()
 
 	select {
 	case err := <-errChan:
 		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return r.OnError(ctx, rr, err)
 		}
 	case <-resolutionCtx.Done():
 		if err := resolutionCtx.Err(); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return r.OnError(ctx, rr, err)
 		}
 	case resource := <-resourceChan:
@@ -223,11 +272,16 @@ func (r *Reconciler) OnError(ctx context.Context, rr *v1beta1.ResolutionRequest,
 // errors that occur during the update process or nil if the update
 // appeared to succeed.
 func (r *Reconciler) MarkFailed(ctx context.Context, rr *v1beta1.ResolutionRequest, resolutionErr error) error {
+	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "MarkFailed")
+	defer span.End()
+
 	key := fmt.Sprintf("%s/%s", rr.Namespace, rr.Name)
 	reason, resolutionErr := resolutioncommon.ReasonError(resolutionErr)
 	latestGeneration, err := r.resolutionRequestClientSet.ResolutionV1beta1().ResolutionRequests(rr.Namespace).Get(ctx, rr.Name, metav1.GetOptions{})
 	if err != nil {
 		logging.FromContext(ctx).Warnf("error getting latest generation of resolutionrequest %q: %v", key, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	if latestGeneration.IsDone() {
@@ -237,12 +291,17 @@ func (r *Reconciler) MarkFailed(ctx context.Context, rr *v1beta1.ResolutionReque
 	_, err = r.resolutionRequestClientSet.ResolutionV1beta1().ResolutionRequests(rr.Namespace).UpdateStatus(ctx, latestGeneration, metav1.UpdateOptions{})
 	if err != nil {
 		logging.FromContext(ctx).Warnf("error marking resolutionrequest %q as failed: %v", key, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	return nil
 }
 
 func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.ResolutionRequest, resource framework.ResolvedResource) error {
+	ctx, span := r.tracerProvider.Tracer(TracerName).Start(ctx, "writeResolvedData")
+	defer span.End()
+
 	encodedData := base64.StdEncoding.Strict().EncodeToString(resource.Data())
 	patchBytes, err := json.Marshal(map[string]statusDataPatch{
 		"status": {
@@ -254,6 +313,8 @@ func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.Resoluti
 	})
 	if err != nil {
 		logging.FromContext(ctx).Warnf("writeResolvedData error serializing resource request patch for resolution request %s:%s: %s", rr.Namespace, rr.Name, err.Error())
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return r.OnError(ctx, rr, &resolutioncommon.UpdatingRequestError{
 			ResolutionRequestKey: fmt.Sprintf("%s/%s", rr.Namespace, rr.Name),
 			Original:             fmt.Errorf("error serializing resource request patch: %w", err),
@@ -262,6 +323,8 @@ func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.Resoluti
 	_, err = r.resolutionRequestClientSet.ResolutionV1beta1().ResolutionRequests(rr.Namespace).Patch(ctx, rr.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
 	if err != nil {
 		logging.FromContext(ctx).Warnf("writeResolvedData error patching resolution request %s:%s: %s", rr.Namespace, rr.Name, err.Error())
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return r.OnError(ctx, rr, &resolutioncommon.UpdatingRequestError{
 			ResolutionRequestKey: fmt.Sprintf("%s/%s", rr.Namespace, rr.Name),
 			Original:             err,

--- a/pkg/remoteresolution/resolver/framework/reconciler_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_test.go
@@ -607,6 +607,7 @@ func getResolverFrameworkController(ctx context.Context, t *testing.T, d test.Da
 	names.TestingSeed()
 
 	ctx, cancel := context.WithCancel(ctx)
+	test.EnsureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
 	ctl := framework.NewController(ctx, resolver, modifiers...)(ctx, configMapWatcher)

--- a/pkg/remoteresolution/resolver/framework/reconciler_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_test.go
@@ -631,6 +631,7 @@ func getResolverFrameworkController(ctx context.Context, t *testing.T, d test.Da
 	names.TestingSeed()
 
 	ctx, cancel := context.WithCancel(ctx)
+	test.EnsureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
 	ctl := framework.NewController(ctx, resolver, modifiers...)(ctx, configMapWatcher)

--- a/pkg/remoteresolution/resolver/framework/testing/fakecontroller.go
+++ b/pkg/remoteresolution/resolver/framework/testing/fakecontroller.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	resolverconfig "github.com/tektoncd/pipeline/pkg/apis/config/resolver"
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework"
@@ -156,32 +157,30 @@ func setClockOnReconciler(r *framework.Reconciler) {
 }
 
 func ensureConfigurationConfigMapsExist(d *test.Data) {
-	var featureFlagsExists bool
-	var resolverCacheConfigExists bool
+	ns := resolverconfig.ResolversNamespace(system.Namespace())
+	existing := make(map[string]bool)
 	for _, cm := range d.ConfigMaps {
-		if cm.Name == resolverconfig.GetFeatureFlagsConfigName() {
-			featureFlagsExists = true
-		}
-		if cm.Name == "resolver-cache-config" {
-			resolverCacheConfigExists = true
-		}
+		existing[cm.Name] = true
 	}
-	if !featureFlagsExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      resolverconfig.GetFeatureFlagsConfigName(),
-				Namespace: resolverconfig.ResolversNamespace(system.Namespace()),
-			},
-			Data: map[string]string{},
-		})
-	}
-	if !resolverCacheConfigExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "resolver-cache-config",
-				Namespace: resolverconfig.ResolversNamespace(system.Namespace()),
-			},
-			Data: map[string]string{},
-		})
+	for _, name := range []string{
+		resolverconfig.GetFeatureFlagsConfigName(),
+		"resolver-cache-config",
+		config.GetDefaultsConfigName(),
+		config.GetFeatureFlagsConfigName(),
+		config.GetMetricsConfigName(),
+		config.GetSpireConfigName(),
+		config.GetEventsConfigName(),
+		config.GetTracingConfigName(),
+		config.GetWaitExponentialBackoffConfigName(),
+	} {
+		if !existing[name] {
+			d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+				Data: map[string]string{},
+			})
+		}
 	}
 }

--- a/pkg/remoteresolution/resolver/framework/tracing_test.go
+++ b/pkg/remoteresolution/resolver/framework/tracing_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is in package framework (not framework_test) so it can access
+// the unexported tracerProvider field on Reconciler.
+package framework
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
+	fakerrclient "github.com/tektoncd/pipeline/pkg/client/resolution/clientset/versioned/fake"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+func TestMarkFailedCreatesSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	rr := &v1beta1.ResolutionRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rr",
+			Namespace: "default",
+		},
+		Status: v1beta1.ResolutionRequestStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   apis.ConditionSucceeded,
+					Status: "Unknown",
+				}},
+			},
+		},
+	}
+
+	fakeClient := fakerrclient.NewSimpleClientset(rr)
+	r := &Reconciler{
+		resolutionRequestClientSet: fakeClient,
+		tracerProvider:             tp,
+	}
+
+	_ = r.MarkFailed(context.Background(), rr, errors.New("something went wrong"))
+
+	spans := recorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span to be recorded, got none")
+	}
+
+	var found bool
+	for _, s := range spans {
+		if s.Name() == "MarkFailed" {
+			found = true
+		}
+	}
+	if !found {
+		names := make([]string, len(spans))
+		for i, s := range spans {
+			names[i] = s.Name()
+		}
+		t.Errorf("MarkFailed span not found; recorded spans: %v", names)
+	}
+}
+
+func TestWriteResolvedDataCreatesSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	rr := &v1beta1.ResolutionRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rr",
+			Namespace: "default",
+		},
+	}
+
+	fakeClient := fakerrclient.NewSimpleClientset(rr)
+	r := &Reconciler{
+		resolutionRequestClientSet: fakeClient,
+		tracerProvider:             tp,
+	}
+
+	resource := &fakeResolvedResource{data: []byte("resolved-content")}
+	_ = r.writeResolvedData(context.Background(), rr, resource)
+
+	spans := recorder.Ended()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span to be recorded, got none")
+	}
+
+	var found bool
+	for _, s := range spans {
+		if s.Name() == "writeResolvedData" {
+			found = true
+		}
+	}
+	if !found {
+		names := make([]string, len(spans))
+		for i, s := range spans {
+			names[i] = s.Name()
+		}
+		t.Errorf("writeResolvedData span not found; recorded spans: %v", names)
+	}
+}
+
+// fakeResolvedResource is a minimal ResolvedResource for use in tracing tests.
+type fakeResolvedResource struct {
+	data []byte
+}
+
+func (f *fakeResolvedResource) Data() []byte                     { return f.data }
+func (f *fakeResolvedResource) Annotations() map[string]string   { return nil }
+func (f *fakeResolvedResource) RefSource() *pipelinev1.RefSource { return nil }

--- a/pkg/remoteresolution/resource/crd_resource.go
+++ b/pkg/remoteresolution/resource/crd_resource.go
@@ -24,10 +24,16 @@ import (
 	rrlisters "github.com/tektoncd/pipeline/pkg/client/resolution/listers/resolution/v1beta1"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	resolutionresource "github.com/tektoncd/pipeline/pkg/resolution/resource"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
+
+// TracerName is the name of the tracer used by CRDRequester.
+const TracerName = "CRDRequester"
 
 // CRDRequester implements the Requester interface using
 // ResolutionRequest CRDs.
@@ -50,18 +56,27 @@ var _ Requester = &CRDRequester{}
 // kubernetes cluster, returning any errors experienced while doing so.
 // If ResolutionRequest is succeeded then it returns the resolved data.
 func (r *CRDRequester) Submit(ctx context.Context, resolver ResolverName, req Request) (ResolvedResource, error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "Submit")
+	defer span.End()
+	span.SetAttributes(attribute.String("resolver.name", string(resolver)))
+
 	rr, _ := r.lister.ResolutionRequests(req.ResolverPayload().Namespace).Get(req.ResolverPayload().Name)
 	if rr == nil {
+		span.AddEvent("cache-miss: creating ResolutionRequest")
 		if err := r.createResolutionRequest(ctx, resolver, req); err != nil &&
 			// When the request reconciles frequently, the creation may fail
 			// because the list informer cache is not updated.
 			// If the request already exists then we can assume that is in progress.
 			// The next reconcile will handle it based on the actual situation.
 			!apierrors.IsAlreadyExists(err) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return nil, err
 		}
 		return nil, resolutioncommon.ErrRequestInProgress
 	}
+
+	span.AddEvent("cache-hit: ResolutionRequest exists")
 
 	if rr.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
 		// TODO(sbwsg): This should be where an existing
@@ -78,10 +93,15 @@ func (r *CRDRequester) Submit(ctx context.Context, resolver ResolverName, req Re
 
 	message := rr.Status.GetCondition(apis.ConditionSucceeded).GetMessage()
 	err := resolutioncommon.NewError(resolutioncommon.ReasonResolutionFailed, errors.New(message))
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
 	return nil, err
 }
 
 func (r *CRDRequester) createResolutionRequest(ctx context.Context, resolver ResolverName, req Request) error {
+	_, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "createResolutionRequest")
+	defer span.End()
+
 	var owner metav1.OwnerReference
 	if ownedReq, ok := req.(OwnedRequest); ok {
 		owner = ownedReq.OwnerRef()
@@ -89,5 +109,9 @@ func (r *CRDRequester) createResolutionRequest(ctx context.Context, resolver Res
 	rr := resolutionresource.CreateResolutionRequest(ctx, resolver, req.ResolverPayload().Name, req.ResolverPayload().Namespace, req.ResolverPayload().ResolutionSpec.Params, owner)
 	rr.Spec.URL = req.ResolverPayload().ResolutionSpec.URL
 	_, err := r.clientset.ResolutionV1beta1().ResolutionRequests(rr.Namespace).Create(ctx, rr, metav1.CreateOptions{})
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
 	return err
 }

--- a/pkg/remoteresolution/resource/crd_resource.go
+++ b/pkg/remoteresolution/resource/crd_resource.go
@@ -24,10 +24,16 @@ import (
 	rrlisters "github.com/tektoncd/pipeline/pkg/client/resolution/listers/resolution/v1beta1"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	resolutionresource "github.com/tektoncd/pipeline/pkg/resolution/resource"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
+
+// TracerName is the name of the tracer used by CRDRequester.
+const TracerName = "CRDRequester"
 
 // CRDRequester implements the Requester interface using
 // ResolutionRequest CRDs.
@@ -50,18 +56,27 @@ var _ Requester = &CRDRequester{}
 // kubernetes cluster, returning any errors experienced while doing so.
 // If ResolutionRequest is succeeded then it returns the resolved data.
 func (r *CRDRequester) Submit(ctx context.Context, resolver ResolverName, req Request) (ResolvedResource, error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "Submit")
+	defer span.End()
+	span.SetAttributes(attribute.String("resolver.name", string(resolver)))
+
 	rr, _ := r.lister.ResolutionRequests(req.ResolverPayload().Namespace).Get(req.ResolverPayload().Name)
 	if rr == nil {
+		span.AddEvent("cache-miss: creating ResolutionRequest")
 		if err := r.createResolutionRequest(ctx, resolver, req); err != nil &&
 			// When the request reconciles frequently, the creation may fail
 			// because the list informer cache is not updated.
 			// If the request already exists then we can assume that is in progress.
 			// The next reconcile will handle it based on the actual situation.
 			!apierrors.IsAlreadyExists(err) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return nil, err
 		}
 		return nil, resolutioncommon.ErrRequestInProgress
 	}
+
+	span.AddEvent("cache-hit: ResolutionRequest exists")
 
 	if rr.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
 		// TODO(sbwsg): This should be where an existing
@@ -78,10 +93,15 @@ func (r *CRDRequester) Submit(ctx context.Context, resolver ResolverName, req Re
 
 	message := rr.Status.GetCondition(apis.ConditionSucceeded).GetMessage()
 	err := resolutioncommon.NewError(resolutioncommon.ReasonResolutionFailed, errors.New(message))
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
 	return nil, err
 }
 
 func (r *CRDRequester) createResolutionRequest(ctx context.Context, resolver ResolverName, req Request) error {
+	_, span := trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName).Start(ctx, "createResolutionRequest")
+	defer span.End()
+
 	var owner metav1.OwnerReference
 	if ownedReq, ok := req.(OwnedRequest); ok {
 		owner = ownedReq.OwnerRef()
@@ -89,5 +109,11 @@ func (r *CRDRequester) createResolutionRequest(ctx context.Context, resolver Res
 	rr := resolutionresource.CreateResolutionRequest(ctx, resolver, req.ResolverPayload().Name, req.ResolverPayload().Namespace, req.ResolverPayload().ResolutionSpec.Params, owner)
 	rr.Spec.URL = req.ResolverPayload().ResolutionSpec.URL
 	_, err := r.clientset.ResolutionV1beta1().ResolutionRequests(rr.Namespace).Create(ctx, rr, metav1.CreateOptions{})
+	// AlreadyExists is an expected outcome while the informer cache catches up
+	// (see Submit), so it should not be recorded as a span error.
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
 	return err
 }

--- a/pkg/remoteresolution/resource/crd_resource_tracing_test.go
+++ b/pkg/remoteresolution/resource/crd_resource_tracing_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/remoteresolution/resource"
+	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
+	"github.com/tektoncd/pipeline/test"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ktesting "k8s.io/client-go/testing"
+)
+
+// TestCRDRequesterSubmitAlreadyExistsIsNotSpanError verifies that when Create
+// returns AlreadyExists (the informer cache lagging behind an existing
+// ResolutionRequest), neither the Submit nor the createResolutionRequest span
+// records it as an error. AlreadyExists is an expected in-progress outcome.
+func TestCRDRequesterSubmitAlreadyExistsIsNotSpanError(t *testing.T) {
+	ownerRef := mustParseOwnerReference(t, `
+apiVersion: tekton.dev/v1beta1
+blockOwnerDeletion: true
+controller: true
+kind: TaskRun
+name: git-clone
+uid: 727019c3-4066-4d8b-919e-90660dfd8b55
+`)
+	request := mustParseRawRequest(t, `
+resolverPayload:
+  name: git-ec247f5592afcaefa8485e34d2bd80c6
+  namespace: namespace
+  resolutionSpec:
+    params:
+    - name: url
+      value: https://github.com/tektoncd/catalog
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: task/git-clone/0.6/git-clone.yaml
+    url: "https://foo/bar"
+`)
+
+	// No seeded ResolutionRequest, so Submit takes the create path.
+	testAssets, cancel := getCRDRequester(t, test.Data{})
+	defer cancel()
+	clients := testAssets.Clients
+
+	// Force Create to return AlreadyExists, mimicking the informer cache
+	// lagging behind a request that already exists in the cluster.
+	clients.ResolutionRequests.PrependReactor("create", "resolutionrequests",
+		func(ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewAlreadyExists(
+				schema.GroupResource{Group: "resolution.tekton.dev", Resource: "resolutionrequests"},
+				request.ResolverPayload.Name)
+		})
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	// The CRD requester derives its tracer provider from the span in ctx, so
+	// start a parent span backed by the recorder before calling Submit.
+	ctx, parent := tp.Tracer("test").Start(testAssets.Ctx, "parent")
+
+	crdRequester := resource.NewCRDRequester(clients.ResolutionRequests, testAssets.Informers.ResolutionRequest.Lister())
+	requestWithOwner := &ownerRequest{
+		Request:  request.Request(),
+		ownerRef: *ownerRef,
+	}
+
+	_, err := crdRequester.Submit(ctx, resolutioncommon.ResolverName("git"), requestWithOwner)
+	parent.End()
+
+	if !errors.Is(err, resolutioncommon.ErrRequestInProgress) {
+		t.Fatalf("expected ErrRequestInProgress for AlreadyExists, got %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, s := range recorder.Ended() {
+		switch s.Name() {
+		case "Submit", "createResolutionRequest":
+			seen[s.Name()] = true
+			if s.Status().Code == codes.Error {
+				t.Errorf("span %q: expected no error status for AlreadyExists, got code=%q description=%q",
+					s.Name(), s.Status().Code, s.Status().Description)
+			}
+			for _, e := range s.Events() {
+				if e.Name == "exception" {
+					t.Errorf("span %q: expected no recorded error for AlreadyExists, but found an exception event", s.Name())
+				}
+			}
+		}
+	}
+	for _, name := range []string{"Submit", "createResolutionRequest"} {
+		if !seen[name] {
+			t.Errorf("expected span %q to be recorded, but it was not", name)
+		}
+	}
+}


### PR DESCRIPTION
# Changes

Add OpenTelemetry spans to the ResolutionRequest subsystem following the established tracerProvider pattern used in TaskRun/PipelineRun reconcilers.

- framework/reconciler.go: root span in Reconcile(), child spans in resolve() for validate/resolverResolve steps, plus spans in writeResolvedData() and MarkFailed(); all error paths call RecordError/SetStatus
- framework/controller.go: wire tracerProvider via tracing.New(), register secret informer handler for credential hot-reload
- resolutionrequest.go: span in ReconcileKind() with outcome attribute (succeeded/timed-out/in-progress)
- resolutionrequest/controller.go: wire tracerProvider into reconciler
- crd_resource.go: spans in Submit() and createResolutionRequest() using trace.SpanFromContext to inherit parent reconciler trace
- remote/resolution/resolver.go: entry span in Get() bridging the caller trace into the resolution subsystem

Closes #9788
Part of #9701

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add OpenTelemetry distributed tracing spans to the ResolutionRequest subsystem, enabling trace visibility into resolver dispatch, cache lookup, data write, and failure marking.
```
