### PR TITLE
fix: override OCI labels in ko publish task

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -179,6 +179,9 @@ spec:
 
       ko resolve \
         --image-label=org.opencontainers.image.source=https://$(params.package) \
+        --image-label=org.opencontainers.image.url=https://$(params.package) \
+        --image-label=org.opencontainers.image.title=pipeline \
+        --image-label=org.opencontainers.image.description=Tekton\ Pipelines \
         --platform=$(params.platforms) \
         -t $(params.versionTag) \
         -R ${KO_EXTRA_ARGS} \
@@ -188,6 +191,9 @@ spec:
       # This is currently the case for `cri-o` (and most likely others)
       ko resolve \
         --image-label=org.opencontainers.image.source=https://$(params.package) \
+        --image-label=org.opencontainers.image.url=https://$(params.package) \
+        --image-label=org.opencontainers.image.title=pipeline \
+        --image-label=org.opencontainers.image.description=Tekton\ Pipelines \
         --platform=$(params.platforms) \
         -R ${KO_EXTRA_ARGS} \
         -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.notags.yaml


### PR DESCRIPTION
# Changes

Images built with `ko` inherit all OCI labels from their base image. Pipeline images that use `ghcr.io/tektoncd/plumbing/tini-git` as their base end up with three incorrect labels inherited from the plumbing repo:

- `org.opencontainers.image.description`: contains the plumbing repo description (including an emoji character) instead of a description of the Tekton Pipelines project. Some OCI registries (e.g. JFrog Artifactory) reject manifests with emoji in label values.
- `org.opencontainers.image.title`: set to `"plumbing"` instead of `"pipeline"`
- `org.opencontainers.image.url`: points to `github.com/tektoncd/plumbing` instead of `github.com/tektoncd/pipeline`

This PR explicitly passes these three labels on both `ko resolve` invocations in `tekton/publish.yaml`, so published images always carry correct pipeline-specific metadata regardless of what the base image provides.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps --> **N/A (internal build task)**
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed --> **N/A (no logic change)**
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix incorrect OCI image labels (title, url, description) inherited from base image in published pipeline images
```
