### PR TITLE
build: bump go directive to 1.25

### DIFF
--- a/test/custom-task-ctrls/wait-task-beta/go.mod
+++ b/test/custom-task-ctrls/wait-task-beta/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/pipeline/test/wait-task-beta
 
-go 1.23.0
+go 1.25
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/test/resolver-with-timeout/go.mod
+++ b/test/resolver-with-timeout/go.mod
@@ -1,8 +1,6 @@
 module resolver_with_timeout
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.25
 
 require (
 	github.com/tektoncd/pipeline v0.65.1


### PR DESCRIPTION
# Changes

Bump the `go` directive in `go.mod` and sub-modules (`test/custom-task-ctrls/wait-task-beta`, `test/resolver-with-timeout`) from 1.24.13/1.23.0 to 1.25.

This fixes golangci-lint compatibility issues where the linter (built with Go 1.24) cannot target Go versions higher than its own build version. Several dependabot PRs (e.g. go-containerregistry v0.20.8) pull in dependencies that bumped their `go` directive to 1.25.x, causing lint failures.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string \"action required\" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```