### PR TITLE
fix: preserve previous condition context when TaskRun is cancelled or times out

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -180,6 +180,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	// If the TaskRun is cancelled, kill resources and update status
 	if tr.IsCancelled() {
 		message := fmt.Sprintf("TaskRun %q was cancelled. %s", tr.Name, tr.Spec.StatusMessage)
+		message = appendPreviousConditionContext(before, message)
 		err := c.failTaskRun(ctx, tr, v1.TaskRunReasonCancelled, message)
 		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, err)
 	}
@@ -199,11 +200,15 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 			logger.Warnf("Failed to update step statuses from pod before timeout: %v", err)
 		}
 		message := fmt.Sprintf("TaskRun %q failed to finish within %q", tr.Name, tr.GetTimeout(ctx))
+		message = appendPreviousConditionContext(before, message)
 		err := c.failTaskRun(ctx, tr, v1.TaskRunReasonTimedOut, message)
 		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, err)
 	}
 
 	// Check for Pod Failures
+	// Note: appendPreviousConditionContext is intentionally NOT used here because
+	// checkPodFailed already provides a specific, actionable error message derived
+	// from the current pod state (e.g., ImagePullBackOff, CreateContainerConfigError).
 	if failed, reason, message := c.checkPodFailed(ctx, tr); failed {
 		err := c.failTaskRun(ctx, tr, reason, message)
 		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, err)
@@ -871,6 +876,28 @@ func (c *Reconciler) failTaskRun(ctx context.Context, tr *v1.TaskRun, reason v1.
 	}
 
 	return nil
+}
+
+// appendPreviousConditionContext preserves diagnostic context from the previous Succeeded
+// condition when a TaskRun is being failed (e.g. due to cancellation or timeout). If the
+// condition had a meaningful prior reason (not just Started/Running/Pending), the previous
+// reason and message are appended to the new message so operators can see why the TaskRun
+// was in its prior state. The prevCondition should be captured before InitializeConditions
+// can overwrite it (e.g. the "before" variable from ReconcileKind).
+func appendPreviousConditionContext(prevCondition *apis.Condition, message string) string {
+	if prevCondition == nil {
+		return message
+	}
+	switch prevCondition.Reason {
+	case v1.TaskRunReasonStarted.String(),
+		v1.TaskRunReasonRunning.String(),
+		v1.TaskRunReasonPending.String():
+		return message
+	}
+	if prevCondition.Message != "" {
+		return fmt.Sprintf("%s\nPrevious status: [%s] %s", message, prevCondition.Reason, prevCondition.Message)
+	}
+	return message
 }
 
 // updateStepStatusesFromPod fetches the pod and updates step statuses in the TaskRun

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -8358,10 +8358,10 @@ func TestAppendPreviousConditionContext(t *testing.T) {
 			expectAppend: false,
 		},
 		{
-			name:        "previous reason is ExceededResourceQuota - preserve",
-			prevReason:  "ExceededResourceQuota",
-			prevMessage: `TaskRun Pod exceeded available resources: pods "test-pod" is forbidden: exceeded quota`,
-			newMessage:  "TaskRun was cancelled. TaskRun cancelled as the PipelineRun it belongs to has timed out.",
+			name:         "previous reason is ExceededResourceQuota - preserve",
+			prevReason:   "ExceededResourceQuota",
+			prevMessage:  `TaskRun Pod exceeded available resources: pods "test-pod" is forbidden: exceeded quota`,
+			newMessage:   "TaskRun was cancelled. TaskRun cancelled as the PipelineRun it belongs to has timed out.",
 			expectAppend: true,
 			expectedContains: []string{
 				"TaskRun was cancelled",
@@ -8370,10 +8370,10 @@ func TestAppendPreviousConditionContext(t *testing.T) {
 			},
 		},
 		{
-			name:        "previous reason is ImagePullBackOff - preserve",
-			prevReason:  "TaskRunImagePullFailed",
-			prevMessage: "The step image failed to pull",
-			newMessage:  "TaskRun was cancelled",
+			name:         "previous reason is ImagePullBackOff - preserve",
+			prevReason:   "TaskRunImagePullFailed",
+			prevMessage:  "The step image failed to pull",
+			newMessage:   "TaskRun was cancelled",
 			expectAppend: true,
 			expectedContains: []string{
 				"TaskRun was cancelled",
@@ -8410,10 +8410,8 @@ func TestAppendPreviousConditionContext(t *testing.T) {
 						t.Errorf("Expected result to contain %q, got: %s", expected, result)
 					}
 				}
-			} else {
-				if result != tc.newMessage {
-					t.Errorf("Expected message to be unchanged %q, got: %s", tc.newMessage, result)
-				}
+			} else if result != tc.newMessage {
+				t.Errorf("Expected message to be unchanged %q, got: %s", tc.newMessage, result)
 			}
 		})
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2731,6 +2731,124 @@ status:
 	}
 }
 
+func TestReconcileOnCancelledTaskRunPreservesPreviousCondition(t *testing.T) {
+	taskRun := parse.MustParseV1TaskRun(t, `
+metadata:
+  name: test-taskrun-quota-then-cancelled
+  namespace: foo
+spec:
+  status: TaskRunCancelled
+  statusMessage: "TaskRun cancelled as the PipelineRun it belongs to has timed out."
+  taskRef:
+    name: test-task
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+    reason: ExceededResourceQuota
+    message: 'TaskRun Pod exceeded available resources: pods "test-pod" is forbidden: exceeded quota'
+  podName: test-taskrun-quota-then-cancelled-pod
+`)
+	pod, err := makePod(taskRun, simpleTask)
+	if err != nil {
+		t.Fatalf("MakePod: %v", err)
+	}
+	d := test.Data{
+		TaskRuns: []*v1.TaskRun{taskRun},
+		Tasks:    []*v1.Task{simpleTask},
+		Pods:     []*corev1.Pod{pod},
+	}
+
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(taskRun)); err != nil {
+		t.Fatalf("Unexpected error when reconciling completed TaskRun : %v", err)
+	}
+	newTr, err := clients.Pipeline.TektonV1().TaskRuns(taskRun.Namespace).Get(testAssets.Ctx, taskRun.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Expected completed TaskRun %s to exist but instead got error when getting it: %v", taskRun.Name, err)
+	}
+
+	cond := newTr.Status.GetCondition(apis.ConditionSucceeded)
+	if cond == nil {
+		t.Fatal("Expected Succeeded condition to be set")
+	}
+	if cond.Status != corev1.ConditionFalse {
+		t.Errorf("Expected condition status False, got %s", cond.Status)
+	}
+	if cond.Reason != v1.TaskRunReasonCancelled.String() {
+		t.Errorf("Expected reason %s, got %s", v1.TaskRunReasonCancelled.String(), cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "ExceededResourceQuota") {
+		t.Errorf("Expected condition message to contain previous reason ExceededResourceQuota, got: %s", cond.Message)
+	}
+	if !strings.Contains(cond.Message, "exceeded quota") {
+		t.Errorf("Expected condition message to contain previous message about exceeded quota, got: %s", cond.Message)
+	}
+	if !strings.Contains(cond.Message, "TaskRun cancelled as the PipelineRun it belongs to has timed out.") {
+		t.Errorf("Expected condition message to contain the cancellation reason, got: %s", cond.Message)
+	}
+}
+
+func TestReconcileOnTimedOutTaskRunPreservesPreviousCondition(t *testing.T) {
+	taskRun := parse.MustParseV1TaskRun(t, `
+metadata:
+  name: test-taskrun-quota-then-timedout
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+  timeout: 10s
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+    reason: ExceededResourceQuota
+    message: 'TaskRun Pod exceeded available resources: pods "test-pod" is forbidden: exceeded quota'
+  startTime: "2021-12-31T23:59:45Z"
+`)
+	d := test.Data{
+		TaskRuns: []*v1.TaskRun{taskRun},
+		Tasks:    []*v1.Task{simpleTask},
+	}
+
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	if err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(taskRun)); err != nil {
+		t.Fatalf("Unexpected error when reconciling timed out TaskRun : %v", err)
+	}
+	newTr, err := clients.Pipeline.TektonV1().TaskRuns(taskRun.Namespace).Get(testAssets.Ctx, taskRun.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Expected timed out TaskRun %s to exist but instead got error when getting it: %v", taskRun.Name, err)
+	}
+
+	cond := newTr.Status.GetCondition(apis.ConditionSucceeded)
+	if cond == nil {
+		t.Fatal("Expected Succeeded condition to be set")
+	}
+	if cond.Status != corev1.ConditionFalse {
+		t.Errorf("Expected condition status False, got %s", cond.Status)
+	}
+	if cond.Reason != v1.TaskRunReasonTimedOut.String() {
+		t.Errorf("Expected reason %s, got %s", v1.TaskRunReasonTimedOut.String(), cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "failed to finish within") {
+		t.Errorf("Expected condition message to contain timeout message, got: %s", cond.Message)
+	}
+	if !strings.Contains(cond.Message, "ExceededResourceQuota") {
+		t.Errorf("Expected condition message to contain previous reason ExceededResourceQuota, got: %s", cond.Message)
+	}
+	if !strings.Contains(cond.Message, "exceeded quota") {
+		t.Errorf("Expected condition message to contain previous message about exceeded quota, got: %s", cond.Message)
+	}
+}
+
 func TestReconcileOnTimedOutTaskRun(t *testing.T) {
 	taskRun := parse.MustParseV1TaskRun(t, `
 metadata:
@@ -8201,5 +8319,102 @@ spec:
 	}
 	if !reconciledTekton.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
 		t.Errorf("Expected Tekton-managed TaskRun to be running, but it was not")
+	}
+}
+
+func TestAppendPreviousConditionContext(t *testing.T) {
+	tests := []struct {
+		name             string
+		prevReason       string
+		prevMessage      string
+		newMessage       string
+		expectAppend     bool
+		expectedContains []string
+	}{
+		{
+			name:         "no previous condition",
+			newMessage:   "TaskRun was cancelled",
+			expectAppend: false,
+		},
+		{
+			name:         "previous reason is Started - skip",
+			prevReason:   v1.TaskRunReasonStarted.String(),
+			prevMessage:  "some message",
+			newMessage:   "TaskRun was cancelled",
+			expectAppend: false,
+		},
+		{
+			name:         "previous reason is Running - skip",
+			prevReason:   v1.TaskRunReasonRunning.String(),
+			prevMessage:  "Not all Steps in the Task have finished executing",
+			newMessage:   "TaskRun was cancelled",
+			expectAppend: false,
+		},
+		{
+			name:         "previous reason is Pending - skip",
+			prevReason:   v1.TaskRunReasonPending.String(),
+			prevMessage:  "TaskRun is pending",
+			newMessage:   "TaskRun was cancelled",
+			expectAppend: false,
+		},
+		{
+			name:        "previous reason is ExceededResourceQuota - preserve",
+			prevReason:  "ExceededResourceQuota",
+			prevMessage: `TaskRun Pod exceeded available resources: pods "test-pod" is forbidden: exceeded quota`,
+			newMessage:  "TaskRun was cancelled. TaskRun cancelled as the PipelineRun it belongs to has timed out.",
+			expectAppend: true,
+			expectedContains: []string{
+				"TaskRun was cancelled",
+				"ExceededResourceQuota",
+				"exceeded quota",
+			},
+		},
+		{
+			name:        "previous reason is ImagePullBackOff - preserve",
+			prevReason:  "TaskRunImagePullFailed",
+			prevMessage: "The step image failed to pull",
+			newMessage:  "TaskRun was cancelled",
+			expectAppend: true,
+			expectedContains: []string{
+				"TaskRun was cancelled",
+				"TaskRunImagePullFailed",
+				"failed to pull",
+			},
+		},
+		{
+			name:         "previous condition has empty message - skip",
+			prevReason:   "SomeReason",
+			prevMessage:  "",
+			newMessage:   "TaskRun was cancelled",
+			expectAppend: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var prevCondition *apis.Condition
+			if tc.prevReason != "" {
+				prevCondition = &apis.Condition{
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionUnknown,
+					Reason:  tc.prevReason,
+					Message: tc.prevMessage,
+				}
+			}
+
+			result := appendPreviousConditionContext(prevCondition, tc.newMessage)
+
+			if tc.expectAppend {
+				for _, expected := range tc.expectedContains {
+					if !strings.Contains(result, expected) {
+						t.Errorf("Expected result to contain %q, got: %s", expected, result)
+					}
+				}
+			} else {
+				if result != tc.newMessage {
+					t.Errorf("Expected message to be unchanged %q, got: %s", tc.newMessage, result)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
When a PipelineRun times out and cancels its child TaskRuns, the cancellation overwrites the TaskRun's status.conditions with the timeout/cancellation reason, losing whatever the previous condition was (e.g., ExceededResourceQuota).

This adds appendPreviousConditionContext() which appends the previous condition's reason and message to the new failure message when the prior condition had a meaningful reason (not Started/Running/Pending).

Fixes #10075

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Preserve previous TaskRun condition context (reason + message) when a TaskRun is cancelled or times out due to a PipelineRun timeout, so diagnostic information like ExceededResourceQuota is no longer lost.
```
