### PR TITLE
Fix cross-arch platform command lookup in entrypoint

### DIFF
--- a/cmd/entrypoint/platform_test.go
+++ b/cmd/entrypoint/platform_test.go
@@ -61,6 +61,18 @@ func TestSelectCommandForPlatform(t *testing.T) {
 		},
 		plat: "linux/amd64/v8",
 		want: []string{"my", "command"},
+	}, {
+		// Regression test for https://github.com/tektoncd/pipeline/issues/10073
+		// When the controller resolves a single-platform image, the map key
+		// won't have a variant. The entrypoint on ARM will look up with
+		// its variant (e.g., "linux/arm64/v8") and should fall back to
+		// the key without variant.
+		desc: "arm64 entrypoint with variant looks up key without variant",
+		m: map[string][]string{
+			"linux/arm64": {"my", "command"},
+		},
+		plat: "linux/arm64/v8",
+		want: []string{"my", "command"},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			got, err := selectCommandForPlatform(c.m, c.plat)

--- a/pkg/pod/entrypoint_lookup_impl.go
+++ b/pkg/pod/entrypoint_lookup_impl.go
@@ -173,16 +173,17 @@ func imageInfo(img v1.Image, hasArgs bool) (cmd []string, platform string, err e
 		ep = append(ep, cf.Config.Cmd...)
 	}
 
-	platformObj := platforms.NewPlatform()
-	platformObj.OS = cf.OS
-	platformObj.Architecture = cf.Architecture
-	// A single image's config metadata doesn't include the CPU
-	// architecture variant, but we'll assume this is okay since
-	// the runtime node's image selection will also select the same
-	// image. This will only be a problem if the image is a
-	// single-platform image that happens to specify a variant, and
-	// the runtime node it gets assigned to has a value for
-	// runtime.GOARM.
+	// Build the platform string from the image's config metadata.
+	// We intentionally do NOT include the controller's CPU variant here:
+	// when the controller runs on a different architecture (e.g., ARM
+	// controller resolving an amd64 image), the controller's variant
+	// would leak into the key (e.g., "linux/amd64/v8"), causing the
+	// entrypoint to fail to find the command for "linux/amd64".
+	// See https://github.com/tektoncd/pipeline/issues/10073
+	platformObj := &platforms.Platform{
+		OS:           cf.OS,
+		Architecture: cf.Architecture,
+	}
 	platform = platformObj.Format()
 
 	return ep, platform, nil

--- a/pkg/pod/entrypoint_lookup_impl_test.go
+++ b/pkg/pod/entrypoint_lookup_impl_test.go
@@ -348,3 +348,73 @@ func TestImageInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestImageInfo_PlatformDoesNotLeakControllerVariant(t *testing.T) {
+	// Regression test for https://github.com/tektoncd/pipeline/issues/10073
+	//
+	// When the controller runs on ARM (which has a CPU variant like "v8"),
+	// and resolves a single-platform amd64 image, the platform key must
+	// NOT include the controller's variant. It should be "linux/amd64",
+	// not "linux/amd64/v8".
+	tests := []struct {
+		name         string
+		os           string
+		arch         string
+		entrypoint   []string
+		wantPlatform string
+	}{{
+		name:         "amd64 image should not have variant",
+		os:           "linux",
+		arch:         "amd64",
+		entrypoint:   []string{"/bin/sh"},
+		wantPlatform: "linux/amd64",
+	}, {
+		name:         "arm64 image should not have variant from controller",
+		os:           "linux",
+		arch:         "arm64",
+		entrypoint:   []string{"/bin/sh"},
+		wantPlatform: "linux/arm64",
+	}, {
+		name:         "windows amd64 image",
+		os:           "windows",
+		arch:         "amd64",
+		entrypoint:   []string{"cmd.exe"},
+		wantPlatform: "windows/amd64",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			img, err := random.Image(1, 1)
+			if err != nil {
+				t.Fatalf("random.Image: %v", err)
+			}
+
+			cf, err := img.ConfigFile()
+			if err != nil {
+				t.Fatalf("ConfigFile: %v", err)
+			}
+			cf.OS = tc.os
+			cf.Architecture = tc.arch
+			cf.Config.Entrypoint = tc.entrypoint
+
+			img, err = mutate.ConfigFile(img, cf)
+			if err != nil {
+				t.Fatalf("mutate.ConfigFile: %v", err)
+			}
+
+			_, platform, err := imageInfo(img, false)
+			if err != nil {
+				t.Fatalf("imageInfo: %v", err)
+			}
+
+			if platform != tc.wantPlatform {
+				t.Errorf("imageInfo platform = %q, want %q (controller variant may have leaked)", platform, tc.wantPlatform)
+			}
+
+			// Verify no CPU variant is present in the platform string.
+			if strings.Count(platform, "/") > 1 {
+				t.Errorf("platform %q contains a CPU variant, which should not be set from single-image config", platform)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

When the Tekton controller runs on ARM (e.g., `arm64/v8`) and resolves
entrypoint commands for single-platform images, `imageInfo()` called
`platforms.NewPlatform()` which picks up the controller's CPU variant,
then only overrode `OS` and `Architecture` from the image config. This
caused the controller's variant to leak into the `TEKTON_PLATFORM_COMMANDS`
map key (e.g., `linux/amd64/v8`). When the entrypoint runs on an `amd64`
node and looks up `linux/amd64`, the key doesn't match, causing:

```
could not find command for platform "linux/amd64"
```

### Root cause fix

The fix constructs the `Platform` directly from the image's config metadata
instead of using `NewPlatform()`, so the controller's runtime variant never
leaks into the key. For single-platform images, variant information isn't
available in the image config anyway (it's only in index manifest platform
descriptors, which `buildCommandMap` already handles correctly).

The existing entrypoint fallback in `selectCommandForPlatform()` already
handles the reverse case (entrypoint has variant, key doesn't) — this was
the originally intended design.

### Tests added

- `TestImageInfo_PlatformDoesNotLeakControllerVariant` in `pkg/pod/` — verifies the controller doesn't inject its variant into map keys
- `arm64 entrypoint with variant looks up key without variant` in `cmd/entrypoint/` — verifies the entrypoint fallback works for the resulting key format

Fixes #10073

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [x] Has a kind label
- [x] Release notes block below has been updated

# Release Notes

```release-note
Fix entrypoint command lookup when controller and worker nodes run on different CPU architectures (e.g., ARM controller with AMD64 workloads). The controller's CPU variant was leaking into TEKTON_PLATFORM_COMMANDS keys via platforms.NewPlatform(), causing "could not find command for platform" errors on worker nodes of a different architecture.
```