### PR TITLE
build: bump go directive to 1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,8 @@ jobs:
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       if: ${{ needs.changes.outputs.non-docs == 'true' }}
       with:
-        version: v2.8.0
+        version: v2.12.2
+        install-mode: goinstall
         args: --new-from-merge-base=origin/${{ github.base_ref }} --timeout=10m
     - name: yamllint
       if: ${{ needs.changes.outputs.yaml == 'true' }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/pipeline
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/test/custom-task-ctrls/wait-task-beta/go.mod
+++ b/test/custom-task-ctrls/wait-task-beta/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/pipeline/test/wait-task-beta
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/test/resolver-with-timeout/go.mod
+++ b/test/resolver-with-timeout/go.mod
@@ -1,6 +1,7 @@
 module resolver_with_timeout
 
-go 1.25.7
+
+go 1.26
 
 require (
 	github.com/tektoncd/pipeline v1.11.1


### PR DESCRIPTION
# Changes

Bump the `go` directive in `go.mod` and sub-modules (`test/custom-task-ctrls/wait-task-beta`, `test/resolver-with-timeout`) from 1.25.7 to 1.26.

This prepares for upcoming dependency updates that require Go 1.26 (e.g. `code.gitea.io/sdk/gitea` v0.25.1).

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string \"action required\" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```