### PR TITLE
fix issue #8255 - seperating step level and task level validation. Va…

### DIFF
--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -247,7 +247,21 @@ func ValidateStepResults(ctx context.Context, results []StepResult) (errs *apis.
 }
 
 // ValidateStepResultsVariables validates if the StepResults referenced in step script are defined in step's results.
+// It only validates $(step.results.<name>.path) references. Task-level $(results.<name>.path) references
+// are validated separately by validateTaskResultsVariables which has the task results context.
 func ValidateStepResultsVariables(ctx context.Context, results []StepResult, script string) (errs *apis.FieldError) {
+	resultsNames := sets.NewString()
+	for _, r := range results {
+		resultsNames.Insert(r.Name)
+	}
+	errs = errs.Also(substitution.ValidateNoReferencesToUnknownVariables(script, "step.results", resultsNames).ViaField("script"))
+	return errs
+}
+
+// ValidateStepActionResultsVariables validates if the results referenced in a StepAction script are defined
+// in the StepAction's results. Unlike ValidateStepResultsVariables, this also validates $(results.<name>.path)
+// references since a standalone StepAction has no task-level result context.
+func ValidateStepActionResultsVariables(ctx context.Context, results []StepResult, script string) (errs *apis.FieldError) {
 	resultsNames := sets.NewString()
 	for _, r := range results {
 		resultsNames.Insert(r.Name)

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -526,6 +526,26 @@ func TestTaskSpecValidate(t *testing.T) {
 				hello "$(context.taskRun.namespace)"`,
 			}},
 		},
+	}, {
+		name: "valid step script with both step results and task results",
+		fields: fields{
+			Steps: []v1.Step{{
+				Name:  "collect-data",
+				Image: "my-image",
+				Script: `
+				#!/usr/bin/env sh
+				echo -n "value" > $(step.results.stepResult.path)
+				echo -n "other" > $(results.taskResult.path)`,
+				Results: []v1.StepResult{{
+					Name: "stepResult",
+					Type: v1.ResultsTypeString,
+				}},
+			}},
+			Results: []v1.TaskResult{{
+				Name: "taskResult",
+				Type: v1.ResultsTypeString,
+			}},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1alpha1/stepaction_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/stepaction_validation.go
@@ -69,7 +69,7 @@ func (ss *StepActionSpec) Validate(ctx context.Context) (errs *apis.FieldError) 
 	errs = errs.Also(validateUsageOfDeclaredParameters(ctx, *ss))
 	errs = errs.Also(v1.ValidateParameterTypes(ctx, ss.Params).ViaField("params"))
 	errs = errs.Also(validateParameterVariables(ctx, *ss, ss.Params))
-	errs = errs.Also(v1.ValidateStepResultsVariables(ctx, ss.Results, ss.Script))
+	errs = errs.Also(v1.ValidateStepActionResultsVariables(ctx, ss.Results, ss.Script))
 	errs = errs.Also(v1.ValidateStepResults(ctx, ss.Results).ViaField("results"))
 	errs = errs.Also(validateVolumeMounts(ss.VolumeMounts, ss.Params).ViaField("volumeMounts"))
 	return errs

--- a/pkg/apis/pipeline/v1alpha1/stepaction_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/stepaction_validation_test.go
@@ -271,6 +271,16 @@ func TestStepActionSpecValidate(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "valid step action script referencing declared results",
+		fields: fields{
+			Image:   "my-image",
+			Results: []v1.StepResult{{Name: "a-result"}},
+			Script: `
+echo foo > $(results.a-result.path)
+echo foo > $(step.results.a-result.path)
+`,
+		},
+	}, {
 		name: "valid volumeMounts",
 		fields: fields{
 			Image: "my-image",

--- a/pkg/apis/pipeline/v1beta1/stepaction_validation.go
+++ b/pkg/apis/pipeline/v1beta1/stepaction_validation.go
@@ -68,7 +68,7 @@ func (ss *StepActionSpec) Validate(ctx context.Context) (errs *apis.FieldError) 
 	errs = errs.Also(validateUsageOfDeclaredParameters(ctx, *ss))
 	errs = errs.Also(v1.ValidateParameterTypes(ctx, ss.Params).ViaField("params"))
 	errs = errs.Also(validateParameterVariables(ctx, *ss, ss.Params))
-	errs = errs.Also(v1.ValidateStepResultsVariables(ctx, ss.Results, ss.Script))
+	errs = errs.Also(v1.ValidateStepActionResultsVariables(ctx, ss.Results, ss.Script))
 	errs = errs.Also(v1.ValidateStepResults(ctx, ss.Results).ViaField("results"))
 	errs = errs.Also(validateVolumeMounts(ss.VolumeMounts, ss.Params).ViaField("volumeMounts"))
 	return errs

--- a/pkg/apis/pipeline/v1beta1/stepaction_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/stepaction_validation_test.go
@@ -239,6 +239,16 @@ func TestStepActionSpecValidate(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "valid step action script referencing declared results",
+		fields: fields{
+			Image:   "my-image",
+			Results: []v1.StepResult{{Name: "a-result"}},
+			Script: `
+echo foo > $(results.a-result.path)
+echo foo > $(step.results.a-result.path)
+`,
+		},
+	}, {
 		name: "valid volumeMounts",
 		fields: fields{
 			Image: "my-image",

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -567,6 +567,26 @@ func TestTaskSpecValidate(t *testing.T) {
 				hello "$(context.taskRun.namespace)"`,
 			}},
 		},
+	}, {
+		name: "valid step script with both step results and task results",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Name:  "collect-data",
+				Image: "my-image",
+				Script: `
+				#!/usr/bin/env sh
+				echo -n "value" > $(step.results.stepResult.path)
+				echo -n "other" > $(results.taskResult.path)`,
+				Results: []v1.StepResult{{
+					Name: "stepResult",
+					Type: v1.ResultsTypeString,
+				}},
+			}},
+			Results: []v1beta1.TaskResult{{
+				Name: "taskResult",
+				Type: v1beta1.ResultsTypeString,
+			}},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2486,7 +2506,7 @@ func TestTaskSpecValidate_StepResults_Error(t *testing.T) {
 			Results: []v1.StepResult{{Name: "a-result"}},
 		},
 		expectedError: apis.FieldError{
-			Message: "non-existent variable `non-exist` in \"\\n\\t\\t\\t#!/usr/bin/env bash\\n\\t\\t\\tdate | tee $(results.non-exist.path)\": steps[0].script\nnon-existent variable in \"\\n\\t\\t\\t#!/usr/bin/env bash\\n\\t\\t\\tdate | tee $(results.non-exist.path)\"",
+			Message: "non-existent variable `non-exist` in \"\\n\\t\\t\\t#!/usr/bin/env bash\\n\\t\\t\\tdate | tee $(results.non-exist.path)\"",
 			Paths:   []string{"steps[0].script"},
 		},
 	}, {


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes #8255
When defining a Task that uses both `spec.results` (task-level) and `spec.steps[].results` (step-level), the admission webhook incorrectly rejects the Task with a "non-existent variable" error. This happens because `ValidateStepResultsVariables` validates `$(results.<name>.path)` references against step result names instead of task result names.
The fix splits the shared validation function into two:
- **`ValidateStepResultsVariables`** (used in Task validation): only validates `$(step.results.<name>.path)` against step results. Task-level `$(results.<name>.path)` references are already validated by `validateTaskResultsVariables`.
- **`ValidateStepActionResultsVariables`** (new, used in StepAction validation): validates both `$(step.results.<name>.path)` and `$(results.<name>.path)` against the StepAction's own results, since a standalone StepAction has no task-level context.
This follows the approach discussed in #8264.

**logs before the fix:**
`Error from server (BadRequest): error when creating "test-issue-8255.yaml": admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: non-existent variable in "#!/usr/bin/env sh\nset -x\nSINGLE_COMPONENT_MODE=\"scott\"\necho -n \"${SINGLE_COMPONENT_MODE}\" > $(step.results.singleComponentMode.path)\necho -n \"tom\" > $(results.resultsDir.path)\n": spec.steps[0].script`


**logs after the fix:**
`taskrun.tekton.dev/test-8255-zlbkx created`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix validation error when a Task uses both spec.results and spec.steps[].results in the same step script
```
