### PR TITLE
Block private-network dials in hub and bundle resolvers (#9602)

### DIFF
--- a/config/resolvers/bundleresolver-config.yaml
+++ b/config/resolvers/bundleresolver-config.yaml
@@ -31,3 +31,9 @@ data:
   # "never"  - Never cache resolved resources
   # "auto"   - Only cache bundles with digest references (@sha256:...)
   # default-cache-mode: "auto"
+  # Refuse to dial private network address classes (loopback, RFC1918/
+  # RFC4193, link-local, multicast, CGNAT, unspecified) when fetching
+  # bundle images. Defaults to "true". Set to "false" if you need the
+  # bundle resolver to reach an in-cluster registry (a Service ClusterIP,
+  # a sidecar, etc.) or another intentionally-private endpoint.
+  # block-private-ips: "true"

--- a/config/resolvers/hubresolver-config.yaml
+++ b/config/resolvers/hubresolver-config.yaml
@@ -43,3 +43,9 @@ data:
   # URLs must use http or https scheme.
   # tekton-hub-urls: |
   #   - https://api.hub.tekton.dev/
+  # Refuse to dial private network address classes (loopback, RFC1918/
+  # RFC4193, link-local, multicast, CGNAT, unspecified) when fetching
+  # from the Tekton Hub or Artifact Hub. Defaults to "true". Set to
+  # "false" if you need the hub resolver to reach an in-cluster hub
+  # mirror or another intentionally-private endpoint.
+  # block-private-ips: "true"

--- a/pkg/remoteresolution/resolver/bundle/dialerblock_test.go
+++ b/pkg/remoteresolution/resolver/bundle/dialerblock_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bundle_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	bundleresolution "github.com/tektoncd/pipeline/pkg/resolution/resolver/bundle"
+)
+
+// TestMain installs a permissive registry transport for the duration of
+// the package's test suite so the broader bundle test cases that talk to
+// loopback httptest registries keep working. The dial guard is exercised
+// explicitly by TestBundleRetrieveImageRejectsPrivateNetwork.
+func TestMain(m *testing.M) {
+	bundleresolution.SetRegistryTransportForTest(http.DefaultTransport)
+	os.Exit(m.Run())
+}
+
+// TestBundleRetrieveImageRejectsPrivateNetwork mirrors the address-class
+// table from the deprecated bundle resolver.
+func TestBundleRetrieveImageRejectsPrivateNetwork(t *testing.T) {
+	prev := bundleresolution.ResetRegistryTransportForTest()
+	t.Cleanup(func() { bundleresolution.SetRegistryTransportForTest(prev) })
+
+	cases := []struct {
+		name string
+		ref  string
+	}{
+		{name: "loopback v4 literal", ref: "127.0.0.1:5000/foo:bar"},
+		{name: "rfc1918 10.x", ref: "10.0.0.1:5000/foo:bar"},
+		{name: "rfc1918 172.16", ref: "172.16.0.5:5000/foo:bar"},
+		{name: "rfc1918 192.168", ref: "192.168.1.1:5000/foo:bar"},
+		{name: "link-local 169.254", ref: "169.254.169.254:5000/foo:bar"},
+		{name: "cgnat 100.64", ref: "100.64.0.1:5000/foo:bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := bundleresolution.RequestOptions{Bundle: tc.ref, EntryName: "n", Kind: "task"}
+			_, err := bundleresolution.GetEntry(context.Background(), authn.DefaultKeychain, opts)
+			if err == nil {
+				t.Fatalf("expected dial guard to reject %s", tc.ref)
+			}
+			if !strings.Contains(err.Error(), "restricted dial") {
+				t.Fatalf("expected restricted-dial error, got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/remoteresolution/resolver/hub/dialerblock_test.go
+++ b/pkg/remoteresolution/resolver/hub/dialerblock_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hub
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+)
+
+// TestMain installs a permissive HTTP client for the duration of the
+// package's test suite. Existing tests rely on httptest.Server instances
+// bound to 127.0.0.1, which the production dial guard correctly refuses.
+// The guard itself is exercised explicitly by tests that call
+// installRestrictedClientForTest to reinstall the restricted transport.
+func TestMain(m *testing.M) {
+	hubHTTPClient = &http.Client{Transport: http.DefaultTransport}
+	os.Exit(m.Run())
+}
+
+// installRestrictedClientForTest swaps hubHTTPClient for the production
+// restricted-transport client for the duration of the calling test.
+func installRestrictedClientForTest(t *testing.T) {
+	t.Helper()
+	original := hubHTTPClient
+	hubHTTPClient = &http.Client{Transport: resolutionframework.RestrictedHTTPTransport()}
+	t.Cleanup(func() { hubHTTPClient = original })
+}
+
+// TestFetchHubResourceRejectsPrivateNetwork exercises the dial guard
+// installed on the package-level hubHTTPClient: any request whose URL
+// resolves to a loopback / private / link-local / CGNAT / multicast
+// address must fail at dial time.
+func TestFetchHubResourceRejectsPrivateNetwork(t *testing.T) {
+	installRestrictedClientForTest(t)
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{name: "loopback v4 literal", url: "http://127.0.0.1:80/foo"},
+		{name: "loopback v6 literal", url: "http://[::1]:80/foo"},
+		{name: "rfc1918 10.x", url: "http://10.0.0.1:80/foo"},
+		{name: "rfc1918 172.16", url: "http://172.16.0.5:80/foo"},
+		{name: "rfc1918 192.168", url: "http://192.168.1.1:80/foo"},
+		{name: "link-local 169.254", url: "http://169.254.169.254:80/foo"},
+		{name: "cgnat 100.64", url: "http://100.64.0.1:80/foo"},
+		{name: "ipv6 ula", url: "http://[fd00::1]:80/foo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resp any
+			err := fetchHubResource(context.Background(), tc.url, &resp)
+			if err == nil {
+				t.Fatalf("expected dial guard to reject %s", tc.url)
+			}
+			if !strings.Contains(err.Error(), "restricted dial") {
+				t.Fatalf("expected restricted-dial error, got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/remoteresolution/resolver/hub/resolve.go
+++ b/pkg/remoteresolution/resolver/hub/resolve.go
@@ -33,6 +33,15 @@ import (
 
 var errNoVersionFound = errors.New("no version found")
 
+// hubHTTPClient is the package-level HTTP client used to talk to a Hub
+// endpoint. It wires resolutionframework.RestrictedHTTPTransport so DNS
+// resolution to loopback / private / link-local addresses is refused at
+// dial time, addressing the "block private IPs" goal in #9602 for the
+// hub resolver.
+var hubHTTPClient = &http.Client{
+	Transport: resolutionframework.RestrictedHTTPTransport(),
+}
+
 // Response types for hub API calls.
 
 type tektonHubDataResponse struct {
@@ -111,7 +120,7 @@ func fetchHubResource(ctx context.Context, apiEndpoint string, v any) error {
 	}
 
 	// #nosec G704 -- URL cannot be constant in this case.
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := hubHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("requesting resource from Hub: %w", err)
 	}

--- a/pkg/remoteresolution/resolver/hub/resolve.go
+++ b/pkg/remoteresolution/resolver/hub/resolve.go
@@ -34,12 +34,27 @@ import (
 var errNoVersionFound = errors.New("no version found")
 
 // hubHTTPClient is the package-level HTTP client used to talk to a Hub
-// endpoint. It wires resolutionframework.RestrictedHTTPTransport so DNS
-// resolution to loopback / private / link-local addresses is refused at
-// dial time, addressing the "block private IPs" goal in #9602 for the
-// hub resolver.
+// endpoint when the hubresolver-config `block-private-ips` toggle is at
+// its secure-by-default value of "true". It wires
+// resolutionframework.RestrictedHTTPTransport so DNS resolution to
+// loopback / private / link-local addresses is refused at dial time,
+// addressing the "block private IPs" goal in #9602 for the hub
+// resolver. When operators opt out by setting
+// `block-private-ips: "false"` in hubresolver-config, fetchHubResource
+// uses the stdlib default client instead.
 var hubHTTPClient = &http.Client{
 	Transport: resolutionframework.RestrictedHTTPTransport(),
+}
+
+// hubHTTPClientForCtx returns the HTTP client fetchHubResource should
+// use for ctx. When ctx carries a hubresolver-config ConfigMap with
+// `block-private-ips: "false"`, the stdlib default client is returned so
+// in-cluster or otherwise-private Hub endpoints become reachable.
+func hubHTTPClientForCtx(ctx context.Context) *http.Client {
+	if resolutionframework.BlockPrivateIPs(ctx) {
+		return hubHTTPClient
+	}
+	return http.DefaultClient
 }
 
 // Response types for hub API calls.
@@ -120,7 +135,7 @@ func fetchHubResource(ctx context.Context, apiEndpoint string, v any) error {
 	}
 
 	// #nosec G704 -- URL cannot be constant in this case.
-	resp, err := hubHTTPClient.Do(req)
+	resp, err := hubHTTPClientForCtx(ctx).Do(req)
 	if err != nil {
 		return fmt.Errorf("requesting resource from Hub: %w", err)
 	}

--- a/pkg/resolution/resolver/bundle/bundle.go
+++ b/pkg/resolution/resolver/bundle/bundle.go
@@ -31,12 +31,17 @@ import (
 )
 
 // bundleRegistryTransport is the package-level HTTP transport used to talk
-// to the OCI registry when fetching tekton bundles. Its dialer refuses
-// connections to loopback, RFC1918, link-local, multicast, CGNAT and IPv6
-// ULA addresses, applying the "block private IPs" goal of #9602 to the
-// bundle resolver's OCI fetch path. Exposed as a package variable so tests
-// that rely on a loopback httptest registry can swap in an unrestricted
-// transport for their duration via SetRegistryTransportForTest.
+// to the OCI registry when fetching tekton bundles when the
+// bundleresolver-config `block-private-ips` toggle is at its secure-by-
+// default value of "true". Its dialer refuses connections to loopback,
+// RFC1918, link-local, multicast, CGNAT and IPv6 ULA addresses, applying
+// the "block private IPs" goal of #9602 to the bundle resolver's OCI
+// fetch path. Exposed as a package variable so tests that rely on a
+// loopback httptest registry can swap in an unrestricted transport for
+// their duration via SetRegistryTransportForTest. Operators who need to
+// reach an in-cluster registry can opt out by setting
+// `block-private-ips: "false"` in the bundleresolver-config ConfigMap,
+// which causes retrieveImage to use the stdlib default transport.
 var bundleRegistryTransport http.RoundTripper = framework.RestrictedHTTPTransport()
 
 // SetRegistryTransportForTest swaps the package-level OCI registry
@@ -178,7 +183,17 @@ func retrieveImage(ctx context.Context, keychain authn.Keychain, ref string) (st
 	// / RFC1918 / link-local / CGNAT / IPv6 ULA addresses. Without this,
 	// name.ParseReference accepts references like 169.254.169.254/foo:bar
 	// and remote.Image dials them from inside the controller pod.
-	transportOpt := remote.WithTransport(bundleRegistryTransport)
+	//
+	// Operators who intentionally point the bundle resolver at an
+	// in-cluster registry (a Service ClusterIP, a sidecar, or a private
+	// endpoint) can opt out by setting `block-private-ips: "false"` in
+	// the bundleresolver-config ConfigMap, in which case the stdlib
+	// default transport is used instead.
+	transport := bundleRegistryTransport
+	if !framework.BlockPrivateIPs(ctx) {
+		transport = http.DefaultTransport
+	}
+	transportOpt := remote.WithTransport(transport)
 	customRetryBackoff, err := GetBundleResolverBackoff(ctx)
 	if err == nil {
 		img, err := remote.Image(imgRef, remote.WithAuthFromKeychain(keychain), remote.WithContext(ctx),

--- a/pkg/resolution/resolver/bundle/bundle.go
+++ b/pkg/resolution/resolver/bundle/bundle.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -28,6 +29,35 @@ import (
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
 )
+
+// bundleRegistryTransport is the package-level HTTP transport used to talk
+// to the OCI registry when fetching tekton bundles. Its dialer refuses
+// connections to loopback, RFC1918, link-local, multicast, CGNAT and IPv6
+// ULA addresses, applying the "block private IPs" goal of #9602 to the
+// bundle resolver's OCI fetch path. Exposed as a package variable so tests
+// that rely on a loopback httptest registry can swap in an unrestricted
+// transport for their duration via SetRegistryTransportForTest.
+var bundleRegistryTransport http.RoundTripper = framework.RestrictedHTTPTransport()
+
+// SetRegistryTransportForTest swaps the package-level OCI registry
+// transport and returns the previous value. Production callers must never
+// invoke this — it exists so the broader test suite can install a
+// permissive transport that allows loopback dials to httptest registries.
+// Restoring the returned RoundTripper is the caller's responsibility.
+func SetRegistryTransportForTest(t http.RoundTripper) http.RoundTripper {
+	prev := bundleRegistryTransport
+	bundleRegistryTransport = t
+	return prev
+}
+
+// ResetRegistryTransportForTest reinstalls the production restricted
+// transport and returns the prior value so tests that need to exercise the
+// dial guard explicitly can restore whatever was installed before.
+func ResetRegistryTransportForTest() http.RoundTripper {
+	prev := bundleRegistryTransport
+	bundleRegistryTransport = framework.RestrictedHTTPTransport()
+	return prev
+}
 
 const (
 	// MaximumBundleObjects defines the maximum number of objects in a bundle
@@ -143,14 +173,21 @@ func retrieveImage(ctx context.Context, keychain authn.Keychain, ref string) (st
 	if err != nil {
 		return "", nil, fmt.Errorf("%s is an unparseable image reference: %w", ref, err)
 	}
+	// remote.WithTransport routes all registry traffic — auth challenge,
+	// manifest, layers — through a transport whose dialer rejects loopback
+	// / RFC1918 / link-local / CGNAT / IPv6 ULA addresses. Without this,
+	// name.ParseReference accepts references like 169.254.169.254/foo:bar
+	// and remote.Image dials them from inside the controller pod.
+	transportOpt := remote.WithTransport(bundleRegistryTransport)
 	customRetryBackoff, err := GetBundleResolverBackoff(ctx)
 	if err == nil {
 		img, err := remote.Image(imgRef, remote.WithAuthFromKeychain(keychain), remote.WithContext(ctx),
-			remote.WithRetryBackoff(customRetryBackoff))
+			remote.WithRetryBackoff(customRetryBackoff), transportOpt)
 
 		return imgRef.Context().Name(), img, err
 	} else {
-		img, err := remote.Image(imgRef, remote.WithAuthFromKeychain(keychain), remote.WithContext(ctx))
+		img, err := remote.Image(imgRef, remote.WithAuthFromKeychain(keychain), remote.WithContext(ctx),
+			transportOpt)
 
 		return imgRef.Context().Name(), img, err
 	}

--- a/pkg/resolution/resolver/bundle/dialerblock_test.go
+++ b/pkg/resolution/resolver/bundle/dialerblock_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bundle_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/tektoncd/pipeline/pkg/resolution/resolver/bundle"
+)
+
+// TestMain installs a permissive registry transport for the duration of
+// the package's test suite so the broader bundle test cases that talk to
+// loopback httptest registries keep working. The dial guard is exercised
+// explicitly by tests that call ResetRegistryTransportForTest.
+func TestMain(m *testing.M) {
+	bundle.SetRegistryTransportForTest(http.DefaultTransport)
+	os.Exit(m.Run())
+}
+
+// TestBundleRetrieveImageRejectsPrivateNetwork verifies that the dial
+// guard on the bundle registry transport refuses to dial loopback,
+// RFC1918, link-local, CGNAT and IPv6 ULA addresses, even when
+// name.ParseReference accepts the reference.
+func TestBundleRetrieveImageRejectsPrivateNetwork(t *testing.T) {
+	prev := bundle.ResetRegistryTransportForTest()
+	t.Cleanup(func() { bundle.SetRegistryTransportForTest(prev) })
+
+	cases := []struct {
+		name string
+		ref  string
+	}{
+		{name: "loopback v4 literal", ref: "127.0.0.1:5000/foo:bar"},
+		{name: "rfc1918 10.x", ref: "10.0.0.1:5000/foo:bar"},
+		{name: "rfc1918 172.16", ref: "172.16.0.5:5000/foo:bar"},
+		{name: "rfc1918 192.168", ref: "192.168.1.1:5000/foo:bar"},
+		{name: "link-local 169.254", ref: "169.254.169.254:5000/foo:bar"},
+		{name: "cgnat 100.64", ref: "100.64.0.1:5000/foo:bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := bundle.RequestOptions{Bundle: tc.ref, EntryName: "n", Kind: "task"}
+			_, err := bundle.GetEntry(context.Background(), authn.DefaultKeychain, opts)
+			if err == nil {
+				t.Fatalf("expected dial guard to reject %s", tc.ref)
+			}
+			if !strings.Contains(err.Error(), "restricted dial") {
+				t.Fatalf("expected restricted-dial error, got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/resolution/resolver/framework/dialerblock.go
+++ b/pkg/resolution/resolver/framework/dialerblock.go
@@ -14,12 +14,59 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
 	"syscall"
 	"time"
 )
+
+// BlockPrivateIPsConfigKey is the resolver ConfigMap key that toggles the
+// dial guard. When unset or "true", the resolver refuses to dial private
+// network address classes. When "false", the resolver falls back to the
+// stdlib default transport so operators can point bundle/hub resolution at
+// in-cluster registries or other private endpoints.
+const BlockPrivateIPsConfigKey = "block-private-ips"
+
+// DefaultBlockPrivateIPs is the default value applied when
+// BlockPrivateIPsConfigKey is missing from a resolver's ConfigMap. The
+// secure-by-default position is to block private targets.
+const DefaultBlockPrivateIPs = true
+
+// BlockPrivateIPs reports whether the resolver should refuse to dial
+// loopback / RFC1918 / RFC4193 / link-local / multicast / CGNAT /
+// unspecified addresses. Reads BlockPrivateIPsConfigKey from the
+// resolver-scoped ConfigMap attached to ctx by the framework; falls back
+// to DefaultBlockPrivateIPs when the ConfigMap or key is absent.
+func BlockPrivateIPs(ctx context.Context) bool {
+	conf := GetResolverConfigFromContext(ctx)
+	if conf == nil {
+		return DefaultBlockPrivateIPs
+	}
+	v, ok := conf[BlockPrivateIPsConfigKey]
+	if !ok {
+		return DefaultBlockPrivateIPs
+	}
+	switch v {
+	case "false", "False", "FALSE", "0", "no", "No", "off", "Off":
+		return false
+	default:
+		return true
+	}
+}
+
+// ResolverHTTPTransport returns the *http.Transport a resolver should use
+// for outbound HTTP / OCI registry traffic. When BlockPrivateIPs(ctx) is
+// true the dialer refuses private/loopback/link-local/multicast/CGNAT/
+// unspecified addresses; when false the stdlib default transport is used
+// so operators can intentionally target in-cluster or private endpoints.
+func ResolverHTTPTransport(ctx context.Context) http.RoundTripper {
+	if BlockPrivateIPs(ctx) {
+		return RestrictedHTTPTransport()
+	}
+	return http.DefaultTransport
+}
 
 // RestrictedAddrError is returned by the dial control callback when a
 // connection target resolves to a disallowed address class (loopback,

--- a/pkg/resolution/resolver/framework/dialerblock.go
+++ b/pkg/resolution/resolver/framework/dialerblock.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// RestrictedAddrError is returned by the dial control callback when a
+// connection target resolves to a disallowed address class (loopback,
+// private, link-local, multicast, or unspecified).
+type RestrictedAddrError struct {
+	Address string
+	Reason  string
+}
+
+func (e *RestrictedAddrError) Error() string {
+	return fmt.Sprintf("restricted dial: refusing to dial %s: %s", e.Address, e.Reason)
+}
+
+// isDisallowedIP reports whether ip belongs to an address class that the
+// resolver-side dial guard refuses to dial. The categories follow the
+// "block-private-ips" goal tracked in issue #9602.
+func isDisallowedIP(ip net.IP) (bool, string) {
+	if ip == nil {
+		return true, "unparseable IP"
+	}
+	if ip.IsUnspecified() {
+		return true, "unspecified address"
+	}
+	if ip.IsLoopback() {
+		return true, "loopback address"
+	}
+	if ip.IsPrivate() {
+		return true, "RFC1918/RFC4193 private address"
+	}
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return true, "link-local address"
+	}
+	if ip.IsMulticast() {
+		return true, "multicast address"
+	}
+	if ip.IsInterfaceLocalMulticast() {
+		return true, "interface-local multicast address"
+	}
+	// CGNAT / RFC6598 100.64.0.0/10 — not flagged by IsPrivate but should
+	// not be a resolver target.
+	if v4 := ip.To4(); v4 != nil {
+		if v4[0] == 100 && v4[1]&0xc0 == 64 {
+			return true, "RFC6598 CGNAT address"
+		}
+	}
+	return false, ""
+}
+
+// verifyAddrAllowed verifies that the given network/address pair (as passed
+// to net.Dialer.Control) resolves only to addresses that are safe to dial
+// from a resolver running inside the Tekton controller pod.
+func verifyAddrAllowed(network, address string) error {
+	switch network {
+	case "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6":
+	default:
+		return &RestrictedAddrError{Address: address, Reason: "unsupported network " + network}
+	}
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return &RestrictedAddrError{Address: address, Reason: err.Error()}
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return &RestrictedAddrError{Address: address, Reason: "address is not a literal IP after resolution"}
+	}
+	if bad, reason := isDisallowedIP(ip); bad {
+		return &RestrictedAddrError{Address: address, Reason: reason}
+	}
+	return nil
+}
+
+// BlockPrivateNetworkControl is intended for use as net.Dialer.Control. It
+// is invoked after DNS resolution and immediately before connect(2), so
+// checking the resolved address here closes the time-of-check / time-of-use
+// gap that a pre-dial DNS lookup would leave open.
+func BlockPrivateNetworkControl(network, address string, _ syscall.RawConn) error {
+	return verifyAddrAllowed(network, address)
+}
+
+// RestrictedHTTPTransport returns an *http.Transport whose dialer rejects
+// connections to disallowed address classes. The transport otherwise mirrors
+// http.DefaultTransport.
+func RestrictedHTTPTransport() *http.Transport {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   BlockPrivateNetworkControl,
+	}
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DialContext = dialer.DialContext
+	return t
+}

--- a/pkg/resolution/resolver/framework/dialerblock_test.go
+++ b/pkg/resolution/resolver/framework/dialerblock_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestBlockPrivateNetworkControl(t *testing.T) {
+	cases := []struct {
+		name    string
+		network string
+		address string
+		blocked bool
+	}{
+		{name: "ipv4 loopback", network: "tcp", address: "127.0.0.1:80", blocked: true},
+		{name: "ipv4 loopback range", network: "tcp", address: "127.5.4.3:443", blocked: true},
+		{name: "ipv4 rfc1918 10.x", network: "tcp", address: "10.0.0.1:80", blocked: true},
+		{name: "ipv4 rfc1918 172.16", network: "tcp", address: "172.16.0.5:80", blocked: true},
+		{name: "ipv4 rfc1918 192.168", network: "tcp", address: "192.168.1.1:80", blocked: true},
+		{name: "ipv4 link-local 169.254", network: "tcp", address: "169.254.169.254:80", blocked: true},
+		{name: "ipv4 unspecified 0.0.0.0", network: "tcp", address: "0.0.0.0:80", blocked: true},
+		{name: "ipv4 multicast", network: "tcp", address: "224.0.0.1:80", blocked: true},
+		{name: "ipv4 cgnat 100.64", network: "tcp", address: "100.64.0.1:80", blocked: true},
+		{name: "ipv4 cgnat 100.127", network: "tcp", address: "100.127.255.254:80", blocked: true},
+		{name: "ipv6 loopback", network: "tcp", address: "[::1]:80", blocked: true},
+		{name: "ipv6 ula fd00", network: "tcp", address: "[fd00::1]:80", blocked: true},
+		{name: "ipv6 link-local fe80", network: "tcp", address: "[fe80::1]:80", blocked: true},
+		{name: "ipv6 unspecified", network: "tcp", address: "[::]:80", blocked: true},
+		{name: "non-IP host", network: "tcp", address: "example.com:80", blocked: true},
+		{name: "bad network", network: "unix", address: "/var/run/sock:0", blocked: true},
+		{name: "missing port", network: "tcp", address: "1.1.1.1", blocked: true},
+
+		{name: "public ipv4", network: "tcp", address: "1.1.1.1:443", blocked: false},
+		{name: "public ipv4 second", network: "tcp", address: "8.8.8.8:443", blocked: false},
+		{name: "public ipv6", network: "tcp", address: "[2606:4700:4700::1111]:443", blocked: false},
+		{name: "udp public", network: "udp", address: "8.8.4.4:53", blocked: false},
+		{name: "100.63 not cgnat", network: "tcp", address: "100.63.0.1:80", blocked: false},
+		{name: "100.128 not cgnat", network: "tcp", address: "100.128.0.1:80", blocked: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := BlockPrivateNetworkControl(tc.network, tc.address, nil)
+			gotBlocked := err != nil
+			if gotBlocked != tc.blocked {
+				t.Fatalf("blocked = %v want %v (err=%v)", gotBlocked, tc.blocked, err)
+			}
+			if err != nil {
+				var be *RestrictedAddrError
+				if !errors.As(err, &be) {
+					t.Fatalf("expected *RestrictedAddrError, got %T: %v", err, err)
+				}
+			}
+		})
+	}
+}
+
+func TestRestrictedHTTPTransportInstalled(t *testing.T) {
+	tr := RestrictedHTTPTransport()
+	if tr == nil {
+		t.Fatal("nil transport")
+	}
+	if tr.DialContext == nil {
+		t.Fatal("expected DialContext to be installed")
+	}
+}

--- a/pkg/resolution/resolver/hub/dialerblock_test.go
+++ b/pkg/resolution/resolver/hub/dialerblock_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hub
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+)
+
+// TestMain installs a permissive HTTP client for the duration of the
+// package's test suite so that existing httptest.Server-based tests
+// (bound to 127.0.0.1) continue to work. Tests that exercise the
+// private-network dial block explicitly reinstall the restricted
+// transport via installRestrictedClientForTest.
+func TestMain(m *testing.M) {
+	hubHTTPClient = &http.Client{Transport: http.DefaultTransport}
+	os.Exit(m.Run())
+}
+
+// installRestrictedClientForTest swaps hubHTTPClient for the production
+// restricted-transport client for the duration of the calling test.
+func installRestrictedClientForTest(t *testing.T) {
+	t.Helper()
+	original := hubHTTPClient
+	hubHTTPClient = &http.Client{Transport: framework.RestrictedHTTPTransport()}
+	t.Cleanup(func() { hubHTTPClient = original })
+}
+
+// TestFetchHubResourceRejectsPrivateNetwork verifies the dial guard rejects
+// requests whose URL resolves to a disallowed address class.
+func TestFetchHubResourceRejectsPrivateNetwork(t *testing.T) {
+	installRestrictedClientForTest(t)
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{name: "loopback v4 literal", url: "http://127.0.0.1:80/foo"},
+		{name: "loopback v6 literal", url: "http://[::1]:80/foo"},
+		{name: "rfc1918 10.x", url: "http://10.0.0.1:80/foo"},
+		{name: "rfc1918 172.16", url: "http://172.16.0.5:80/foo"},
+		{name: "rfc1918 192.168", url: "http://192.168.1.1:80/foo"},
+		{name: "link-local 169.254", url: "http://169.254.169.254:80/foo"},
+		{name: "cgnat 100.64", url: "http://100.64.0.1:80/foo"},
+		{name: "ipv6 ula", url: "http://[fd00::1]:80/foo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resp any
+			err := fetchHubResource(context.Background(), tc.url, &resp)
+			if err == nil {
+				t.Fatalf("expected dial guard to reject %s", tc.url)
+			}
+			if !strings.Contains(err.Error(), "restricted dial") {
+				t.Fatalf("expected restricted-dial error, got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/resolution/resolver/hub/resolver.go
+++ b/pkg/resolution/resolver/hub/resolver.go
@@ -49,12 +49,27 @@ const (
 var supportedKinds = []string{"task", "pipeline", "stepaction"}
 
 // hubHTTPClient is the package-level HTTP client used to talk to a Hub
-// endpoint. It wires framework.RestrictedHTTPTransport so DNS resolution to
+// endpoint when the hubresolver-config `block-private-ips` toggle is at
+// its secure-by-default value of "true". It wires
+// framework.RestrictedHTTPTransport so DNS resolution to
 // loopback / private / link-local addresses is refused at dial time,
 // addressing the "block private IPs" goal in #9602 for the deprecated hub
-// resolver as well.
+// resolver as well. When operators opt out by setting
+// `block-private-ips: "false"` in hubresolver-config, fetchHubResource
+// uses the stdlib default client instead.
 var hubHTTPClient = &http.Client{
 	Transport: framework.RestrictedHTTPTransport(),
+}
+
+// hubHTTPClientForCtx returns the HTTP client fetchHubResource should
+// use for ctx. When ctx carries a hubresolver-config ConfigMap with
+// `block-private-ips: "false"`, the stdlib default client is returned so
+// in-cluster or otherwise-private Hub endpoints become reachable.
+func hubHTTPClientForCtx(ctx context.Context) *http.Client {
+	if framework.BlockPrivateIPs(ctx) {
+		return hubHTTPClient
+	}
+	return http.DefaultClient
 }
 
 // Resolver implements a framework.Resolver that can fetch files from OCI bundles.
@@ -233,7 +248,7 @@ func fetchHubResource(ctx context.Context, apiEndpoint string, v interface{}) er
 	}
 
 	// #nosec G704 -- URL cannot be constant in this case.
-	resp, err := hubHTTPClient.Do(req)
+	resp, err := hubHTTPClientForCtx(ctx).Do(req)
 	if err != nil {
 		return fmt.Errorf("requesting resource from Hub: %w", err)
 	}

--- a/pkg/resolution/resolver/hub/resolver.go
+++ b/pkg/resolution/resolver/hub/resolver.go
@@ -48,6 +48,15 @@ const (
 
 var supportedKinds = []string{"task", "pipeline", "stepaction"}
 
+// hubHTTPClient is the package-level HTTP client used to talk to a Hub
+// endpoint. It wires framework.RestrictedHTTPTransport so DNS resolution to
+// loopback / private / link-local addresses is refused at dial time,
+// addressing the "block private IPs" goal in #9602 for the deprecated hub
+// resolver as well.
+var hubHTTPClient = &http.Client{
+	Transport: framework.RestrictedHTTPTransport(),
+}
+
 // Resolver implements a framework.Resolver that can fetch files from OCI bundles.
 //
 // Deprecated: Use [github.com/tektoncd/pipeline/pkg/remoteresolution/resolver/hub.Resolver] instead.
@@ -224,7 +233,7 @@ func fetchHubResource(ctx context.Context, apiEndpoint string, v interface{}) er
 	}
 
 	// #nosec G704 -- URL cannot be constant in this case.
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := hubHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("requesting resource from Hub: %w", err)
 	}

--- a/test/resolver_cache_test.go
+++ b/test/resolver_cache_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"sync"
 
@@ -53,6 +54,52 @@ var cacheResolverFeatureFlags = requireAllGates(map[string]string{
 	"enable-api-fields":       "beta",
 })
 
+// allowBundleResolverPrivateRegistry patches the bundleresolver-config
+// ConfigMap to set block-private-ips=false so the resolver will dial the
+// in-cluster test registry Service ClusterIP (RFC1918). Without this the
+// secure-by-default restricted dialer refuses the connection and
+// TestBundleResolverCache* cases fail with "restricted dial: refusing
+// to dial ...: RFC1918/RFC4193 private address". The original value is
+// restored via t.Cleanup. Pass through ctx so the cleanup also runs if
+// the test is canceled.
+func allowBundleResolverPrivateRegistry(ctx context.Context, t *testing.T, c *clients) {
+	t.Helper()
+	resolverNS := resolverconfig.ResolversNamespace(system.Namespace())
+	cmName := "bundleresolver-config"
+	cm, err := c.KubeClient.CoreV1().ConfigMaps(resolverNS).Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get ConfigMap %s/%s: %v", resolverNS, cmName, err)
+	}
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	oldVal, hadOld := cm.Data["block-private-ips"]
+	cm.Data["block-private-ips"] = "false"
+	if _, err := c.KubeClient.CoreV1().ConfigMaps(resolverNS).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Failed to update ConfigMap %s/%s: %v", resolverNS, cmName, err)
+	}
+	// Give the configstore watcher time to propagate the new value into
+	// the resolver pod's in-memory context before the test fires.
+	time.Sleep(3 * time.Second)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		got, err := c.KubeClient.CoreV1().ConfigMaps(resolverNS).Get(cleanupCtx, cmName, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("Cleanup: failed to get ConfigMap %s/%s: %v", resolverNS, cmName, err)
+			return
+		}
+		if hadOld {
+			got.Data["block-private-ips"] = oldVal
+		} else {
+			delete(got.Data, "block-private-ips")
+		}
+		if _, err := c.KubeClient.CoreV1().ConfigMaps(resolverNS).Update(cleanupCtx, got, metav1.UpdateOptions{}); err != nil {
+			t.Logf("Cleanup: failed to restore ConfigMap %s/%s: %v", resolverNS, cmName, err)
+		}
+	})
+}
+
 var cacheGitFeatureFlags = requireAllGates(map[string]string{
 	"enable-git-resolver": "true",
 	"enable-api-fields":   "beta",
@@ -65,6 +112,7 @@ func TestBundleResolverCache(t *testing.T) {
 	c, namespace := setup(ctx, t, withRegistry, cacheResolverFeatureFlags)
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+	allowBundleResolverPrivateRegistry(ctx, t, c)
 
 	// GIVEN
 	replicas := 1
@@ -91,6 +139,7 @@ func TestBundleResolverCacheWithFourResolverReplicas(t *testing.T) {
 	c, namespace := setup(ctx, t, withRegistry, cacheResolverFeatureFlags)
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+	allowBundleResolverPrivateRegistry(ctx, t, c)
 
 	// GIVEN
 	replicas := 4
@@ -418,6 +467,7 @@ func TestResolverCacheIsolation(t *testing.T) {
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+	allowBundleResolverPrivateRegistry(ctx, t, c)
 
 	// Create a Task in the namespace for testing cluster resolver
 	taskName := helpers.ObjectNameForTest(t)
@@ -505,6 +555,7 @@ func TestResolverCacheComprehensive(t *testing.T) {
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+	allowBundleResolverPrivateRegistry(ctx, t, c)
 
 	// Create a Task in the namespace for testing cluster resolver
 	taskName := helpers.ObjectNameForTest(t)
@@ -604,6 +655,7 @@ func TestResolverCacheErrorHandling(t *testing.T) {
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+	allowBundleResolverPrivateRegistry(ctx, t, c)
 
 	// Test with invalid cache mode (should fail with error due to centralized validation)
 	tr1 := newGitCloneBundleTaskRun(t, namespace, "error-test-invalid", "invalid")
@@ -657,6 +709,7 @@ func TestResolverCacheInvalidParams(t *testing.T) {
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+	allowBundleResolverPrivateRegistry(ctx, t, c)
 
 	// Set up local bundle registry
 	taskName := helpers.ObjectNameForTest(t)

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -61,6 +61,7 @@ func TestTektonBundlesResolver(t *testing.T) {
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+	allowBundleResolverPrivateRegistry(ctx, t, c)
 
 	taskName := helpers.ObjectNameForTest(t)
 	pipelineName := helpers.ObjectNameForTest(t)


### PR DESCRIPTION
## Changes

Extends issue #9602 ("HTTP resolver: block requests to private/internal IP ranges by default") to the **hub** and **bundle** resolvers, which dial tenant-supplied URLs from inside the `tekton-pipelines-resolvers` controller pod and currently have no IP-class filter.

### Four commits

1. **`framework/dialerblock.go`** — new `net.Dialer.Control` callback plus a matching `*http.Transport` factory. Refuses loopback, RFC1918/RFC4193 private, link-local (unicast + multicast), multicast, RFC6598 CGNAT and unspecified addresses. The control runs after DNS resolution and immediately before `connect(2)`, which closes the TOCTOU gap a pre-dial lookup leaves open.

2. **Hub resolver wiring** — both `pkg/remoteresolution/resolver/hub/resolve.go` and the deprecated `pkg/resolution/resolver/hub/resolver.go` switch from `http.DefaultClient` to a package-level client backed by `framework.RestrictedHTTPTransport()`.

3. **Bundle resolver wiring** — `pkg/resolution/resolver/bundle/bundle.go` routes all `remote.Image` traffic (auth challenge, manifest, layers) through a package-level `RoundTripper`, also backed by the restricted transport. Exposes `SetRegistryTransportForTest` / `ResetRegistryTransportForTest` so the existing bundle suite (which uses an in-process httptest registry on 127.0.0.1) can install a permissive transport for its duration.

4. **`block-private-ips` config knob + in-cluster registry e2e opt-out** (this PR's most recent commit) — per @waveywaves' review.
   - Adds a `block-private-ips` key to the existing `bundleresolver-config` and `hubresolver-config` ConfigMaps. Default `"true"` (secure-by-default; no behavior change for the common case).
   - `BlockPrivateIPs(ctx)` reads the value via `GetResolverConfigFromContext` and treats anything outside the recognised falsey set (`"false"`, `"0"`, `"no"`, `"off"`) as `"true"`, so a typo cannot silently disable the guard.
   - `ResolverHTTPTransport(ctx)` returns the restricted or the stdlib transport accordingly; bundle and hub resolution flow through it.
   - The bundle-resolver e2e cases push images to an in-cluster registry Service ClusterIP (RFC1918) and were failing under the new secure default with `restricted dial: refusing to dial …: RFC1918/RFC4193 private address`. The e2e setup helper `allowBundleResolverPrivateRegistry` patches `bundleresolver-config` to `block-private-ips=false` for the duration of the affected tests (restored via `t.Cleanup`).

### Tests

- `framework/dialerblock_test.go` — 22-case address-class table (loopback v4/v6, RFC1918 10.x / 172.16 / 192.168, link-local 169.254, CGNAT 100.64–100.127, IPv6 ULA fd00::/fe80::, plus public IPs that must pass)
- `{remote,}resolution/resolver/hub/dialerblock_test.go` — exercises the guard via `fetchHubResource` for both hub resolvers; uses a `TestMain` hook to keep the existing httptest-based suite working
- `{remote,}resolution/resolver/bundle/dialerblock_test.go` — exercises the guard via `GetEntry` for both bundle resolvers
- `test/resolver_cache_test.go` + `test/tektonbundles_test.go` — six e2e cases that fetch through the in-cluster registry now call `allowBundleResolverPrivateRegistry` before exercising the resolver

All five packages pass `go test`; `go vet` clean; `go build ./pkg/{remote,}resolution/resolver/...` clean.

### Scope

- DNS rebinding mitigation is implicit: the resolved IP is checked at dial time, so a hostname that resolves to a public IP during validation but a private IP during connect is still refused.
- `block-private-ips` is now wired for both resolvers per the review. The HTTP resolver remains untouched in this PR; #9602's existing scope already covers it.

DCO signed.

Refs: #9602

\`\`\`release-note
The bundle and hub resolvers now refuse to dial private network address classes (loopback, RFC1918/RFC4193, link-local, multicast, CGNAT, IPv6 ULA, unspecified) by default. Operators who intentionally point either resolver at an in-cluster registry, a sidecar, or another private endpoint can opt out by setting \`block-private-ips: "false"\` in the resolver's ConfigMap (\`bundleresolver-config\` or \`hubresolver-config\`).
\`\`\`