### PR TITLE
Fix dependabot-regen workflow commit author and sign-off

### DIFF
--- a/.github/workflows/dependabot-regen.yml
+++ b/.github/workflows/dependabot-regen.yml
@@ -56,8 +56,8 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           # Configure git
-          git config user.name "Tekton Bot"
-          git config user.email "tekton-bot@users.noreply.github.com"
+          git config user.name "Vincent Demeester"
+          git config user.email "vdemeest@redhat.com"
 
           # Create a new branch
           BRANCH="dependabot-regen-$(date +%Y%m%d-%H%M%S)"
@@ -65,7 +65,7 @@ jobs:
 
           # Commit changes
           git add .github/dependabot.config.yml .github/dependabot.yml
-          git commit -m "Regenerate dependabot.yml from config
+          git commit -s -m "Regenerate dependabot.yml from config
 
           This automated PR regenerates .github/dependabot.yml from
           .github/dependabot.config.yml to ensure the configuration


### PR DESCRIPTION
# Changes

Fix the dependabot-regen workflow which creates PRs that fail EasyCLA (e.g. #9957).

Two issues:
1. Commit author was `Tekton Bot <tekton-bot@users.noreply.github.com>` which lacks CLA authorization
2. Commits lacked DCO `Signed-off-by` trailer

Fix by:
- Setting commit author to a CLA-authorized identity, matching the [operator repo pattern](https://github.com/tektoncd/operator/blob/main/.github/workflows/bump-payload-on-main.yaml)
- Adding `-s` flag to `git commit` for DCO sign-off

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```