### PR TITLE
feat: add Prometheus metrics for resolver framework

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -39,6 +39,19 @@ The Labels/Tags marked as "\*" are optional. There is a choice between Histogram
 > instrumentation package. This label is informational and transparent to
 > most PromQL queries.
 
+## Resolver Metrics
+
+The remote resolver pod exposes resolver framework metrics on port `9090` when
+`metrics-protocol` is `prometheus`.
+
+| Name | Type | Labels/Tags | Status |
+|---|---|---|---|
+| `tekton_pipelines_resolver_resolution_duration_seconds_[bucket, sum, count]` | Histogram | `resolver_type`=&lt;resolver&gt; <br> `status`=&lt;success\|error\|timeout\|invalid_request&gt; <br> `resource_kind`=&lt;Task\|Pipeline\|StepAction\|unknown&gt; | experimental |
+| `tekton_pipelines_resolver_resolution_total` | Counter | `resolver_type`=&lt;resolver&gt; <br> `status`=&lt;success\|error\|timeout\|invalid_request&gt; <br> `resource_kind`=&lt;Task\|Pipeline\|StepAction\|unknown&gt; | experimental |
+| `tekton_pipelines_resolver_cache_hit_total` | Counter | `resolver_type`=&lt;resolver&gt; | experimental |
+| `tekton_pipelines_resolver_cache_miss_total` | Counter | `resolver_type`=&lt;resolver&gt; | experimental |
+| `tekton_pipelines_resolver_singleflight_dedup_total` | Counter | `resolver_type`=&lt;resolver&gt; | experimental |
+
 ## Infrastructure Metrics
 
 These metrics are provided by the Knative and Go runtime infrastructure.

--- a/pkg/remoteresolution/resolver/framework/cache/cache.go
+++ b/pkg/remoteresolution/resolver/framework/cache/cache.go
@@ -117,7 +117,9 @@ func (c *resolverCache) GetCachedOrResolveFromRemote(
 	if c.metrics != nil {
 		c.metrics.RecordCacheMiss(ctx, resolverType)
 	}
+	called := false
 	untyped, err, shared := c.flightGroup.Do(key, func() (any, error) {
+		called = true
 		resolved, err := resolveFromRemote()
 		if err != nil {
 			return nil, err
@@ -140,7 +142,7 @@ func (c *resolverCache) GetCachedOrResolveFromRemote(
 		return nil, err
 	}
 
-	if shared {
+	if shared && !called {
 		c.infow("Resolution deduplicated by singleflight", "resolverType", resolverType, "key", key)
 		if c.metrics != nil {
 			c.metrics.RecordSingleflightDedup(ctx, resolverType)

--- a/pkg/remoteresolution/resolver/framework/cache/cache.go
+++ b/pkg/remoteresolution/resolver/framework/cache/cache.go
@@ -27,6 +27,7 @@ import (
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"github.com/tektoncd/pipeline/pkg/resolvermetrics"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 	utilcache "k8s.io/apimachinery/pkg/util/cache"
@@ -45,6 +46,7 @@ type resolverCache struct {
 	maxSize     int
 	clock       utilcache.Clock
 	flightGroup *singleflight.Group
+	metrics     *resolvermetrics.Recorder
 }
 
 func newResolverCache(maxSize int, ttl time.Duration) *resolverCache {
@@ -69,7 +71,12 @@ func (c *resolverCache) GetConfigName(_ context.Context) string {
 // withLogger returns a new ResolverCache instance with the provided logger.
 // This prevents state leak by not storing logger in the global singleton.
 func (c *resolverCache) withLogger(logger *zap.SugaredLogger) *resolverCache {
-	return &resolverCache{logger: logger, cache: c.cache, ttl: c.ttl, maxSize: c.maxSize, clock: c.clock, flightGroup: c.flightGroup}
+	return &resolverCache{logger: logger, cache: c.cache, ttl: c.ttl, maxSize: c.maxSize, clock: c.clock, flightGroup: c.flightGroup, metrics: c.metrics}
+}
+
+// SetMetrics sets the metrics recorder on the cache.
+func (c *resolverCache) SetMetrics(m *resolvermetrics.Recorder) {
+	c.metrics = m
 }
 
 // TTL returns the time-to-live duration for cache entries.
@@ -99,11 +106,17 @@ func (c *resolverCache) GetCachedOrResolveFromRemote(
 		}
 
 		c.infow("Cache hit", "key", key)
+		if c.metrics != nil {
+			c.metrics.RecordCacheHit(ctx, resolverType)
+		}
 
 		return c.annotate(cached, resolverType, cacheOperationRetrieve), nil
 	}
 
 	// If cache miss, resolve from remote using singleflight
+	if c.metrics != nil {
+		c.metrics.RecordCacheMiss(ctx, resolverType)
+	}
 	untyped, err, shared := c.flightGroup.Do(key, func() (any, error) {
 		resolved, err := resolveFromRemote()
 		if err != nil {
@@ -129,6 +142,9 @@ func (c *resolverCache) GetCachedOrResolveFromRemote(
 
 	if shared {
 		c.infow("Resolution deduplicated by singleflight", "resolverType", resolverType, "key", key)
+		if c.metrics != nil {
+			c.metrics.RecordSingleflightDedup(ctx, resolverType)
+		}
 	}
 
 	return untyped.(resolutionframework.ResolvedResource), nil

--- a/pkg/remoteresolution/resolver/framework/cache/cache_test.go
+++ b/pkg/remoteresolution/resolver/framework/cache/cache_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -24,6 +25,10 @@ import (
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	bundleresolution "github.com/tektoncd/pipeline/pkg/resolution/resolver/bundle"
 	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"github.com/tektoncd/pipeline/pkg/resolvermetrics"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.uber.org/zap/zaptest"
 	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
 )
@@ -510,4 +515,95 @@ func TestGetCachedOrResolveFromRemote(t *testing.T) {
 			t.Fatalf("expected fresh resolution to succeed, got error: %v", thirdAttemptErr)
 		}
 	})
+}
+
+func TestCacheMetrics_HitAndMiss(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	oldProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	defer func() {
+		otel.SetMeterProvider(oldProvider)
+		_ = provider.Shutdown(context.Background())
+	}()
+
+	rec, err := resolvermetrics.NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+
+	cache := newResolverCache(100, 1*time.Hour)
+	cache.SetMetrics(rec)
+	cache.logger = zaptest.NewLogger(t).Sugar()
+	defer cache.Clear()
+
+	params := []pipelinev1.Param{{
+		Name:  bundleresolution.ParamBundle,
+		Value: pipelinev1.ParamValue{StringVal: "registry.io/repo@sha256:abcdef"},
+	}}
+	resolveFn := func() (resolutionframework.ResolvedResource, error) {
+		return &mockResolvedResource{data: []byte("test data")}, nil
+	}
+
+	// First call: cache miss
+	if _, err := cache.GetCachedOrResolveFromRemote(t.Context(), params, "bundles", resolveFn); err != nil {
+		t.Fatalf("first resolve error: %v", err)
+	}
+	// Second call: cache hit
+	if _, err := cache.GetCachedOrResolveFromRemote(t.Context(), params, "bundles", resolveFn); err != nil {
+		t.Fatalf("second resolve error: %v", err)
+	}
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect error: %v", err)
+	}
+
+	foundHit := false
+	foundMiss := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "tekton_pipelines_resolver_cache_hit_total" {
+				foundHit = true
+				sum := m.Data.(metricdata.Sum[int64])
+				if len(sum.DataPoints) == 0 || sum.DataPoints[0].Value != 1 {
+					t.Errorf("expected 1 cache hit, got %d", sum.DataPoints[0].Value)
+				}
+			}
+			if m.Name == "tekton_pipelines_resolver_cache_miss_total" {
+				foundMiss = true
+				sum := m.Data.(metricdata.Sum[int64])
+				if len(sum.DataPoints) == 0 || sum.DataPoints[0].Value != 1 {
+					t.Errorf("expected 1 cache miss, got %d", sum.DataPoints[0].Value)
+				}
+			}
+		}
+	}
+	if !foundHit {
+		t.Error("cache_hit_total metric not found")
+	}
+	if !foundMiss {
+		t.Error("cache_miss_total metric not found")
+	}
+}
+
+func TestCacheMetrics_NilRecorder(t *testing.T) {
+	cache := newResolverCache(100, 1*time.Hour)
+	defer cache.Clear()
+
+	params := []pipelinev1.Param{{
+		Name:  bundleresolution.ParamBundle,
+		Value: pipelinev1.ParamValue{StringVal: "registry.io/repo@sha256:abc"},
+	}}
+	resolveFn := func() (resolutionframework.ResolvedResource, error) {
+		return &mockResolvedResource{data: []byte("data")}, nil
+	}
+
+	// Should not panic with nil metrics
+	if _, err := cache.GetCachedOrResolveFromRemote(t.Context(), params, "bundles", resolveFn); err != nil {
+		t.Fatalf("resolve error with nil metrics: %v", err)
+	}
+	if _, err := cache.GetCachedOrResolveFromRemote(t.Context(), params, "bundles", resolveFn); err != nil {
+		t.Fatalf("cached resolve error with nil metrics: %v", err)
+	}
 }

--- a/pkg/remoteresolution/resolver/framework/cache/cache_test.go
+++ b/pkg/remoteresolution/resolver/framework/cache/cache_test.go
@@ -19,6 +19,8 @@ package cache
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -585,6 +587,96 @@ func TestCacheMetrics_HitAndMiss(t *testing.T) {
 	if !foundMiss {
 		t.Error("cache_miss_total metric not found")
 	}
+}
+
+func TestCacheMetrics_SingleflightDedupCountsOnlyWaiters(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	oldProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	defer func() {
+		otel.SetMeterProvider(oldProvider)
+		_ = provider.Shutdown(context.Background())
+	}()
+
+	rec, err := resolvermetrics.NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+
+	cache := newResolverCache(100, 1*time.Hour)
+	cache.SetMetrics(rec)
+	cache.logger = zaptest.NewLogger(t).Sugar()
+	defer cache.Clear()
+
+	params := []pipelinev1.Param{{
+		Name:  bundleresolution.ParamBundle,
+		Value: pipelinev1.ParamValue{StringVal: "registry.io/repo@sha256:dedup"},
+	}}
+
+	const callers = 5
+	ready := make(chan struct{}, callers)
+	start := make(chan struct{})
+	resolveStarted := make(chan struct{})
+	release := make(chan struct{})
+	errs := make(chan error, callers)
+	var calls atomic.Int32
+	resolveFn := func() (resolutionframework.ResolvedResource, error) {
+		if calls.Add(1) == 1 {
+			close(resolveStarted)
+		}
+		<-release
+		return &mockResolvedResource{data: []byte("data")}, nil
+	}
+
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ready <- struct{}{}
+			<-start
+			_, err := cache.GetCachedOrResolveFromRemote(t.Context(), params, "bundles", resolveFn)
+			errs <- err
+		}()
+	}
+	for range callers {
+		<-ready
+	}
+	close(start)
+	<-resolveStarted
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("cached resolve error: %v", err)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("expected one remote resolution, got %d", calls.Load())
+	}
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect error: %v", err)
+	}
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "tekton_pipelines_resolver_singleflight_dedup_total" {
+				continue
+			}
+			sum := m.Data.(metricdata.Sum[int64])
+			if len(sum.DataPoints) == 0 || sum.DataPoints[0].Value != callers-1 {
+				t.Fatalf("expected %d deduplicated callers, got %d", callers-1, sum.DataPoints[0].Value)
+			}
+			return
+		}
+	}
+	t.Fatal("singleflight_dedup_total metric not found")
 }
 
 func TestCacheMetrics_NilRecorder(t *testing.T) {

--- a/pkg/remoteresolution/resolver/framework/cache/setup.go
+++ b/pkg/remoteresolution/resolver/framework/cache/setup.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/tektoncd/pipeline/pkg/resolvermetrics"
 	"k8s.io/client-go/rest"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
@@ -37,7 +38,11 @@ func init() {
 }
 
 func addCacheWithLoggerToCtx(ctx context.Context, _ *rest.Config) context.Context {
-	return context.WithValue(ctx, resolverCacheKey{}, createCacheOnce(ctx))
+	c := createCacheOnce(ctx)
+	if m := resolvermetrics.Get(ctx); m != nil {
+		c.SetMetrics(m)
+	}
+	return context.WithValue(ctx, resolverCacheKey{}, c)
 }
 
 func createCacheOnce(ctx context.Context) *resolverCache {

--- a/pkg/remoteresolution/resolver/framework/controller.go
+++ b/pkg/remoteresolution/resolver/framework/controller.go
@@ -24,6 +24,7 @@ import (
 	rrinformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	rrcache "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
 	framework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"github.com/tektoncd/pipeline/pkg/resolvermetrics"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/clock"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -60,6 +61,7 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 			resolutionRequestLister:    rrInformer.Lister(),
 			resolutionRequestClientSet: rrclientset,
 			resolver:                   resolver,
+			metrics:                    resolvermetrics.Get(ctx),
 		}
 
 		watchConfigChanges(ctx, r, cmw)

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
+	"sigs.k8s.io/yaml"
 )
 
 // defaultMaximumResolutionDuration is the maximum amount of time
@@ -124,9 +125,10 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	startTime := r.Clock.Now()
 	resolverType := rr.Labels[resolutioncommon.LabelKeyResolverType]
 	metricsStatus := resolvermetrics.StatusError
+	resourceKind := resolvermetrics.ResourceKindUnknown
 	defer func() {
 		if r.metrics != nil && metricsStatus != "" {
-			r.metrics.RecordResolution(ctx, resolverType, metricsStatus, r.Clock.Now().Sub(startTime))
+			r.metrics.RecordResolution(ctx, resolverType, metricsStatus, resourceKind, r.Clock.Now().Sub(startTime))
 		}
 	}()
 
@@ -210,6 +212,7 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 		}
 	case resource := <-resourceChan:
 		metricsStatus = resolvermetrics.StatusSuccess
+		resourceKind = resolvedResourceKind(resource)
 		return r.writeResolvedData(ctx, rr, resource)
 	}
 
@@ -287,4 +290,14 @@ func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.Resoluti
 func isInvalidRequestError(err error) bool {
 	var invalidErr *resolutioncommon.InvalidRequestError
 	return errors.As(err, &invalidErr)
+}
+
+func resolvedResourceKind(resource framework.ResolvedResource) string {
+	var metadata struct {
+		Kind string
+	}
+	if err := yaml.Unmarshal(resource.Data(), &metadata); err != nil || metadata.Kind == "" {
+		return resolvermetrics.ResourceKindUnknown
+	}
+	return metadata.Kind
 }

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -32,6 +32,7 @@ import (
 	rrcache "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"github.com/tektoncd/pipeline/pkg/resolvermetrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -77,6 +78,7 @@ type Reconciler struct {
 	resolutionRequestClientSet rrclient.Interface
 
 	configStore *framework.ConfigStore
+	metrics     *resolvermetrics.Recorder
 }
 
 var _ reconciler.LeaderAware = &Reconciler{}
@@ -119,6 +121,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 }
 
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
+	startTime := r.Clock.Now()
+	resolverType := rr.Labels[resolutioncommon.LabelKeyResolverType]
+	metricsStatus := resolvermetrics.StatusError
+	defer func() {
+		if r.metrics != nil && metricsStatus != "" {
+			r.metrics.RecordResolution(ctx, resolverType, metricsStatus, r.Clock.Now().Sub(startTime))
+		}
+	}()
+
 	errChan := make(chan error, 1)
 	resourceChan := make(chan framework.ResolvedResource, 1)
 
@@ -184,13 +195,21 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	select {
 	case err := <-errChan:
 		if err != nil {
+			switch {
+			case resolutioncommon.IsErrTransient(err):
+				metricsStatus = ""
+			case isInvalidRequestError(err):
+				metricsStatus = resolvermetrics.StatusInvalidRequest
+			}
 			return r.OnError(ctx, rr, err)
 		}
 	case <-resolutionCtx.Done():
 		if err := resolutionCtx.Err(); err != nil {
+			metricsStatus = resolvermetrics.StatusTimeout
 			return r.OnError(ctx, rr, err)
 		}
 	case resource := <-resourceChan:
+		metricsStatus = resolvermetrics.StatusSuccess
 		return r.writeResolvedData(ctx, rr, resource)
 	}
 
@@ -263,4 +282,9 @@ func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.Resoluti
 	}
 
 	return nil
+}
+
+func isInvalidRequestError(err error) bool {
+	var invalidErr *resolutioncommon.InvalidRequestError
+	return errors.As(err, &invalidErr)
 }

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -143,6 +143,7 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	// Centralized cache parameter validation for all resolvers
 	if cacheMode, exists := paramsMap[rrcache.CacheParam]; exists && cacheMode != "" {
 		if err := rrcache.Validate(cacheMode); err != nil {
+			metricsStatus = resolvermetrics.StatusInvalidRequest
 			return &resolutioncommon.InvalidRequestError{
 				ResolutionRequestKey: key,
 				Message:              err.Error(),
@@ -155,6 +156,7 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 		var err error
 		timeoutDuration, err = timed.GetResolutionTimeout(ctx, defaultMaximumResolutionDuration, paramsMap)
 		if err != nil {
+			metricsStatus = resolutionMetricStatus(err)
 			return err
 		}
 	}
@@ -197,17 +199,12 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	select {
 	case err := <-errChan:
 		if err != nil {
-			switch {
-			case resolutioncommon.IsErrTransient(err):
-				metricsStatus = ""
-			case isInvalidRequestError(err):
-				metricsStatus = resolvermetrics.StatusInvalidRequest
-			}
+			metricsStatus = resolutionMetricStatus(err)
 			return r.OnError(ctx, rr, err)
 		}
 	case <-resolutionCtx.Done():
 		if err := resolutionCtx.Err(); err != nil {
-			metricsStatus = resolvermetrics.StatusTimeout
+			metricsStatus = resolutionMetricStatus(err)
 			return r.OnError(ctx, rr, err)
 		}
 	case resource := <-resourceChan:
@@ -287,6 +284,21 @@ func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.Resoluti
 	return nil
 }
 
+func resolutionMetricStatus(err error) string {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return resolvermetrics.StatusTimeout
+	case errors.Is(err, context.Canceled):
+		return ""
+	case isInvalidRequestError(err):
+		return resolvermetrics.StatusInvalidRequest
+	case resolutioncommon.IsErrTransient(err):
+		return ""
+	default:
+		return resolvermetrics.StatusError
+	}
+}
+
 func isInvalidRequestError(err error) bool {
 	var invalidErr *resolutioncommon.InvalidRequestError
 	return errors.As(err, &invalidErr)
@@ -296,8 +308,13 @@ func resolvedResourceKind(resource framework.ResolvedResource) string {
 	var metadata struct {
 		Kind string
 	}
-	if err := yaml.Unmarshal(resource.Data(), &metadata); err != nil || metadata.Kind == "" {
+	if err := yaml.Unmarshal(resource.Data(), &metadata); err != nil {
 		return resolvermetrics.ResourceKindUnknown
 	}
-	return metadata.Kind
+	switch metadata.Kind {
+	case "Task", "Pipeline", "StepAction":
+		return metadata.Kind
+	default:
+		return resolvermetrics.ResourceKindUnknown
+	}
 }

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -214,9 +214,13 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 			return r.OnError(ctx, rr, err)
 		}
 	case resource := <-resourceChan:
-		metricsStatus = resolvermetrics.StatusSuccess
 		resourceKind = resolvedResourceKind(resource)
-		return r.writeResolvedData(ctx, rr, resource)
+		if err := r.writeResolvedData(ctx, rr, resource); err != nil {
+			metricsStatus = resolutionMetricStatus(err)
+			return err
+		}
+		metricsStatus = resolvermetrics.StatusSuccess
+		return nil
 	}
 
 	return errors.New("unknown error")
@@ -299,7 +303,7 @@ func resolutionMetricStatus(err error) string {
 	case isInvalidRequestError(err):
 		return resolvermetrics.StatusInvalidRequest
 	case resolutioncommon.IsErrTransient(err):
-		return ""
+		return resolvermetrics.StatusError
 	default:
 		return resolvermetrics.StatusError
 	}

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -149,6 +149,7 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	// Centralized cache parameter validation for all resolvers
 	if cacheMode, exists := paramsMap[rrcache.CacheParam]; exists && cacheMode != "" {
 		if err := rrcache.Validate(cacheMode); err != nil {
+			metricsStatus = resolvermetrics.StatusInvalidRequest
 			return &resolutioncommon.InvalidRequestError{
 				ResolutionRequestKey: key,
 				Message:              err.Error(),
@@ -161,6 +162,7 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 		var err error
 		timeoutDuration, err = timed.GetResolutionTimeout(ctx, defaultMaximumResolutionDuration, paramsMap)
 		if err != nil {
+			metricsStatus = resolutionMetricStatus(err)
 			return err
 		}
 	}
@@ -203,17 +205,12 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	select {
 	case err := <-errChan:
 		if err != nil {
-			switch {
-			case resolutioncommon.IsErrTransient(err):
-				metricsStatus = ""
-			case isInvalidRequestError(err):
-				metricsStatus = resolvermetrics.StatusInvalidRequest
-			}
+			metricsStatus = resolutionMetricStatus(err)
 			return r.OnError(ctx, rr, err)
 		}
 	case <-resolutionCtx.Done():
 		if err := resolutionCtx.Err(); err != nil {
-			metricsStatus = resolvermetrics.StatusTimeout
+			metricsStatus = resolutionMetricStatus(err)
 			return r.OnError(ctx, rr, err)
 		}
 	case resource := <-resourceChan:
@@ -293,6 +290,21 @@ func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.Resoluti
 	return nil
 }
 
+func resolutionMetricStatus(err error) string {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return resolvermetrics.StatusTimeout
+	case errors.Is(err, context.Canceled):
+		return ""
+	case isInvalidRequestError(err):
+		return resolvermetrics.StatusInvalidRequest
+	case resolutioncommon.IsErrTransient(err):
+		return ""
+	default:
+		return resolvermetrics.StatusError
+	}
+}
+
 func isInvalidRequestError(err error) bool {
 	var invalidErr *resolutioncommon.InvalidRequestError
 	return errors.As(err, &invalidErr)
@@ -302,8 +314,13 @@ func resolvedResourceKind(resource framework.ResolvedResource) string {
 	var metadata struct {
 		Kind string
 	}
-	if err := yaml.Unmarshal(resource.Data(), &metadata); err != nil || metadata.Kind == "" {
+	if err := yaml.Unmarshal(resource.Data(), &metadata); err != nil {
 		return resolvermetrics.ResourceKindUnknown
 	}
-	return metadata.Kind
+	switch metadata.Kind {
+	case "Task", "Pipeline", "StepAction":
+		return metadata.Kind
+	default:
+		return resolvermetrics.ResourceKindUnknown
+	}
 }

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -32,6 +32,7 @@ import (
 	rrcache "github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/framework/cache"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"github.com/tektoncd/pipeline/pkg/resolvermetrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -77,6 +78,7 @@ type Reconciler struct {
 	resolutionRequestClientSet rrclient.Interface
 
 	configStore *framework.ConfigStore
+	metrics     *resolvermetrics.Recorder
 }
 
 var _ reconciler.LeaderAware = &Reconciler{}
@@ -125,6 +127,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 }
 
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
+	startTime := r.Clock.Now()
+	resolverType := rr.Labels[resolutioncommon.LabelKeyResolverType]
+	metricsStatus := resolvermetrics.StatusError
+	defer func() {
+		if r.metrics != nil && metricsStatus != "" {
+			r.metrics.RecordResolution(ctx, resolverType, metricsStatus, r.Clock.Now().Sub(startTime))
+		}
+	}()
+
 	errChan := make(chan error, 1)
 	resourceChan := make(chan framework.ResolvedResource, 1)
 
@@ -190,13 +201,21 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	select {
 	case err := <-errChan:
 		if err != nil {
+			switch {
+			case resolutioncommon.IsErrTransient(err):
+				metricsStatus = ""
+			case isInvalidRequestError(err):
+				metricsStatus = resolvermetrics.StatusInvalidRequest
+			}
 			return r.OnError(ctx, rr, err)
 		}
 	case <-resolutionCtx.Done():
 		if err := resolutionCtx.Err(); err != nil {
+			metricsStatus = resolvermetrics.StatusTimeout
 			return r.OnError(ctx, rr, err)
 		}
 	case resource := <-resourceChan:
+		metricsStatus = resolvermetrics.StatusSuccess
 		return r.writeResolvedData(ctx, rr, resource)
 	}
 
@@ -269,4 +288,9 @@ func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.Resoluti
 	}
 
 	return nil
+}
+
+func isInvalidRequestError(err error) bool {
+	var invalidErr *resolutioncommon.InvalidRequestError
+	return errors.As(err, &invalidErr)
 }

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
+	"sigs.k8s.io/yaml"
 )
 
 // defaultMaximumResolutionDuration is the maximum amount of time
@@ -130,9 +131,10 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	startTime := r.Clock.Now()
 	resolverType := rr.Labels[resolutioncommon.LabelKeyResolverType]
 	metricsStatus := resolvermetrics.StatusError
+	resourceKind := resolvermetrics.ResourceKindUnknown
 	defer func() {
 		if r.metrics != nil && metricsStatus != "" {
-			r.metrics.RecordResolution(ctx, resolverType, metricsStatus, r.Clock.Now().Sub(startTime))
+			r.metrics.RecordResolution(ctx, resolverType, metricsStatus, resourceKind, r.Clock.Now().Sub(startTime))
 		}
 	}()
 
@@ -216,6 +218,7 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 		}
 	case resource := <-resourceChan:
 		metricsStatus = resolvermetrics.StatusSuccess
+		resourceKind = resolvedResourceKind(resource)
 		return r.writeResolvedData(ctx, rr, resource)
 	}
 
@@ -293,4 +296,14 @@ func (r *Reconciler) writeResolvedData(ctx context.Context, rr *v1beta1.Resoluti
 func isInvalidRequestError(err error) bool {
 	var invalidErr *resolutioncommon.InvalidRequestError
 	return errors.As(err, &invalidErr)
+}
+
+func resolvedResourceKind(resource framework.ResolvedResource) string {
+	var metadata struct {
+		Kind string
+	}
+	if err := yaml.Unmarshal(resource.Data(), &metadata); err != nil || metadata.Kind == "" {
+		return resolvermetrics.ResourceKindUnknown
+	}
+	return metadata.Kind
 }

--- a/pkg/remoteresolution/resolver/framework/reconciler_internal_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_internal_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
+	"github.com/tektoncd/pipeline/pkg/resolvermetrics"
+)
+
+type testResolvedResource struct {
+	data []byte
+}
+
+func (r testResolvedResource) Data() []byte                     { return r.data }
+func (r testResolvedResource) Annotations() map[string]string   { return nil }
+func (r testResolvedResource) RefSource() *pipelinev1.RefSource { return nil }
+
+func TestResolutionMetricStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "deadline", err: context.DeadlineExceeded, want: resolvermetrics.StatusTimeout},
+		{name: "wrapped deadline", err: fmt.Errorf("resolver: %w", context.DeadlineExceeded), want: resolvermetrics.StatusTimeout},
+		{name: "canceled", err: context.Canceled, want: ""},
+		{name: "invalid request", err: &resolutioncommon.InvalidRequestError{ResolutionRequestKey: "ns/name", Message: "bad param"}, want: resolvermetrics.StatusInvalidRequest},
+		{name: "transient", err: errors.New("etcdserver: leader changed"), want: ""},
+		{name: "generic", err: errors.New("boom"), want: resolvermetrics.StatusError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolutionMetricStatus(tt.err); got != tt.want {
+				t.Fatalf("resolutionMetricStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvedResourceKind(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{name: "task", data: `apiVersion: tekton.dev/v1
+kind: Task`, want: "Task"},
+		{name: "pipeline", data: `apiVersion: tekton.dev/v1
+kind: Pipeline`, want: "Pipeline"},
+		{name: "step action", data: `apiVersion: tekton.dev/v1beta1
+kind: StepAction`, want: "StepAction"},
+		{name: "unsupported kind", data: `apiVersion: v1
+kind: Pod`, want: resolvermetrics.ResourceKindUnknown},
+		{name: "missing kind", data: `apiVersion: tekton.dev/v1`, want: resolvermetrics.ResourceKindUnknown},
+		{name: "bad yaml", data: `kind: [`, want: resolvermetrics.ResourceKindUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := testResolvedResource{data: []byte(tt.data)}
+			if got := resolvedResourceKind(resource); got != tt.want {
+				t.Fatalf("resolvedResourceKind() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/remoteresolution/resolver/framework/reconciler_internal_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_internal_test.go
@@ -21,10 +21,21 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
+	rrfake "github.com/tektoncd/pipeline/pkg/client/resolution/clientset/versioned/fake"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
+	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 	"github.com/tektoncd/pipeline/pkg/resolvermetrics"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+	clock "k8s.io/utils/clock/testing"
 )
 
 type testResolvedResource struct {
@@ -45,7 +56,7 @@ func TestResolutionMetricStatus(t *testing.T) {
 		{name: "wrapped deadline", err: fmt.Errorf("resolver: %w", context.DeadlineExceeded), want: resolvermetrics.StatusTimeout},
 		{name: "canceled", err: context.Canceled, want: ""},
 		{name: "invalid request", err: &resolutioncommon.InvalidRequestError{ResolutionRequestKey: "ns/name", Message: "bad param"}, want: resolvermetrics.StatusInvalidRequest},
-		{name: "transient", err: errors.New("etcdserver: leader changed"), want: ""},
+		{name: "transient", err: errors.New("etcdserver: leader changed"), want: resolvermetrics.StatusError},
 		{name: "generic", err: errors.New("boom"), want: resolvermetrics.StatusError},
 	}
 
@@ -56,6 +67,73 @@ func TestResolutionMetricStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveRecordsWriteFailureAsError(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	oldProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	defer func() {
+		otel.SetMeterProvider(oldProvider)
+		_ = provider.Shutdown(context.Background())
+	}()
+
+	recorder, err := resolvermetrics.NewRecorder()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := &v1beta1.ResolutionRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "request",
+			Namespace: "test",
+			Labels: map[string]string{
+				resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+			},
+		},
+		Spec: v1beta1.ResolutionRequestSpec{Params: []pipelinev1.Param{{
+			Name:  resolutionframework.FakeParamName,
+			Value: *pipelinev1.NewStructuredValues("resource"),
+		}}},
+	}
+	client := rrfake.NewSimpleClientset(rr)
+	client.PrependReactor("patch", "resolutionrequests", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("patch failed")
+	})
+	r := &Reconciler{
+		Clock: clock.NewFakePassiveClock(time.Unix(0, 0)),
+		resolver: &FakeResolver{ForParam: map[string]*resolutionframework.FakeResolvedResource{
+			"resource": {Content: `apiVersion: tekton.dev/v1
+kind: Pipeline`},
+		}},
+		resolutionRequestClientSet: client,
+		metrics:                    recorder,
+	}
+
+	if err := r.resolve(context.Background(), "test/request", rr); err == nil {
+		t.Fatal("resolve() succeeded, want patch error")
+	}
+	var metrics metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &metrics); err != nil {
+		t.Fatal(err)
+	}
+	for _, scope := range metrics.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != "tekton_pipelines_resolver_resolution_total" {
+				continue
+			}
+			sum := metric.Data.(metricdata.Sum[int64])
+			if len(sum.DataPoints) != 1 {
+				t.Fatalf("resolution metric has %d data points, want 1", len(sum.DataPoints))
+			}
+			status, _ := sum.DataPoints[0].Attributes.Value("status")
+			if got := status.AsString(); got != resolvermetrics.StatusError {
+				t.Fatalf("resolution status = %q, want %q", got, resolvermetrics.StatusError)
+			}
+			return
+		}
+	}
+	t.Fatal("resolution metric not found")
 }
 
 func TestResolvedResourceKind(t *testing.T) {

--- a/pkg/resolvermetrics/injection.go
+++ b/pkg/resolvermetrics/injection.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolvermetrics
+
+import (
+	"context"
+
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/logging"
+)
+
+// RecorderKey is used for associating the Recorder inside the context.Context.
+type RecorderKey struct{}
+
+func init() {
+	injection.Default.RegisterClient(func(ctx context.Context, _ *rest.Config) context.Context { return WithClient(ctx) })
+}
+
+// WithClient creates a new metrics recorder and adds it to the context.
+func WithClient(ctx context.Context) context.Context {
+	rec, err := NewRecorder()
+	if err != nil {
+		logging.FromContext(ctx).Errorf("Failed to create resolver metrics recorder: %v", err)
+	}
+	return context.WithValue(ctx, RecorderKey{}, rec)
+}
+
+// Get extracts the resolver metrics Recorder from the context.
+func Get(ctx context.Context) *Recorder {
+	untyped := ctx.Value(RecorderKey{})
+	if untyped == nil {
+		logging.FromContext(ctx).Warn("Unable to fetch *resolvermetrics.Recorder from context, metrics will be disabled")
+		return nil
+	}
+	return untyped.(*Recorder)
+}

--- a/pkg/resolvermetrics/injection.go
+++ b/pkg/resolvermetrics/injection.go
@@ -47,5 +47,10 @@ func Get(ctx context.Context) *Recorder {
 		logging.FromContext(ctx).Warn("Unable to fetch *resolvermetrics.Recorder from context, metrics will be disabled")
 		return nil
 	}
-	return untyped.(*Recorder)
+	rec, ok := untyped.(*Recorder)
+	if !ok {
+		logging.FromContext(ctx).Warnf("Expected *resolvermetrics.Recorder in context, got %T; metrics will be disabled", untyped)
+		return nil
+	}
+	return rec
 }

--- a/pkg/resolvermetrics/injection_test.go
+++ b/pkg/resolvermetrics/injection_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolvermetrics
+
+import (
+	"context"
+	"testing"
+
+	_ "knative.dev/pkg/system/testing"
+)
+
+func TestWithClientStoresRecorder(t *testing.T) {
+	_, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	ctx := WithClient(context.Background())
+	rec := ctx.Value(RecorderKey{})
+	if rec == nil {
+		t.Fatal("WithClient did not store recorder in context")
+	}
+	if _, ok := rec.(*Recorder); !ok {
+		t.Fatalf("expected *Recorder, got %T", rec)
+	}
+}
+
+func TestGetReturnsRecorder(t *testing.T) {
+	_, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	ctx := WithClient(context.Background())
+	rec := Get(ctx)
+	if rec == nil {
+		t.Fatal("Get returned nil")
+	}
+	if !rec.initialized {
+		t.Fatal("Get returned uninitialized recorder")
+	}
+}
+
+func TestGetReturnsNilForMissingContext(t *testing.T) {
+	rec := Get(context.Background())
+	if rec != nil {
+		t.Fatal("expected nil for missing context, got non-nil")
+	}
+}

--- a/pkg/resolvermetrics/injection_test.go
+++ b/pkg/resolvermetrics/injection_test.go
@@ -57,3 +57,11 @@ func TestGetReturnsNilForMissingContext(t *testing.T) {
 		t.Fatal("expected nil for missing context, got non-nil")
 	}
 }
+
+func TestGetReturnsNilForWrongContextType(t *testing.T) {
+	ctx := context.WithValue(context.Background(), RecorderKey{}, "not a recorder")
+	rec := Get(ctx)
+	if rec != nil {
+		t.Fatal("expected nil for wrong context type, got non-nil")
+	}
+}

--- a/pkg/resolvermetrics/metrics.go
+++ b/pkg/resolvermetrics/metrics.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolvermetrics
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	meterName = "tekton_pipelines_resolver"
+
+	StatusSuccess        = "success"
+	StatusError          = "error"
+	StatusTimeout        = "timeout"
+	StatusInvalidRequest = "invalid_request"
+)
+
+var (
+	resolverTypeKey = attribute.Key("resolver_type")
+	statusKey       = attribute.Key("status")
+)
+
+// Recorder holds OpenTelemetry instruments for resolver metrics.
+type Recorder struct {
+	initialized bool
+	meter       metric.Meter
+
+	resolutionDuration     metric.Float64Histogram
+	resolutionTotal        metric.Int64Counter
+	cacheHitTotal          metric.Int64Counter
+	cacheMissTotal         metric.Int64Counter
+	singleflightDedupTotal metric.Int64Counter
+}
+
+// NewRecorder creates a new metrics Recorder for the resolver framework.
+func NewRecorder() (*Recorder, error) {
+	r := &Recorder{
+		meter: otel.GetMeterProvider().Meter(meterName),
+	}
+
+	duration, err := r.meter.Float64Histogram(
+		"tekton_pipelines_resolver_resolution_duration_seconds",
+		metric.WithDescription("Duration of resolution requests in seconds."),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resolution duration histogram: %w", err)
+	}
+	r.resolutionDuration = duration
+
+	total, err := r.meter.Int64Counter(
+		"tekton_pipelines_resolver_resolution_total",
+		metric.WithDescription("Total number of resolution requests."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resolution total counter: %w", err)
+	}
+	r.resolutionTotal = total
+
+	cacheHit, err := r.meter.Int64Counter(
+		"tekton_pipelines_resolver_cache_hit_total",
+		metric.WithDescription("Total number of resolver cache hits."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cache hit counter: %w", err)
+	}
+	r.cacheHitTotal = cacheHit
+
+	cacheMiss, err := r.meter.Int64Counter(
+		"tekton_pipelines_resolver_cache_miss_total",
+		metric.WithDescription("Total number of resolver cache misses."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cache miss counter: %w", err)
+	}
+	r.cacheMissTotal = cacheMiss
+
+	singleflightDedup, err := r.meter.Int64Counter(
+		"tekton_pipelines_resolver_singleflight_dedup_total",
+		metric.WithDescription("Total number of resolution requests deduplicated by singleflight."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create singleflight dedup counter: %w", err)
+	}
+	r.singleflightDedupTotal = singleflightDedup
+
+	r.initialized = true
+	return r, nil
+}
+
+// RecordResolution records the duration and count of a resolution request.
+func (r *Recorder) RecordResolution(ctx context.Context, resolverType, status string, duration time.Duration) {
+	if r == nil || !r.initialized {
+		return
+	}
+
+	attrs := metric.WithAttributes(
+		resolverTypeKey.String(resolverType),
+		statusKey.String(status),
+	)
+
+	r.resolutionDuration.Record(ctx, duration.Seconds(), attrs)
+	r.resolutionTotal.Add(ctx, 1, attrs)
+}
+
+// RecordCacheHit records a resolver cache hit.
+func (r *Recorder) RecordCacheHit(ctx context.Context, resolverType string) {
+	if r == nil || !r.initialized {
+		return
+	}
+
+	r.cacheHitTotal.Add(ctx, 1, metric.WithAttributes(
+		resolverTypeKey.String(resolverType),
+	))
+}
+
+// RecordCacheMiss records a resolver cache miss.
+func (r *Recorder) RecordCacheMiss(ctx context.Context, resolverType string) {
+	if r == nil || !r.initialized {
+		return
+	}
+
+	r.cacheMissTotal.Add(ctx, 1, metric.WithAttributes(
+		resolverTypeKey.String(resolverType),
+	))
+}
+
+// RecordSingleflightDedup records a singleflight deduplication event.
+func (r *Recorder) RecordSingleflightDedup(ctx context.Context, resolverType string) {
+	if r == nil || !r.initialized {
+		return
+	}
+
+	r.singleflightDedupTotal.Add(ctx, 1, metric.WithAttributes(
+		resolverTypeKey.String(resolverType),
+	))
+}

--- a/pkg/resolvermetrics/metrics.go
+++ b/pkg/resolvermetrics/metrics.go
@@ -33,11 +33,14 @@ const (
 	StatusError          = "error"
 	StatusTimeout        = "timeout"
 	StatusInvalidRequest = "invalid_request"
+
+	ResourceKindUnknown = "unknown"
 )
 
 var (
 	resolverTypeKey = attribute.Key("resolver_type")
 	statusKey       = attribute.Key("status")
+	resourceKindKey = attribute.Key("resource_kind")
 )
 
 // Recorder holds OpenTelemetry instruments for resolver metrics.
@@ -110,14 +113,18 @@ func NewRecorder() (*Recorder, error) {
 }
 
 // RecordResolution records the duration and count of a resolution request.
-func (r *Recorder) RecordResolution(ctx context.Context, resolverType, status string, duration time.Duration) {
+func (r *Recorder) RecordResolution(ctx context.Context, resolverType, status, resourceKind string, duration time.Duration) {
 	if r == nil || !r.initialized {
 		return
+	}
+	if resourceKind == "" {
+		resourceKind = ResourceKindUnknown
 	}
 
 	attrs := metric.WithAttributes(
 		resolverTypeKey.String(resolverType),
 		statusKey.String(status),
+		resourceKindKey.String(resourceKind),
 	)
 
 	r.resolutionDuration.Record(ctx, duration.Seconds(), attrs)

--- a/pkg/resolvermetrics/metrics_test.go
+++ b/pkg/resolvermetrics/metrics_test.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolvermetrics
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func setupTestMeter(t *testing.T) (*sdkmetric.ManualReader, func()) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	oldProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	return reader, func() {
+		otel.SetMeterProvider(oldProvider)
+		_ = provider.Shutdown(context.Background())
+	}
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect error: %v", err)
+	}
+	return rm
+}
+
+func findMetric(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	for _, sm := range rm.ScopeMetrics {
+		for i := range sm.Metrics {
+			if sm.Metrics[i].Name == name {
+				return &sm.Metrics[i]
+			}
+		}
+	}
+	return nil
+}
+
+func TestNewRecorder(t *testing.T) {
+	reader, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	rec, err := NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("NewRecorder() returned nil")
+	}
+	if !rec.initialized {
+		t.Fatal("Recorder not initialized")
+	}
+
+	rec.RecordResolution(context.Background(), "git", StatusSuccess, 100*time.Millisecond)
+	rm := collectMetrics(t, reader)
+
+	duration := findMetric(rm, "tekton_pipelines_resolver_resolution_duration_seconds")
+	if duration == nil {
+		t.Fatal("resolution_duration_seconds metric not found")
+	}
+	total := findMetric(rm, "tekton_pipelines_resolver_resolution_total")
+	if total == nil {
+		t.Fatal("resolution_total metric not found")
+	}
+}
+
+func TestRecordResolutionSuccess(t *testing.T) {
+	reader, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	rec, err := NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+
+	rec.RecordResolution(context.Background(), "git", StatusSuccess, 500*time.Millisecond)
+
+	rm := collectMetrics(t, reader)
+
+	total := findMetric(rm, "tekton_pipelines_resolver_resolution_total")
+	if total == nil {
+		t.Fatal("resolution_total not found")
+	}
+
+	sum, ok := total.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("expected Sum[int64], got %T", total.Data)
+	}
+	if len(sum.DataPoints) == 0 {
+		t.Fatal("no data points for resolution_total")
+	}
+	if sum.DataPoints[0].Value != 1 {
+		t.Errorf("expected total count 1, got %d", sum.DataPoints[0].Value)
+	}
+	assertAttribute(t, sum.DataPoints[0].Attributes, "resolver_type", "git")
+	assertAttribute(t, sum.DataPoints[0].Attributes, "status", "success")
+}
+
+func TestRecordResolutionError(t *testing.T) {
+	reader, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	rec, err := NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+
+	rec.RecordResolution(context.Background(), "hub", StatusError, 200*time.Millisecond)
+
+	rm := collectMetrics(t, reader)
+
+	total := findMetric(rm, "tekton_pipelines_resolver_resolution_total")
+	if total == nil {
+		t.Fatal("resolution_total not found")
+	}
+	sum := total.Data.(metricdata.Sum[int64])
+	assertAttribute(t, sum.DataPoints[0].Attributes, "resolver_type", "hub")
+	assertAttribute(t, sum.DataPoints[0].Attributes, "status", "error")
+}
+
+func TestRecordResolutionTimeout(t *testing.T) {
+	reader, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	rec, err := NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+
+	rec.RecordResolution(context.Background(), "bundles", StatusTimeout, 60*time.Second)
+
+	rm := collectMetrics(t, reader)
+
+	total := findMetric(rm, "tekton_pipelines_resolver_resolution_total")
+	if total == nil {
+		t.Fatal("resolution_total not found")
+	}
+	sum := total.Data.(metricdata.Sum[int64])
+	assertAttribute(t, sum.DataPoints[0].Attributes, "resolver_type", "bundles")
+	assertAttribute(t, sum.DataPoints[0].Attributes, "status", "timeout")
+}
+
+func TestRecordResolutionDuration(t *testing.T) {
+	reader, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	rec, err := NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+
+	rec.RecordResolution(context.Background(), "cluster", StatusSuccess, 250*time.Millisecond)
+
+	rm := collectMetrics(t, reader)
+
+	duration := findMetric(rm, "tekton_pipelines_resolver_resolution_duration_seconds")
+	if duration == nil {
+		t.Fatal("resolution_duration_seconds not found")
+	}
+	hist, ok := duration.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("expected Histogram[float64], got %T", duration.Data)
+	}
+	if len(hist.DataPoints) == 0 {
+		t.Fatal("no data points for duration histogram")
+	}
+	if hist.DataPoints[0].Count != 1 {
+		t.Errorf("expected histogram count 1, got %d", hist.DataPoints[0].Count)
+	}
+	if hist.DataPoints[0].Sum < 0.2 || hist.DataPoints[0].Sum > 0.3 {
+		t.Errorf("expected histogram sum ~0.25, got %f", hist.DataPoints[0].Sum)
+	}
+}
+
+func TestRecordCacheHit(t *testing.T) {
+	reader, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	rec, err := NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+
+	rec.RecordCacheHit(context.Background(), "git")
+	rec.RecordCacheHit(context.Background(), "git")
+	rec.RecordCacheHit(context.Background(), "bundles")
+
+	rm := collectMetrics(t, reader)
+
+	cacheHit := findMetric(rm, "tekton_pipelines_resolver_cache_hit_total")
+	if cacheHit == nil {
+		t.Fatal("cache_hit_total not found")
+	}
+	sum, ok := cacheHit.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("expected Sum[int64], got %T", cacheHit.Data)
+	}
+
+	gitCount := int64(0)
+	bundlesCount := int64(0)
+	for _, dp := range sum.DataPoints {
+		val, _ := dp.Attributes.Value("resolver_type")
+		switch val.AsString() {
+		case "git":
+			gitCount = dp.Value
+		case "bundles":
+			bundlesCount = dp.Value
+		}
+	}
+	if gitCount != 2 {
+		t.Errorf("expected git cache hits 2, got %d", gitCount)
+	}
+	if bundlesCount != 1 {
+		t.Errorf("expected bundles cache hits 1, got %d", bundlesCount)
+	}
+}
+
+func TestRecordCacheMiss(t *testing.T) {
+	reader, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	rec, err := NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+
+	rec.RecordCacheMiss(context.Background(), "git")
+
+	rm := collectMetrics(t, reader)
+	cacheMiss := findMetric(rm, "tekton_pipelines_resolver_cache_miss_total")
+	if cacheMiss == nil {
+		t.Fatal("cache_miss_total not found")
+	}
+	sum := cacheMiss.Data.(metricdata.Sum[int64])
+	if len(sum.DataPoints) == 0 || sum.DataPoints[0].Value != 1 {
+		t.Errorf("expected cache miss count 1, got %d", sum.DataPoints[0].Value)
+	}
+}
+
+func TestRecordSingleflightDedup(t *testing.T) {
+	reader, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	rec, err := NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+
+	rec.RecordSingleflightDedup(context.Background(), "bundles")
+	rec.RecordSingleflightDedup(context.Background(), "bundles")
+
+	rm := collectMetrics(t, reader)
+	dedup := findMetric(rm, "tekton_pipelines_resolver_singleflight_dedup_total")
+	if dedup == nil {
+		t.Fatal("singleflight_dedup_total not found")
+	}
+	sum := dedup.Data.(metricdata.Sum[int64])
+	if len(sum.DataPoints) == 0 || sum.DataPoints[0].Value != 2 {
+		t.Errorf("expected singleflight dedup count 2, got %d", sum.DataPoints[0].Value)
+	}
+}
+
+func TestRecordResolutionInvalidRequest(t *testing.T) {
+	reader, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	rec, err := NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+
+	rec.RecordResolution(context.Background(), "http", StatusInvalidRequest, 5*time.Millisecond)
+
+	rm := collectMetrics(t, reader)
+	total := findMetric(rm, "tekton_pipelines_resolver_resolution_total")
+	if total == nil {
+		t.Fatal("resolution_total not found")
+	}
+	sum := total.Data.(metricdata.Sum[int64])
+	assertAttribute(t, sum.DataPoints[0].Attributes, "status", "invalid_request")
+	assertAttribute(t, sum.DataPoints[0].Attributes, "resolver_type", "http")
+}
+
+func TestRecordResolutionNilRecorder(t *testing.T) {
+	var rec *Recorder
+	rec.RecordResolution(context.Background(), "git", StatusSuccess, time.Second)
+	rec.RecordCacheHit(context.Background(), "git")
+	rec.RecordCacheMiss(context.Background(), "git")
+	rec.RecordSingleflightDedup(context.Background(), "git")
+}
+
+func TestRecordResolutionConcurrency(t *testing.T) {
+	reader, cleanup := setupTestMeter(t)
+	defer cleanup()
+
+	rec, err := NewRecorder()
+	if err != nil {
+		t.Fatalf("NewRecorder() error: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec.RecordResolution(context.Background(), "git", StatusSuccess, time.Millisecond)
+		}()
+	}
+	wg.Wait()
+
+	rm := collectMetrics(t, reader)
+	total := findMetric(rm, "tekton_pipelines_resolver_resolution_total")
+	if total == nil {
+		t.Fatal("resolution_total not found")
+	}
+	sum := total.Data.(metricdata.Sum[int64])
+	if len(sum.DataPoints) == 0 || sum.DataPoints[0].Value != 100 {
+		t.Errorf("expected 100 concurrent recordings, got %d", sum.DataPoints[0].Value)
+	}
+}
+
+func assertAttribute(t *testing.T, attrs attribute.Set, key, expected string) {
+	t.Helper()
+	val, exists := attrs.Value(attribute.Key(key))
+	if !exists {
+		t.Errorf("attribute %q not found", key)
+		return
+	}
+	if val.AsString() != expected {
+		t.Errorf("attribute %q: expected %q, got %q", key, expected, val.AsString())
+	}
+}

--- a/pkg/resolvermetrics/metrics_test.go
+++ b/pkg/resolvermetrics/metrics_test.go
@@ -75,7 +75,7 @@ func TestNewRecorder(t *testing.T) {
 		t.Fatal("Recorder not initialized")
 	}
 
-	rec.RecordResolution(context.Background(), "git", StatusSuccess, 100*time.Millisecond)
+	rec.RecordResolution(context.Background(), "git", StatusSuccess, "Task", 100*time.Millisecond)
 	rm := collectMetrics(t, reader)
 
 	duration := findMetric(rm, "tekton_pipelines_resolver_resolution_duration_seconds")
@@ -97,7 +97,7 @@ func TestRecordResolutionSuccess(t *testing.T) {
 		t.Fatalf("NewRecorder() error: %v", err)
 	}
 
-	rec.RecordResolution(context.Background(), "git", StatusSuccess, 500*time.Millisecond)
+	rec.RecordResolution(context.Background(), "git", StatusSuccess, "Task", 500*time.Millisecond)
 
 	rm := collectMetrics(t, reader)
 
@@ -118,6 +118,7 @@ func TestRecordResolutionSuccess(t *testing.T) {
 	}
 	assertAttribute(t, sum.DataPoints[0].Attributes, "resolver_type", "git")
 	assertAttribute(t, sum.DataPoints[0].Attributes, "status", "success")
+	assertAttribute(t, sum.DataPoints[0].Attributes, "resource_kind", "Task")
 }
 
 func TestRecordResolutionError(t *testing.T) {
@@ -129,7 +130,7 @@ func TestRecordResolutionError(t *testing.T) {
 		t.Fatalf("NewRecorder() error: %v", err)
 	}
 
-	rec.RecordResolution(context.Background(), "hub", StatusError, 200*time.Millisecond)
+	rec.RecordResolution(context.Background(), "hub", StatusError, ResourceKindUnknown, 200*time.Millisecond)
 
 	rm := collectMetrics(t, reader)
 
@@ -140,6 +141,7 @@ func TestRecordResolutionError(t *testing.T) {
 	sum := total.Data.(metricdata.Sum[int64])
 	assertAttribute(t, sum.DataPoints[0].Attributes, "resolver_type", "hub")
 	assertAttribute(t, sum.DataPoints[0].Attributes, "status", "error")
+	assertAttribute(t, sum.DataPoints[0].Attributes, "resource_kind", ResourceKindUnknown)
 }
 
 func TestRecordResolutionTimeout(t *testing.T) {
@@ -151,7 +153,7 @@ func TestRecordResolutionTimeout(t *testing.T) {
 		t.Fatalf("NewRecorder() error: %v", err)
 	}
 
-	rec.RecordResolution(context.Background(), "bundles", StatusTimeout, 60*time.Second)
+	rec.RecordResolution(context.Background(), "bundles", StatusTimeout, ResourceKindUnknown, 60*time.Second)
 
 	rm := collectMetrics(t, reader)
 
@@ -162,6 +164,7 @@ func TestRecordResolutionTimeout(t *testing.T) {
 	sum := total.Data.(metricdata.Sum[int64])
 	assertAttribute(t, sum.DataPoints[0].Attributes, "resolver_type", "bundles")
 	assertAttribute(t, sum.DataPoints[0].Attributes, "status", "timeout")
+	assertAttribute(t, sum.DataPoints[0].Attributes, "resource_kind", ResourceKindUnknown)
 }
 
 func TestRecordResolutionDuration(t *testing.T) {
@@ -173,7 +176,7 @@ func TestRecordResolutionDuration(t *testing.T) {
 		t.Fatalf("NewRecorder() error: %v", err)
 	}
 
-	rec.RecordResolution(context.Background(), "cluster", StatusSuccess, 250*time.Millisecond)
+	rec.RecordResolution(context.Background(), "cluster", StatusSuccess, "Pipeline", 250*time.Millisecond)
 
 	rm := collectMetrics(t, reader)
 
@@ -293,7 +296,7 @@ func TestRecordResolutionInvalidRequest(t *testing.T) {
 		t.Fatalf("NewRecorder() error: %v", err)
 	}
 
-	rec.RecordResolution(context.Background(), "http", StatusInvalidRequest, 5*time.Millisecond)
+	rec.RecordResolution(context.Background(), "http", StatusInvalidRequest, ResourceKindUnknown, 5*time.Millisecond)
 
 	rm := collectMetrics(t, reader)
 	total := findMetric(rm, "tekton_pipelines_resolver_resolution_total")
@@ -303,11 +306,12 @@ func TestRecordResolutionInvalidRequest(t *testing.T) {
 	sum := total.Data.(metricdata.Sum[int64])
 	assertAttribute(t, sum.DataPoints[0].Attributes, "status", "invalid_request")
 	assertAttribute(t, sum.DataPoints[0].Attributes, "resolver_type", "http")
+	assertAttribute(t, sum.DataPoints[0].Attributes, "resource_kind", ResourceKindUnknown)
 }
 
 func TestRecordResolutionNilRecorder(t *testing.T) {
 	var rec *Recorder
-	rec.RecordResolution(context.Background(), "git", StatusSuccess, time.Second)
+	rec.RecordResolution(context.Background(), "git", StatusSuccess, "Task", time.Second)
 	rec.RecordCacheHit(context.Background(), "git")
 	rec.RecordCacheMiss(context.Background(), "git")
 	rec.RecordSingleflightDedup(context.Background(), "git")
@@ -327,7 +331,7 @@ func TestRecordResolutionConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			rec.RecordResolution(context.Background(), "git", StatusSuccess, time.Millisecond)
+			rec.RecordResolution(context.Background(), "git", StatusSuccess, "Task", time.Millisecond)
 		}()
 	}
 	wg.Wait()

--- a/pkg/resolvermetrics/metrics_test.go
+++ b/pkg/resolvermetrics/metrics_test.go
@@ -259,7 +259,10 @@ func TestRecordCacheMiss(t *testing.T) {
 		t.Fatal("cache_miss_total not found")
 	}
 	sum := cacheMiss.Data.(metricdata.Sum[int64])
-	if len(sum.DataPoints) == 0 || sum.DataPoints[0].Value != 1 {
+	if len(sum.DataPoints) == 0 {
+		t.Fatal("cache miss has no data points")
+	}
+	if sum.DataPoints[0].Value != 1 {
 		t.Errorf("expected cache miss count 1, got %d", sum.DataPoints[0].Value)
 	}
 }
@@ -282,7 +285,10 @@ func TestRecordSingleflightDedup(t *testing.T) {
 		t.Fatal("singleflight_dedup_total not found")
 	}
 	sum := dedup.Data.(metricdata.Sum[int64])
-	if len(sum.DataPoints) == 0 || sum.DataPoints[0].Value != 2 {
+	if len(sum.DataPoints) == 0 {
+		t.Fatal("singleflight dedup has no data points")
+	}
+	if sum.DataPoints[0].Value != 2 {
 		t.Errorf("expected singleflight dedup count 2, got %d", sum.DataPoints[0].Value)
 	}
 }

--- a/test/resolver_metrics_test.go
+++ b/test/resolver_metrics_test.go
@@ -1,0 +1,334 @@
+//go:build e2e
+
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
+	"github.com/tektoncd/pipeline/pkg/resolvermetrics"
+	"github.com/tektoncd/pipeline/test/parse"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
+)
+
+const (
+	resolverMetricsPort     = "9090"
+	resolverNamespace       = "tekton-pipelines-resolvers"
+	resolverDeployment      = "tekton-pipelines-remote-resolvers"
+	durationMetricName      = "tekton_pipelines_resolver_resolution_duration_seconds"
+	totalMetricName         = "tekton_pipelines_resolver_resolution_total"
+	cacheHitMetricName      = "tekton_pipelines_resolver_cache_hit_total"
+	cacheMissMetricName     = "tekton_pipelines_resolver_cache_miss_total"
+	singleflightDedupMetric = "tekton_pipelines_resolver_singleflight_dedup_total"
+)
+
+// TestResolverMetrics_SuccessfulResolution verifies that successful resolution
+// increments the duration histogram and total counter with status=success.
+// @test:execution=parallel
+func TestResolverMetrics_SuccessfulResolution(t *testing.T) {
+	ctx := t.Context()
+	c, namespace := setup(ctx, t, clusterFeatureFlags)
+
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	taskName := helpers.ObjectNameForTest(t)
+	task := parse.MustParseV1Task(t, fmt.Sprintf(`
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  steps:
+  - name: echo
+    image: mirror.gcr.io/ubuntu
+    script: echo hello
+`, taskName, namespace))
+	if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create Task: %s", err)
+	}
+
+	trName := helpers.ObjectNameForTest(t)
+	taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  taskRef:
+    resolver: cluster
+    params:
+    - name: kind
+      value: task
+    - name: name
+      value: %s
+    - name: namespace
+      value: %s
+`, trName, namespace, taskName, namespace))
+
+	if _, err := c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create TaskRun: %s", err)
+	}
+
+	t.Logf("Waiting for TaskRun %s to succeed", trName)
+	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSuccess", v1Version); err != nil {
+		t.Fatalf("Error waiting for TaskRun to succeed: %s", err)
+	}
+
+	metrics := scrapeResolverMetrics(ctx, t, c)
+
+	assertMetricExists(t, metrics, totalMetricName)
+	assertMetricHasLabel(t, metrics, totalMetricName, "resolver_type", "cluster")
+	assertMetricHasLabel(t, metrics, totalMetricName, "status", resolvermetrics.StatusSuccess)
+	assertMetricExists(t, metrics, durationMetricName)
+}
+
+// TestResolverMetrics_FailedResolution verifies that a failed resolution
+// (nonexistent resource) records metrics with status=error.
+// @test:execution=parallel
+func TestResolverMetrics_FailedResolution(t *testing.T) {
+	ctx := t.Context()
+	c, namespace := setup(ctx, t, clusterFeatureFlags)
+
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	prName := helpers.ObjectNameForTest(t)
+	pipelineRun := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineRef:
+    resolver: cluster
+    params:
+    - name: kind
+      value: pipeline
+    - name: name
+      value: does-not-exist-for-metrics-test
+    - name: namespace
+      value: %s
+`, prName, namespace, namespace))
+
+	if _, err := c.V1PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create PipelineRun: %s", err)
+	}
+
+	t.Logf("Waiting for PipelineRun %s to fail", prName)
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout,
+		FailedWithReason(pipelinerun.ReasonCouldntGetPipeline, prName),
+		"PipelineRunFailed", v1Version); err != nil {
+		t.Fatalf("Error waiting for PipelineRun to fail: %s", err)
+	}
+
+	metrics := scrapeResolverMetrics(ctx, t, c)
+
+	assertMetricExists(t, metrics, totalMetricName)
+	assertMetricCounterValue(t, metrics, totalMetricName,
+		map[string]string{"resolver_type": "cluster", "status": resolvermetrics.StatusError},
+	)
+}
+
+// TestResolverMetrics_MultipleResolverTypes verifies that metrics are correctly
+// labeled per resolver type when multiple resolver types are used.
+// @test:execution=parallel
+func TestResolverMetrics_MultipleResolverTypes(t *testing.T) {
+	ctx := t.Context()
+	c, namespace := setup(ctx, t, requireAllGates(map[string]string{
+		"enable-cluster-resolver": "true",
+		"enable-http-resolver":    "true",
+		"enable-api-fields":       "beta",
+	}))
+
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// Test 1: Cluster resolver
+	taskName := helpers.ObjectNameForTest(t)
+	task := parse.MustParseV1Task(t, fmt.Sprintf(`
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  steps:
+  - name: echo
+    image: mirror.gcr.io/ubuntu
+    script: echo hello
+`, taskName, namespace))
+	if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create Task: %s", err)
+	}
+
+	trName := helpers.ObjectNameForTest(t)
+	taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  taskRef:
+    resolver: cluster
+    params:
+    - name: kind
+      value: task
+    - name: name
+      value: %s
+    - name: namespace
+      value: %s
+`, trName, namespace, taskName, namespace))
+
+	if _, err := c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create TaskRun: %s", err)
+	}
+
+	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSuccess", v1Version); err != nil {
+		t.Fatalf("Error waiting for TaskRun to succeed: %s", err)
+	}
+
+	metrics := scrapeResolverMetrics(ctx, t, c)
+
+	// Verify cluster resolver metrics exist
+	assertMetricHasLabel(t, metrics, totalMetricName, "resolver_type", "cluster")
+}
+
+// scrapeResolverMetrics fetches Prometheus metrics from the resolver pod.
+func scrapeResolverMetrics(ctx context.Context, t *testing.T, c *clients) map[string]*dto.MetricFamily {
+	t.Helper()
+
+	pods, err := c.KubeClient.CoreV1().Pods(resolverNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/component=resolvers",
+	})
+	if err != nil || len(pods.Items) == 0 {
+		t.Fatalf("Failed to find resolver pod: %v", err)
+	}
+
+	podName := pods.Items[0].Name
+
+	result := c.KubeClient.
+		CoreV1().
+		RESTClient().
+		Get().
+		Resource("pods").
+		Name(podName + ":" + resolverMetricsPort).
+		Namespace(resolverNamespace).
+		SubResource("proxy").
+		Suffix("metrics").
+		Do(ctx)
+
+	body, err := result.Raw()
+	if err != nil {
+		t.Fatalf("Failed to scrape resolver metrics from pod %s: %v", podName, err)
+	}
+
+	parser := expfmt.NewTextParser(model.LegacyValidation)
+	families, err := parser.TextToMetricFamilies(strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("Failed to parse resolver metrics: %v", err)
+	}
+
+	return families
+}
+
+// assertMetricExists checks that a metric family exists in the scraped output.
+func assertMetricExists(t *testing.T, families map[string]*dto.MetricFamily, name string) {
+	t.Helper()
+	if _, ok := families[name]; !ok {
+		t.Errorf("Expected metric %q to exist, but it was not found. Available metrics: %s",
+			name, availableMetricNames(families))
+	}
+}
+
+// assertMetricHasLabel checks that at least one data point has the given label value.
+func assertMetricHasLabel(t *testing.T, families map[string]*dto.MetricFamily, name, labelName, labelValue string) {
+	t.Helper()
+	family, ok := families[name]
+	if !ok {
+		t.Errorf("Metric %q not found", name)
+		return
+	}
+
+	for _, m := range family.GetMetric() {
+		for _, label := range m.GetLabel() {
+			if label.GetName() == labelName && label.GetValue() == labelValue {
+				return
+			}
+		}
+	}
+
+	t.Errorf("Metric %q has no data point with label %s=%s", name, labelName, labelValue)
+}
+
+// assertMetricCounterValue checks that a counter metric has at least one data point
+// matching the given labels and with a value > 0.
+func assertMetricCounterValue(t *testing.T, families map[string]*dto.MetricFamily, name string, labels map[string]string) {
+	t.Helper()
+	family, ok := families[name]
+	if !ok {
+		t.Errorf("Metric %q not found", name)
+		return
+	}
+
+	for _, m := range family.GetMetric() {
+		if matchLabels(m, labels) {
+			if m.GetCounter() != nil && m.GetCounter().GetValue() > 0 {
+				return
+			}
+		}
+	}
+
+	t.Errorf("Metric %q has no data point > 0 with labels %v", name, labels)
+}
+
+func matchLabels(m *dto.Metric, expected map[string]string) bool {
+	labelMap := make(map[string]string)
+	for _, label := range m.GetLabel() {
+		labelMap[label.GetName()] = label.GetValue()
+	}
+	for k, v := range expected {
+		if labelMap[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func availableMetricNames(families map[string]*dto.MetricFamily) string {
+	names := make([]string, 0, len(families))
+	for name := range families {
+		if strings.HasPrefix(name, "tekton_") {
+			names = append(names, name)
+		}
+	}
+	return strings.Join(names, ", ")
+}

--- a/test/resolver_metrics_test.go
+++ b/test/resolver_metrics_test.go
@@ -103,10 +103,9 @@ spec:
 
 	metrics := scrapeResolverMetrics(ctx, t, c)
 
-	assertMetricExists(t, metrics, totalMetricName)
-	assertMetricHasLabel(t, metrics, totalMetricName, "resolver_type", "cluster")
-	assertMetricHasLabel(t, metrics, totalMetricName, "status", resolvermetrics.StatusSuccess)
-	assertMetricHasLabel(t, metrics, totalMetricName, "resource_kind", "Task")
+	assertMetricCounterValue(t, metrics, totalMetricName,
+		map[string]string{"resolver_type": "cluster", "status": resolvermetrics.StatusSuccess, "resource_kind": "Task"},
+	)
 	assertMetricExists(t, metrics, durationMetricName)
 }
 
@@ -156,72 +155,6 @@ spec:
 	assertMetricCounterValue(t, metrics, totalMetricName,
 		map[string]string{"resolver_type": "cluster", "status": resolvermetrics.StatusError, "resource_kind": resolvermetrics.ResourceKindUnknown},
 	)
-}
-
-// TestResolverMetrics_MultipleResolverTypes verifies that metrics are correctly
-// labeled per resolver type when multiple resolver types are used.
-// @test:execution=parallel
-func TestResolverMetrics_MultipleResolverTypes(t *testing.T) {
-	ctx := t.Context()
-	c, namespace := setup(ctx, t, requireAllGates(map[string]string{
-		"enable-cluster-resolver": "true",
-		"enable-http-resolver":    "true",
-		"enable-api-fields":       "beta",
-	}))
-
-	t.Parallel()
-
-	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
-	defer tearDown(ctx, t, c, namespace)
-
-	// Test 1: Cluster resolver
-	taskName := helpers.ObjectNameForTest(t)
-	task := parse.MustParseV1Task(t, fmt.Sprintf(`
-apiVersion: tekton.dev/v1
-kind: Task
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  steps:
-  - name: echo
-    image: mirror.gcr.io/ubuntu
-    script: echo hello
-`, taskName, namespace))
-	if _, err := c.V1TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Task: %s", err)
-	}
-
-	trName := helpers.ObjectNameForTest(t)
-	taskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  taskRef:
-    resolver: cluster
-    params:
-    - name: kind
-      value: task
-    - name: name
-      value: %s
-    - name: namespace
-      value: %s
-`, trName, namespace, taskName, namespace))
-
-	if _, err := c.V1TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create TaskRun: %s", err)
-	}
-
-	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "TaskRunSuccess", v1Version); err != nil {
-		t.Fatalf("Error waiting for TaskRun to succeed: %s", err)
-	}
-
-	metrics := scrapeResolverMetrics(ctx, t, c)
-
-	// Verify cluster resolver metrics exist
-	assertMetricHasLabel(t, metrics, totalMetricName, "resolver_type", "cluster")
-	assertMetricHasLabel(t, metrics, totalMetricName, "resource_kind", "Task")
 }
 
 // scrapeResolverMetrics fetches Prometheus metrics from the resolver pod.

--- a/test/resolver_metrics_test.go
+++ b/test/resolver_metrics_test.go
@@ -204,26 +204,6 @@ func assertMetricExists(t *testing.T, families map[string]*dto.MetricFamily, nam
 	}
 }
 
-// assertMetricHasLabel checks that at least one data point has the given label value.
-func assertMetricHasLabel(t *testing.T, families map[string]*dto.MetricFamily, name, labelName, labelValue string) {
-	t.Helper()
-	family, ok := families[name]
-	if !ok {
-		t.Errorf("Metric %q not found", name)
-		return
-	}
-
-	for _, m := range family.GetMetric() {
-		for _, label := range m.GetLabel() {
-			if label.GetName() == labelName && label.GetValue() == labelValue {
-				return
-			}
-		}
-	}
-
-	t.Errorf("Metric %q has no data point with label %s=%s", name, labelName, labelValue)
-}
-
 // assertMetricCounterValue checks that a counter metric has at least one data point
 // matching the given labels and with a value > 0.
 func assertMetricCounterValue(t *testing.T, families map[string]*dto.MetricFamily, name string, labels map[string]string) {

--- a/test/resolver_metrics_test.go
+++ b/test/resolver_metrics_test.go
@@ -106,6 +106,7 @@ spec:
 	assertMetricExists(t, metrics, totalMetricName)
 	assertMetricHasLabel(t, metrics, totalMetricName, "resolver_type", "cluster")
 	assertMetricHasLabel(t, metrics, totalMetricName, "status", resolvermetrics.StatusSuccess)
+	assertMetricHasLabel(t, metrics, totalMetricName, "resource_kind", "Task")
 	assertMetricExists(t, metrics, durationMetricName)
 }
 
@@ -153,7 +154,7 @@ spec:
 
 	assertMetricExists(t, metrics, totalMetricName)
 	assertMetricCounterValue(t, metrics, totalMetricName,
-		map[string]string{"resolver_type": "cluster", "status": resolvermetrics.StatusError},
+		map[string]string{"resolver_type": "cluster", "status": resolvermetrics.StatusError, "resource_kind": resolvermetrics.ResourceKindUnknown},
 	)
 }
 
@@ -220,6 +221,7 @@ spec:
 
 	// Verify cluster resolver metrics exist
 	assertMetricHasLabel(t, metrics, totalMetricName, "resolver_type", "cluster")
+	assertMetricHasLabel(t, metrics, totalMetricName, "resource_kind", "Task")
 }
 
 // scrapeResolverMetrics fetches Prometheus metrics from the resolver pod.

--- a/test/resolver_metrics_test.go
+++ b/test/resolver_metrics_test.go
@@ -195,15 +195,6 @@ func scrapeResolverMetrics(ctx context.Context, t *testing.T, c *clients) map[st
 	return families
 }
 
-// assertMetricExists checks that a metric family exists in the scraped output.
-func assertMetricExists(t *testing.T, families map[string]*dto.MetricFamily, name string) {
-	t.Helper()
-	if _, ok := families[name]; !ok {
-		t.Errorf("Expected metric %q to exist, but it was not found. Available metrics: %s",
-			name, availableMetricNames(families))
-	}
-}
-
 // assertMetricCounterValue checks that a counter metric has at least one data point
 // matching the given labels and with a value > 0.
 func assertMetricCounterValue(t *testing.T, families map[string]*dto.MetricFamily, name string, labels map[string]string) {
@@ -236,14 +227,4 @@ func matchLabels(m *dto.Metric, expected map[string]string) bool {
 		}
 	}
 	return true
-}
-
-func availableMetricNames(families map[string]*dto.MetricFamily) string {
-	names := make([]string, 0, len(families))
-	for name := range families {
-		if strings.HasPrefix(name, "tekton_") {
-			names = append(names, name)
-		}
-	}
-	return strings.Join(names, ", ")
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add five low-cardinality Prometheus metrics to the remote resolver framework so users can monitor individual resolution attempts and cache behavior per resolver type (git, hub, bundles, cluster, http), including the resolved Tekton resource kind for successful attempts.

New metrics exposed on the resolver pod's `:9090/metrics` endpoint:
- `tekton_pipelines_resolver_resolution_duration_seconds` (histogram, labels: `resolver_type`, `status`, `resource_kind`)
- `tekton_pipelines_resolver_resolution_total` (counter, labels: `resolver_type`, `status`, `resource_kind`)
- `tekton_pipelines_resolver_cache_hit_total` (counter, label: `resolver_type`)
- `tekton_pipelines_resolver_cache_miss_total` (counter, label: `resolver_type`)
- `tekton_pipelines_resolver_singleflight_dedup_total` (counter, label: `resolver_type`)

Each resolution sample describes one framework `resolve()` attempt, not the full lifetime of a `ResolutionRequest`; a request can produce more than one sample when retried. Status label values are `success`, `error`, `timeout`, and `invalid_request`. Resource kind values are limited to `Task`, `Pipeline`, `StepAction`, or `unknown`. Context cancellation and retryable non-timeout failures are not recorded. Workqueue delay, lifecycle-controller processing, and parent `TaskRun`/`PipelineRun` wait time are outside this metric's scope.

Metrics recording is wired into the production resolver framework (`pkg/remoteresolution/`). Resolver type comes from `rr.Labels["resolution.tekton.dev/type"]`, and resource kind is parsed from validated resolved data. Cache metrics are recorded inside `GetCachedOrResolveFromRemote()`. Labels intentionally exclude request names, namespaces, URLs, revisions, cache keys, and error text.

The resolver pod requires `metrics-protocol: prometheus` in the `config-observability` ConfigMap to start the Prometheus exporter.

Validated on a local kind cluster: built with `ko`, deployed, ran TaskRuns against the cluster resolver, and confirmed histogram buckets + counters appear correctly (~16ms avg resolution time).

Related to #7116

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add Prometheus metrics for remote resolver attempts and cache behavior. Five new metrics are exposed on the resolver pod's :9090/metrics endpoint: resolution-attempt duration and count, cache hit/miss counters, and a singleflight deduplication counter. Resolution metrics use bounded resolver type, status, and resource kind labels; cache metrics use resolver type.
```


