### PR TITLE
Fix #7756 - Validate variable references in Pipeline task params

### DIFF
--- a/pkg/apis/pipeline/v1/param_types.go
+++ b/pkg/apis/pipeline/v1/param_types.go
@@ -32,6 +32,8 @@ import (
 
 // ParamsPrefix is the prefix used in $(...) expressions referring to parameters
 const ParamsPrefix = "params"
+const matrixField = "matrix"
+const lengthField = "length"
 
 // ParamSpec defines arbitrary parameters needed beyond typed inputs (such as
 // resources). Parameter values are provided by users as inputs on a TaskRun
@@ -260,12 +262,19 @@ func (p Param) ParseTaskandResultName() (string, string) {
 	if expressions, ok := p.GetVarSubstitutionExpressions(); ok {
 		for _, expression := range expressions {
 			subExpressions := strings.Split(expression, ".")
-			pipelineTaskName := subExpressions[1]
-			if len(subExpressions) == 4 {
-				return pipelineTaskName, ""
-			} else if len(subExpressions) == 5 {
-				resultName := subExpressions[3]
-				return pipelineTaskName, resultName
+			// tasks.<name>.matrix.length
+			if len(subExpressions) == 4 &&
+				subExpressions[0] == PipelineTasks &&
+				subExpressions[2] == matrixField &&
+				subExpressions[3] == lengthField {
+				return subExpressions[1], ""
+			}
+			// tasks.<name>.matrix.<result>.length
+			if len(subExpressions) == 5 &&
+				subExpressions[0] == PipelineTasks &&
+				subExpressions[2] == matrixField &&
+				subExpressions[4] == lengthField {
+				return subExpressions[1], subExpressions[3]
 			}
 		}
 	}

--- a/pkg/apis/pipeline/v1/param_types_test.go
+++ b/pkg/apis/pipeline/v1/param_types_test.go
@@ -675,6 +675,26 @@ func TestParseTaskandResultName(t *testing.T) {
 		param:            v1.Param{Name: "foo", Value: v1.ParamValue{StringVal: "", Type: v1.ParamTypeString}},
 		pipelineTaskName: "",
 		resultName:       "",
+	}, {
+		name:             "invalid variable reference without dots should not panic",
+		param:            v1.Param{Name: "foo", Value: v1.ParamValue{StringVal: "$(new_image)", Type: v1.ParamTypeString}},
+		pipelineTaskName: "",
+		resultName:       "",
+	}, {
+		name:             "invalid variable reference with one dot should not panic",
+		param:            v1.Param{Name: "foo", Value: v1.ParamValue{StringVal: "$(image.name)", Type: v1.ParamTypeString}},
+		pipelineTaskName: "",
+		resultName:       "",
+	}, {
+		name:             "mixed expressions: result ref and matrix context var returns matrix task name",
+		param:            v1.Param{Name: "foo", Value: v1.ParamValue{StringVal: "$(tasks.producer.results.digest) $(tasks.matrixed.matrix.length)", Type: v1.ParamTypeString}},
+		pipelineTaskName: "matrixed",
+		resultName:       "",
+	}, {
+		name:             "mixed expressions: result ref and matrix result length var returns matrix task name",
+		param:            v1.Param{Name: "foo", Value: v1.ParamValue{StringVal: "$(tasks.producer.results.digest) $(tasks.matrixed.matrix.myresult.length)", Type: v1.ParamTypeString}},
+		pipelineTaskName: "matrixed",
+		resultName:       "myresult",
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -97,6 +97,8 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validateArtifactReference(ctx, ps.Tasks, ps.Finally))
 	errs = errs.Also(validateMatrix(ctx, ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validateMatrix(ctx, ps.Finally).ViaField("finally"))
+	errs = errs.Also(validateVarSubstitutionExpressions(ps.Tasks, "tasks"))
+	errs = errs.Also(validateVarSubstitutionExpressions(ps.Finally, "finally"))
 	return errs
 }
 
@@ -865,6 +867,69 @@ func validateMatrix(ctx context.Context, tasks []PipelineTask) (errs *apis.Field
 		errs = errs.Also(task.validateMatrix(ctx).ViaIndex(idx))
 	}
 	errs = errs.Also(validateTaskResultsFromMatrixedPipelineTasksConsumed(tasks))
+	return errs
+}
+
+func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) (errs *apis.FieldError) {
+	validPrefixes := sets.NewString("params", "tasks", "finally", "context", "workspaces")
+	for idx, task := range tasks {
+		for _, param := range task.Params {
+			if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
+				for _, expression := range expressions {
+					prefix := strings.SplitN(expression, ".", 2)[0]
+					if !validPrefixes.Has(prefix) {
+						errs = errs.Also(apis.ErrInvalidValue(
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							"value",
+						).ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
+					}
+				}
+			}
+		}
+		for i, we := range task.When {
+			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
+				for _, expression := range expressions {
+					prefix := strings.SplitN(expression, ".", 2)[0]
+					if !validPrefixes.Has(prefix) {
+						errs = errs.Also(apis.ErrInvalidValue(
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							"",
+						).ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
+					}
+				}
+			}
+		}
+		if task.IsMatrixed() {
+			for _, param := range task.Matrix.Params {
+				if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
+					for _, expression := range expressions {
+						prefix := strings.SplitN(expression, ".", 2)[0]
+						if !validPrefixes.Has(prefix) {
+							errs = errs.Also(apis.ErrInvalidValue(
+								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+								"value",
+							).ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
+						}
+					}
+				}
+			}
+			for i, include := range task.Matrix.Include {
+				for _, param := range include.Params {
+					if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
+						for _, expression := range expressions {
+							prefix := strings.SplitN(expression, ".", 2)[0]
+							if !validPrefixes.Has(prefix) {
+								errs = errs.Also(apis.ErrInvalidValue(
+									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+									"value",
+								).ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -207,7 +207,7 @@ func TestPipeline_Validate_Success(t *testing.T) {
 							Name: "name2",
 							Value: ParamValue{
 								Type:      ParamTypeString,
-								StringVal: "$(tasks.pipeline-words.results.hello) + $(pipeline-words)",
+								StringVal: "$(tasks.pipeline-words.results.hello) + $(params.pipeline-words.hello)",
 							},
 						},
 					},
@@ -265,7 +265,7 @@ func TestPipeline_Validate_Success(t *testing.T) {
 							Name: "name2",
 							Value: ParamValue{
 								Type:      ParamTypeString,
-								StringVal: "$(tasks.pipeline-words.results.hello[*]) + $(pipeline-words)",
+								StringVal: "$(tasks.pipeline-words.results.hello[*]) + $(params.pipeline-words.hello)",
 							},
 						},
 					},
@@ -692,6 +692,67 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `PipelineTask OnError cannot be set to "continue" when Retries is greater than 0`,
 			Paths:   []string{""},
+		},
+	}, {
+		name: "invalid variable reference in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env_value_set_from_yq)"},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
+		},
+	}, {
+		name: "invalid variable reference in matrix param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Matrix: &Matrix{
+						Params: Params{{
+							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(invalid_ref)", "image2"}},
+						}},
+					},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].matrix.params[IMAGE].value"},
+		},
+	}, {
+		name: "invalid variable reference in matrix include param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Matrix: &Matrix{
+						Include: IncludeParamsList{{
+							Name: "build-1",
+							Params: Params{{
+								Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(invalid_ref)"},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].matrix.include[0].params[IMAGE].value"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -99,6 +99,8 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validateArtifactReference(ctx, ps.Tasks, ps.Finally))
 	errs = errs.Also(validateMatrix(ctx, ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validateMatrix(ctx, ps.Finally).ViaField("finally"))
+	errs = errs.Also(validateVarSubstitutionExpressions(ps.Tasks, "tasks"))
+	errs = errs.Also(validateVarSubstitutionExpressions(ps.Finally, "finally"))
 	return errs
 }
 
@@ -847,6 +849,69 @@ func validateMatrix(ctx context.Context, tasks []PipelineTask) (errs *apis.Field
 		errs = errs.Also(task.validateMatrix(ctx).ViaIndex(idx))
 	}
 	errs = errs.Also(validateTaskResultsFromMatrixedPipelineTasksConsumed(tasks))
+	return errs
+}
+
+func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) (errs *apis.FieldError) {
+	validPrefixes := sets.NewString("params", "tasks", "finally", "context", "workspaces")
+	for idx, task := range tasks {
+		for _, param := range task.Params {
+			if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
+				for _, expression := range expressions {
+					prefix := strings.SplitN(expression, ".", 2)[0]
+					if !validPrefixes.Has(prefix) {
+						errs = errs.Also(apis.ErrInvalidValue(
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							"value",
+						).ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
+					}
+				}
+			}
+		}
+		for i, we := range task.WhenExpressions {
+			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
+				for _, expression := range expressions {
+					prefix := strings.SplitN(expression, ".", 2)[0]
+					if !validPrefixes.Has(prefix) {
+						errs = errs.Also(apis.ErrInvalidValue(
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							"",
+						).ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
+					}
+				}
+			}
+		}
+		if task.IsMatrixed() {
+			for _, param := range task.Matrix.Params {
+				if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
+					for _, expression := range expressions {
+						prefix := strings.SplitN(expression, ".", 2)[0]
+						if !validPrefixes.Has(prefix) {
+							errs = errs.Also(apis.ErrInvalidValue(
+								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+								"value",
+							).ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
+						}
+					}
+				}
+			}
+			for i, include := range task.Matrix.Include {
+				for _, param := range include.Params {
+					if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
+						for _, expression := range expressions {
+							prefix := strings.SplitN(expression, ".", 2)[0]
+							if !validPrefixes.Has(prefix) {
+								errs = errs.Also(apis.ErrInvalidValue(
+									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+									"value",
+								).ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -620,6 +620,67 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			Message: `PipelineTask OnError cannot be set to "continue" when Retries is greater than 0`,
 			Paths:   []string{""},
 		},
+	}, {
+		name: "invalid variable reference in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env_value_set_from_yq)"},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
+		},
+	}, {
+		name: "invalid variable reference in matrix param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Matrix: &Matrix{
+						Params: Params{{
+							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(invalid_ref)", "image2"}},
+						}},
+					},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].matrix.params[IMAGE].value"},
+		},
+	}, {
+		name: "invalid variable reference in matrix include param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Matrix: &Matrix{
+						Include: IncludeParamsList{{
+							Name: "build-1",
+							Params: Params{{
+								Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(invalid_ref)"},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].matrix.include[0].params[IMAGE].value"},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Fixes #7756
# Changes


When a Pipeline param value contains a `$(...)` expression that doesn't match any valid Tekton variable prefix (e.g., `$(new_image)` where the user meant `${new_image}` for a shell variable), the validation webhook  silently accepts it with no feedback.

This PR:

1. **Adds a bounds check** in `ParseTaskandResultName` (`param_types.go`) to prevent an index-out-of-range panic when the expression has fewer than 4 dot-separated components.

2. **Adds a catch-all validator** (`validateVarSubstitutionExpressions`) in both `v1` and `v1beta1` `pipeline_validation.go` that rejects `$(...)` expressions whose prefix doesn't match any known Tekton variable namespace (`params`, `tasks`, `finally`, `context`, `workspaces`), returning a clear error message like:

    invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, or workspaces: spec.tasks[0].params[SCRIPT].value

created the pipelineRun from here- #7756 . 

**before the change:** (Silently fails)
`pipeline.tekton.dev/example-pipeline created` 

**After the change:**
`Error from server (BadRequest): error when creating "STDIN": admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, or workspaces: spec.tasks[0].params[SCRIPT].value`





***Also edited an existing test that silently passed although should have failed, Replaced the variable name `$(pipeline-words)` with the equivalent valid reference `$(params.pipeline-words.hello)` to match the param already declared in each test.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Pipeline validation now rejects invalid variable references like $(new_image) in task parameters with a clear error message, instead of silently accepting them or crashing the webhook. Users who accidentally use $() (Tekton variable syntax) instead of ${} (shell variable syntax) in Pipeline param values will now receive a helpful validation error indicating the valid prefixes (params, tasks, finally, context, workspaces).
```
