### PR TITLE
[release-v1.9.x] fix: surface clear errors when completed tasks miss referenced results

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -919,14 +919,27 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 		// added to the validationFailedTask list
 		err := resources.CheckMissingResultReferences(pipelineRunFacts.State, rpt)
 		if err != nil {
-			logger.Infof("Failed to resolve task result reference for %q with error %v", pr.Name, err)
+			// Use Errorf when a task succeeded but didn't emit a result (surprising),
+			// Infof when the referenced task failed (expected that results are missing).
+			var missingResultErr *resources.MissingResultFromCompletedTaskError
+			if errors.As(err, &missingResultErr) {
+				logger.Errorf("Failed to resolve task result reference for %q with error %v", pr.Name, err)
+			} else {
+				logger.Infof("Failed to resolve task result reference for %q with error %v", pr.Name, err)
+			}
 			// If there is an error encountered, no new task
 			// will be scheduled, hence nextRpts should be empty
 			// If finally tasks are found, then those tasks will
 			// be added to the nextRpts
 			nextRpts = nil
-			logger.Infof("Adding the task %q to the validation failed list", rpt.ResolvedTask)
+			logger.Infof("Adding the task %q to the validation failed list", rpt.PipelineTask.Name)
 			pipelineRunFacts.ValidationFailedTask = append(pipelineRunFacts.ValidationFailedTask, rpt)
+			if pipelineRunFacts.ValidationFailedErrors == nil {
+				pipelineRunFacts.ValidationFailedErrors = make(map[string]string)
+			}
+			pipelineRunFacts.ValidationFailedErrors[rpt.PipelineTask.Name] = err.Error()
+			recorder.Eventf(pr, corev1.EventTypeWarning, "ResultValidationFailed",
+				"Task %q failed result validation: %v", rpt.PipelineTask.Name, err)
 		}
 	}
 	// GetFinalTasks only returns final tasks when a DAG is complete

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1308,7 +1308,7 @@ status:
           image: busybox
           script: 'exit 0'
   conditions:
-  - message: "Tasks Completed: 1 (Failed: 0, Cancelled 0), Skipped: 0, Failed Validation: 1"
+  - message: 'Tasks Completed: 1 (Failed: 0, Cancelled 0), Skipped: 0, Failed Validation: 1 (task "task1" completed successfully but did not emit the result "result2", which is referenced by task "task2")'
     reason: PipelineValidationFailed
     status: "False"
     type: Succeeded
@@ -1325,7 +1325,12 @@ status:
 	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
-	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-missing-results", []string{}, false)
+	wantEvents := []string{
+		"Normal Started",
+		"Warning ResultValidationFailed",
+		"Warning Failed",
+	}
+	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-missing-results", wantEvents, false)
 	if reconciledRun.Status.CompletionTime == nil {
 		t.Errorf("Expected a CompletionTime on invalid PipelineRun but was nil")
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -38,6 +38,19 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 )
+// MissingResultFromCompletedTaskError indicates a task completed successfully
+// but did not emit a result that a downstream task references.
+type MissingResultFromCompletedTaskError struct {
+	Task   string
+	Result string
+	Target string
+}
+
+func (e *MissingResultFromCompletedTaskError) Error() string {
+	return fmt.Sprintf("task %q completed successfully but did not emit the result %q, which is referenced by task %q",
+		e.Task, e.Result, e.Target)
+}
+
 
 const (
 	// ReasonConditionCheckFailed indicates that the reason for the failure status is that the
@@ -1002,6 +1015,13 @@ func CheckMissingResultReferences(pipelineRunState PipelineRunState, target *Res
 			customRun := referencedPipelineTask.CustomRuns[0]
 			_, err := findRunResultForParam(customRun, resultRef)
 			if err != nil {
+				if referencedPipelineTask.isSuccessful() {
+					return &MissingResultFromCompletedTaskError{
+						Task:   resultRef.PipelineTask,
+						Result: resultRef.Result,
+						Target: target.PipelineTask.Name,
+					}
+				}
 				return err
 			}
 		} else {
@@ -1011,6 +1031,13 @@ func CheckMissingResultReferences(pipelineRunState PipelineRunState, target *Res
 			taskRun := referencedPipelineTask.TaskRuns[0]
 			_, err := findTaskResultForParam(taskRun, resultRef)
 			if err != nil {
+				if referencedPipelineTask.isSuccessful() {
+					return &MissingResultFromCompletedTaskError{
+						Task:   resultRef.PipelineTask,
+						Result: resultRef.Result,
+						Target: target.PipelineTask.Name,
+					}
+				}
 				return err
 			}
 		}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -76,6 +77,12 @@ type PipelineRunFacts struct {
 	// the case of failing at the validation is during CheckMissingResultReferences method
 	// Tasks in ValidationFailedTask is added in method runNextSchedulableTask
 	ValidationFailedTask []*ResolvedPipelineTask
+
+	// ValidationFailedErrors maps pipeline task name to the error message for tasks
+	// that failed validation. These messages are included in the PipelineRun status
+	// condition to help users understand why specific tasks were not executed
+	// (e.g. missing result references).
+	ValidationFailedErrors map[string]string
 }
 
 // PipelineRunTimeoutsState records information about start times and timeouts for the PipelineRun, so that the PipelineRunFacts
@@ -572,9 +579,25 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, p
 			message = fmt.Sprintf("Tasks Completed: %d (Failed: %d, Cancelled %d), Skipped: %d",
 				cmTasks, totalFailedTasks, s.Cancelled, s.Skipped)
 		}
-		// append validation failed count in the message
+		// append validation failed count and details in the message
 		if s.ValidationFailed > 0 {
 			message += fmt.Sprintf(", Failed Validation: %d", s.ValidationFailed)
+			if len(facts.ValidationFailedErrors) > 0 {
+				keys := make([]string, 0, len(facts.ValidationFailedErrors))
+				for k := range facts.ValidationFailedErrors {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				var errors []string
+				for _, k := range keys {
+					errors = append(errors, facts.ValidationFailedErrors[k])
+				}
+				errMsg := strings.Join(errors, "; ")
+				if len(errMsg) > 1024 {
+					errMsg = errMsg[:1024] + "..."
+				}
+				message += fmt.Sprintf(" (%s)", errMsg)
+			}
 		}
 		// Set reason to ReasonCompleted - At least one is skipped
 		if s.Skipped > 0 {

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -747,14 +747,14 @@ func TestCheckMissingResultReferences(t *testing.T) {
 		targets: PipelineRunState{
 			pipelineRunState[3],
 		},
-		wantErr: "Invalid task result reference: Could not find result with name missingResult for pipeline task aTask",
+		wantErr: `task "aTask" completed successfully but did not emit the result "missingResult", which is referenced by task "bTask"`,
 	}, {
 		name:             "Test unsuccessful result references resolution - params",
 		pipelineRunState: pipelineRunState,
 		targets: PipelineRunState{
 			pipelineRunState[4],
 		},
-		wantErr: "Invalid task result reference: Could not find result with name missingResult for pipeline task aTask",
+		wantErr: `task "aTask" completed successfully but did not emit the result "missingResult", which is referenced by task "bTask"`,
 	}, {
 		name:             "Valid: Test successful result references resolution - params - Run",
 		pipelineRunState: pipelineRunState,
@@ -791,14 +791,14 @@ func TestCheckMissingResultReferences(t *testing.T) {
 		targets: PipelineRunState{
 			pipelineRunState[13],
 		},
-		wantErr: "Invalid task result reference: Could not find result with name iDoNotExist for pipeline task dTask",
+		wantErr: `task "dTask" completed successfully but did not emit the result "iDoNotExist", which is referenced by task "iTask"`,
 	}, {
 		name:             "Invalid: Test result references resolution - matrix custom task - missing references to string replacements",
 		pipelineRunState: pipelineRunState,
 		targets: PipelineRunState{
 			pipelineRunState[14],
 		},
-		wantErr: "Invalid task result reference: Could not find result with name iDoNotExist for pipeline task aCustomPipelineTask",
+		wantErr: `task "aCustomPipelineTask" completed successfully but did not emit the result "iDoNotExist", which is referenced by task "jTask"`,
 	}, {
 		name:             "Invalid: Test result references where ref does not exist in pipelineRunState map",
 		pipelineRunState: pipelineRunState,
@@ -828,6 +828,223 @@ func TestCheckMissingResultReferences(t *testing.T) {
 			}
 			if err == nil && tt.wantErr != "" {
 				t.Fatalf("Expecting error %v, but did not get an error", tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckMissingResultReferences_UninitializedResults tests the specific scenario
+// described in https://github.com/tektoncd/pipeline/issues/9527: when a completed
+// (successful) task doesn't emit a result that downstream tasks reference, the error
+// message should clearly indicate which result was missing and from which task.
+func TestCheckMissingResultReferences_UninitializedResults(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		pipelineRunState PipelineRunState
+		target           *ResolvedPipelineTask
+		wantErr          string
+	}{{
+		name: "successful task missing referenced result produces clear error",
+		pipelineRunState: PipelineRunState{{
+			TaskRunNames: []string{"producer-taskrun"},
+			TaskRuns: []*v1.TaskRun{{
+				ObjectMeta: metav1.ObjectMeta{Name: "producer-taskrun"},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{successCondition},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						// Task succeeded but didn't emit "expected-result"
+						Results: []v1.TaskRunResult{},
+					},
+				},
+			}},
+			PipelineTask: &v1.PipelineTask{
+				Name:    "producer",
+				TaskRef: &v1.TaskRef{Name: "producer-task"},
+			},
+		}},
+		target: &ResolvedPipelineTask{
+			PipelineTask: &v1.PipelineTask{
+				Name:    "consumer",
+				TaskRef: &v1.TaskRef{Name: "consumer-task"},
+				Params: []v1.Param{{
+					Name:  "input",
+					Value: *v1.NewStructuredValues("$(tasks.producer.results.expected-result)"),
+				}},
+			},
+		},
+		wantErr: `task "producer" completed successfully but did not emit the result "expected-result", which is referenced by task "consumer"`,
+	}, {
+		name: "failed task missing referenced result uses original error",
+		pipelineRunState: PipelineRunState{{
+			TaskRunNames: []string{"producer-taskrun"},
+			TaskRuns: []*v1.TaskRun{{
+				ObjectMeta: metav1.ObjectMeta{Name: "producer-taskrun"},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{failedCondition},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Results: []v1.TaskRunResult{},
+					},
+				},
+			}},
+			PipelineTask: &v1.PipelineTask{
+				Name:    "producer",
+				TaskRef: &v1.TaskRef{Name: "producer-task"},
+			},
+		}},
+		target: &ResolvedPipelineTask{
+			PipelineTask: &v1.PipelineTask{
+				Name:    "consumer",
+				TaskRef: &v1.TaskRef{Name: "consumer-task"},
+				Params: []v1.Param{{
+					Name:  "input",
+					Value: *v1.NewStructuredValues("$(tasks.producer.results.expected-result)"),
+				}},
+			},
+		},
+		// Failed tasks use the original ErrInvalidTaskResultReference message
+		wantErr: "Invalid task result reference: Could not find result with name expected-result for pipeline task producer",
+	}, {
+		name: "successful task with result present does not error",
+		pipelineRunState: PipelineRunState{{
+			TaskRunNames: []string{"producer-taskrun"},
+			TaskRuns: []*v1.TaskRun{{
+				ObjectMeta: metav1.ObjectMeta{Name: "producer-taskrun"},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{successCondition},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Results: []v1.TaskRunResult{{
+							Name:  "expected-result",
+							Value: *v1.NewStructuredValues("some-value"),
+						}},
+					},
+				},
+			}},
+			PipelineTask: &v1.PipelineTask{
+				Name:    "producer",
+				TaskRef: &v1.TaskRef{Name: "producer-task"},
+			},
+		}},
+		target: &ResolvedPipelineTask{
+			PipelineTask: &v1.PipelineTask{
+				Name:    "consumer",
+				TaskRef: &v1.TaskRef{Name: "consumer-task"},
+				Params: []v1.Param{{
+					Name:  "input",
+					Value: *v1.NewStructuredValues("$(tasks.producer.results.expected-result)"),
+				}},
+			},
+		},
+		wantErr: "",
+	}, {
+		name: "successful custom task missing referenced result produces clear error",
+		pipelineRunState: PipelineRunState{{
+			CustomTask:     true,
+			CustomRunNames: []string{"producer-run"},
+			CustomRuns: []*v1beta1.CustomRun{{
+				ObjectMeta: metav1.ObjectMeta{Name: "producer-run"},
+				Status: v1beta1.CustomRunStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{successCondition},
+					},
+					CustomRunStatusFields: v1beta1.CustomRunStatusFields{
+						Results: []v1beta1.CustomRunResult{},
+					},
+				},
+			}},
+			PipelineTask: &v1.PipelineTask{
+				Name:    "custom-producer",
+				TaskRef: &v1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: "custom-task"},
+			},
+		}},
+		target: &ResolvedPipelineTask{
+			PipelineTask: &v1.PipelineTask{
+				Name:    "consumer",
+				TaskRef: &v1.TaskRef{Name: "consumer-task"},
+				Params: []v1.Param{{
+					Name:  "input",
+					Value: *v1.NewStructuredValues("$(tasks.custom-producer.results.custom-result)"),
+				}},
+			},
+		},
+		wantErr: `task "custom-producer" completed successfully but did not emit the result "custom-result", which is referenced by task "consumer"`,
+	}, {
+		name: "successful task with partial results - only missing result errors",
+		pipelineRunState: PipelineRunState{{
+			TaskRunNames: []string{"producer-taskrun"},
+			TaskRuns: []*v1.TaskRun{{
+				ObjectMeta: metav1.ObjectMeta{Name: "producer-taskrun"},
+				Status: v1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{successCondition},
+					},
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						Results: []v1.TaskRunResult{{
+							Name:  "result-a",
+							Value: *v1.NewStructuredValues("value-a"),
+						}},
+					},
+				},
+			}},
+			PipelineTask: &v1.PipelineTask{
+				Name:    "producer",
+				TaskRef: &v1.TaskRef{Name: "producer-task"},
+			},
+		}},
+		target: &ResolvedPipelineTask{
+			PipelineTask: &v1.PipelineTask{
+				Name:    "consumer",
+				TaskRef: &v1.TaskRef{Name: "consumer-task"},
+				Params: []v1.Param{{
+					Name:  "input-a",
+					Value: *v1.NewStructuredValues("$(tasks.producer.results.result-a)"),
+				}, {
+					Name:  "input-b",
+					Value: *v1.NewStructuredValues("$(tasks.producer.results.result-b)"),
+				}},
+			},
+		},
+		wantErr: `task "producer" completed successfully but did not emit the result "result-b", which is referenced by task "consumer"`,
+	}, {
+		name: "zero-length TaskRuns still produces original error",
+		pipelineRunState: PipelineRunState{{
+			TaskRunNames: []string{"producer-taskrun"},
+			TaskRuns:     []*v1.TaskRun{},
+			PipelineTask: &v1.PipelineTask{
+				Name:    "producer",
+				TaskRef: &v1.TaskRef{Name: "producer-task"},
+			},
+		}},
+		target: &ResolvedPipelineTask{
+			PipelineTask: &v1.PipelineTask{
+				Name:    "consumer",
+				TaskRef: &v1.TaskRef{Name: "consumer-task"},
+				Params: []v1.Param{{
+					Name:  "input",
+					Value: *v1.NewStructuredValues("$(tasks.producer.results.some-result)"),
+				}},
+			},
+		},
+		wantErr: `Result reference error: Internal result ref "producer" has zero-length TaskRuns`,
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckMissingResultReferences(tt.pipelineRunState, tt.target)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("CheckMissingResultReferences() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("CheckMissingResultReferences() expected error %q but got nil", tt.wantErr)
+				}
+				if err.Error() != tt.wantErr {
+					t.Errorf("CheckMissingResultReferences() error = %q, want %q", err.Error(), tt.wantErr)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Cherry-pick of #9529 to release-v1.9.x.

# Changes

When a PipelineTask references results from a completed task that didn't emit those results, the referencing task was silently marked as "ValidationFailed" with a generic count-only message. Users had no indication of which result was missing from which task, and no Kubernetes Warning event was emitted.

This PR fixes both issues:

1. **Clear error messages:** If a referenced result is missing from a completed (successful) task, the error message now states which task completed without emitting which result and which downstream task references it.

2. **Warning event:** A `ResultValidationFailed` Warning event is now emitted when a task fails result validation, consistent with `TaskRunsCreationFailed`, `RunsCreationFailed`, and `ChildPipelineRunsCreationFailed` events.

Upstream issue: #9527

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
PipelineRun status now shows which specific results were missing when tasks are skipped due to uninitialized result references from completed tasks. A Warning event with reason ResultValidationFailed is also emitted for consistency with other failure modes.
```