### PR TITLE
refactor: remove placeholder URL workaround in hub resolver Validate()

### DIFF
--- a/pkg/remoteresolution/resolver/hub/resolver.go
+++ b/pkg/remoteresolution/resolver/hub/resolver.go
@@ -84,36 +84,14 @@ func (r *Resolver) Validate(ctx context.Context, req *v1beta1.ResolutionRequestS
 	if isDisabled(ctx) {
 		return errors.New(disabledError)
 	}
-
-	paramsMap := extractParams(req.Params)
-
-	// Validate URL param if provided.
-	if paramURL := paramsMap[ParamURL]; paramURL != "" {
-		if err := validateHubURL(paramURL); err != nil {
-			return fmt.Errorf("failed to validate params: invalid url param: %w", err)
-		}
+	paramsMap, err := populateDefaultParams(ctx, req.Params)
+	if err != nil {
+		return fmt.Errorf("failed to populate default params: %w", err)
 	}
-
-	// For TektonHub type with no env var URL, check if url param or ConfigMap URLs are available.
-	hasURLOverride := paramsMap[ParamURL] != ""
-	conf := resolutionframework.GetResolverConfigFromContext(ctx)
-	hubType := paramsMap[hub.ParamType]
-	if hubType == "" {
-		hubType = conf[hub.ConfigType]
+	if err := r.validateParamsForResolve(ctx, paramsMap); err != nil {
+		return fmt.Errorf("failed to validate params: %w", err)
 	}
-	if hubType == hub.TektonHubType && r.TektonHubURL == "" {
-		if hasURLOverride {
-			// URL param overrides the env var, pass a placeholder to skip the env var check.
-			return hub.ValidateParams(ctx, req.Params, "url-param-configured")
-		}
-		configURLs, _ := parseURLList(conf[ConfigTektonHubURLs])
-		if len(configURLs) > 0 {
-			// ConfigMap URLs are available, skip the env var check.
-			return hub.ValidateParams(ctx, req.Params, "configmap-urls-configured")
-		}
-	}
-
-	return hub.ValidateParams(ctx, req.Params, r.TektonHubURL)
+	return nil
 }
 
 // Resolve uses the given params to resolve the requested file or resource.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Closes #9684.

Replace the cross-package `hub.ValidateParams()` call in `Validate()` (which required passing placeholder strings `"url-param-configured"` and `"configmap-urls-configured"` to bypass the env-var check) with the self-contained `populateDefaultParams` + `validateParamsForResolve` chain that `Resolve()` already uses.

The placeholder strings were introduced in #9465 to work around the fact that `validateParams()` in the deprecated `pkg/resolution/resolver/hub` package rejects an empty `tektonHubURL`. The `remoteresolution` package already has `validateParamsForResolve()` which handles the URL param / ConfigMap / env-var precedence correctly without needing a fake URL value, so the workaround is unnecessary.

The deprecated `pkg/resolution/resolver/hub` package is left untouched.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing (N/A — internal refactor, no user-visible behavior change)
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed (existing tests cover the affected paths: `TestValidate`, `TestValidateMissing`, `TestValidateConflictingKindName`, `TestValidateURLParam`, `TestValidateParamsTektonTypeWithConfigMapURLs`)
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label (`/kind cleanup` applied)
- [x] Release notes block below has been updated with any user facing changes (no user-facing changes)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release (N/A)

# Release Notes

```release-note
NONE
```
