### PR TITLE
fix: resolve goroutine leak from unbuffered channels in resolver reconciler

### DIFF
--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -227,14 +227,14 @@ type FeatureFlags struct {
 	Coschedule                               string `json:"coschedule,omitempty"`
 	EnableCELInWhenExpression                bool   `json:"enableCELInWhenExpression,omitempty"`
 	// EnableStepActions is a no-op flag since StepActions are stable
-	EnableStepActions            bool   `json:"enableStepActions,omitempty"`
-	EnableParamEnum              bool   `json:"enableParamEnum,omitempty"`
-	EnableArtifacts              bool   `json:"enableArtifacts,omitempty"`
-	DisableInlineSpec            string `json:"disableInlineSpec,omitempty"`
-	EnableConciseResolverSyntax  bool   `json:"enableConciseResolverSyntax,omitempty"`
-	EnableKubernetesSidecar      bool   `json:"enableKubernetesSidecar,omitempty"`
-	EnableWaitExponentialBackoff         bool `json:"enableWaitExponentialBackoff,omitempty"`
-	EnableTerminationMessageCompression bool `json:"enableTerminationMessageCompression,omitempty"`
+	EnableStepActions                   bool   `json:"enableStepActions,omitempty"`
+	EnableParamEnum                     bool   `json:"enableParamEnum,omitempty"`
+	EnableArtifacts                     bool   `json:"enableArtifacts,omitempty"`
+	DisableInlineSpec                   string `json:"disableInlineSpec,omitempty"`
+	EnableConciseResolverSyntax         bool   `json:"enableConciseResolverSyntax,omitempty"`
+	EnableKubernetesSidecar             bool   `json:"enableKubernetesSidecar,omitempty"`
+	EnableWaitExponentialBackoff        bool   `json:"enableWaitExponentialBackoff,omitempty"`
+	EnableTerminationMessageCompression bool   `json:"enableTerminationMessageCompression,omitempty"`
 	// DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
 	// to allow deletion of PipelineRuns created before v0.62.x.
 	// This field is not used and can be removed in a future release

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -332,7 +332,6 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 			return controller.NewRequeueAfter(timeout - elapsed)
 		}
 		return nil
-
 	}
 	return nil
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -8527,7 +8527,6 @@ func getTaskRunStatus(t string, status corev1.ConditionStatus) *v1.PipelineRunTa
 	}
 }
 
-
 // this test validates taskSpec metadata is embedded into task run
 func TestReconcilePipeline_TaskSpecMetadata(t *testing.T) {
 	names.TestingSeed()

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -38,6 +38,7 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 )
+
 // MissingResultFromCompletedTaskError indicates a task completed successfully
 // but did not emit a result that a downstream task references.
 type MissingResultFromCompletedTaskError struct {
@@ -50,7 +51,6 @@ func (e *MissingResultFromCompletedTaskError) Error() string {
 	return fmt.Sprintf("task %q completed successfully but did not emit the result %q, which is referenced by task %q",
 		e.Task, e.Result, e.Target)
 }
-
 
 const (
 	// ReasonConditionCheckFailed indicates that the reason for the failure status is that the

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -116,8 +116,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 }
 
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
-	errChan := make(chan error)
-	resourceChan := make(chan framework.ResolvedResource)
+	errChan := make(chan error, 1)
+	resourceChan := make(chan framework.ResolvedResource, 1)
 
 	paramsMap := make(map[string]string)
 	for _, p := range rr.Spec.Params {

--- a/pkg/remoteresolution/resolver/framework/reconciler_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -510,6 +512,77 @@ func TestReconcile(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestResolveGoroutineLeak(t *testing.T) {
+	const numRequests = 5
+
+	paramMap := map[string]*resolutionframework.FakeResolvedResource{
+		"bar": {WaitFor: 200 * time.Millisecond},
+	}
+
+	requests := make([]*v1beta1.ResolutionRequest, numRequests)
+	for i := range numRequests {
+		requests[i] = &v1beta1.ResolutionRequest{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "resolution.tekton.dev/v1beta1",
+				Kind:       "ResolutionRequest",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              fmt.Sprintf("rr-%d", i),
+				Namespace:         "foo",
+				CreationTimestamp: metav1.Time{Time: time.Now()},
+				Labels: map[string]string{
+					resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+				},
+			},
+			Spec: v1beta1.ResolutionRequestSpec{
+				Params: []pipelinev1.Param{{
+					Name:  resolutionframework.FakeParamName,
+					Value: *pipelinev1.NewStructuredValues("bar"),
+				}},
+			},
+		}
+	}
+
+	d := test.Data{
+		ResolutionRequests: requests,
+		ConfigMaps: []*corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "resolver-cache-config",
+				Namespace: system.Namespace(),
+			},
+			Data: map[string]string{},
+		}},
+	}
+
+	fakeResolver := &framework.FakeResolver{
+		ForParam: paramMap,
+		Timeout:  50 * time.Millisecond,
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	testAssets, cancel := getResolverFrameworkController(ctx, t, d, fakeResolver, setClockOnReconciler)
+	defer cancel()
+
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	for _, rr := range requests {
+		_ = testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(rr))
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	leaked := after - before
+	if leaked >= numRequests {
+		t.Errorf("goroutine leak detected: %d goroutines leaked after %d timed-out resolutions (before=%d, after=%d)",
+			leaked, numRequests, before, after)
 	}
 }
 

--- a/pkg/resolution/resolver/framework/reconciler.go
+++ b/pkg/resolution/resolver/framework/reconciler.go
@@ -113,8 +113,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 }
 
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
-	errChan := make(chan error)
-	resourceChan := make(chan ResolvedResource)
+	errChan := make(chan error, 1)
+	resourceChan := make(chan ResolvedResource, 1)
 
 	paramsMap := make(map[string]string)
 	for _, p := range rr.Spec.Params {

--- a/pkg/resolution/resolver/framework/reconciler_test.go
+++ b/pkg/resolution/resolver/framework/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -249,6 +251,70 @@ func TestReconcile(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestResolveGoroutineLeak(t *testing.T) {
+	const numRequests = 5
+
+	paramMap := map[string]*framework.FakeResolvedResource{
+		"bar": {WaitFor: 200 * time.Millisecond},
+	}
+
+	requests := make([]*v1beta1.ResolutionRequest, numRequests)
+	for i := range numRequests {
+		requests[i] = &v1beta1.ResolutionRequest{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "resolution.tekton.dev/v1beta1",
+				Kind:       "ResolutionRequest",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              fmt.Sprintf("rr-%d", i),
+				Namespace:         "foo",
+				CreationTimestamp: metav1.Time{Time: time.Now()},
+				Labels: map[string]string{
+					resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
+				},
+			},
+			Spec: v1beta1.ResolutionRequestSpec{
+				Params: []pipelinev1.Param{{
+					Name:  framework.FakeParamName,
+					Value: *pipelinev1.NewStructuredValues("bar"),
+				}},
+			},
+		}
+	}
+
+	d := test.Data{
+		ResolutionRequests: requests,
+	}
+
+	fakeResolver := &framework.FakeResolver{
+		ForParam: paramMap,
+		Timeout:  50 * time.Millisecond,
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	testAssets, cancel := getResolverFrameworkController(ctx, t, d, fakeResolver, setClockOnReconciler)
+	defer cancel()
+
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	for _, rr := range requests {
+		_ = testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(rr))
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	leaked := after - before
+	if leaked >= numRequests {
+		t.Errorf("goroutine leak detected: %d goroutines leaked after %d timed-out resolutions (before=%d, after=%d)",
+			leaked, numRequests, before, after)
 	}
 }
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
  ## Summary

  - Fix goroutine leak in resolver framework reconcilers caused by
    unbuffered channel sends after context timeout. When `Resolve()`
    outlasts its deadline, the select returns via `resolutionCtx.Done()`
    but the goroutine blocks forever trying to send on the unbuffered
    `errChan`/`resourceChan` — no receiver is left.
  - Buffer both channels to 1 so the goroutine always completes, even
    when the caller has already exited.
  - Add `TestResolveGoroutineLeak` to both framework packages to
    prevent regression.

  ## Root cause

  `errChan` and `resourceChan` were created with `make(chan ...)` (capacity 0).
  The goroutine spawned by `resolve()` calls `r.resolver.Resolve()`, which may
  block on a network call (git, OCI, HTTP). If the resolution context times out
  before the call returns, `select` takes the `resolutionCtx.Done()` branch and
  `resolve()` returns. When the goroutine's `Resolve()` call eventually fails
  with a context-cancelled error, it attempts `errChan <- err` — but nobody is
  reading. The unbuffered send blocks forever.

  Each timed-out resolution leaks one goroutine plus whatever resources it
  holds (connections, memory). Under sustained load this saturates the resolver
  queue and degrades the controller until restart.

  ## Fix

  ```go
  // Before
  errChan := make(chan error)
  resourceChan := make(chan framework.ResolvedResource)

  // After
  errChan := make(chan error, 1)
  resourceChan := make(chan framework.ResolvedResource, 1)
```

  The goroutine deposits its result into the buffer and exits. The buffered
  value is garbage-collected when the channel goes out of scope.
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
