### PR TITLE
[Cherry-pick Release-v1.3.x] fix: resolve goroutine leak from unbuffered channels in resolver reconcilers

### DIFF
--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -115,8 +115,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 }
 
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
-	errChan := make(chan error)
-	resourceChan := make(chan framework.ResolvedResource)
+	errChan := make(chan error, 1)
+	resourceChan := make(chan framework.ResolvedResource, 1)
 
 	paramsMap := make(map[string]string)
 	for _, p := range rr.Spec.Params {

--- a/pkg/remoteresolution/resolver/framework/reconciler_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -35,6 +37,7 @@ import (
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -502,6 +505,77 @@ func TestReconcile(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestResolveGoroutineLeak(t *testing.T) {
+	const numRequests = 5
+
+	paramMap := map[string]*resolutionframework.FakeResolvedResource{
+		"bar": {WaitFor: 200 * time.Millisecond},
+	}
+
+	requests := make([]*v1beta1.ResolutionRequest, numRequests)
+	for i := range numRequests {
+		requests[i] = &v1beta1.ResolutionRequest{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "resolution.tekton.dev/v1beta1",
+				Kind:       "ResolutionRequest",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              fmt.Sprintf("rr-%d", i),
+				Namespace:         "foo",
+				CreationTimestamp: metav1.Time{Time: time.Now()},
+				Labels: map[string]string{
+					resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+				},
+			},
+			Spec: v1beta1.ResolutionRequestSpec{
+				Params: []pipelinev1.Param{{
+					Name:  resolutionframework.FakeParamName,
+					Value: *pipelinev1.NewStructuredValues("bar"),
+				}},
+			},
+		}
+	}
+
+	d := test.Data{
+		ResolutionRequests: requests,
+		ConfigMaps: []*corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "resolver-cache-config",
+				Namespace: system.Namespace(),
+			},
+			Data: map[string]string{},
+		}},
+	}
+
+	fakeResolver := &framework.FakeResolver{
+		ForParam: paramMap,
+		Timeout:  50 * time.Millisecond,
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	testAssets, cancel := getResolverFrameworkController(ctx, t, d, fakeResolver, setClockOnReconciler)
+	defer cancel()
+
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	for _, rr := range requests {
+		_ = testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(rr))
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	leaked := after - before
+	if leaked >= numRequests {
+		t.Errorf("goroutine leak detected: %d goroutines leaked after %d timed-out resolutions (before=%d, after=%d)",
+			leaked, numRequests, before, after)
 	}
 }
 

--- a/pkg/resolution/resolver/framework/reconciler.go
+++ b/pkg/resolution/resolver/framework/reconciler.go
@@ -113,8 +113,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 }
 
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
-	errChan := make(chan error)
-	resourceChan := make(chan ResolvedResource)
+	errChan := make(chan error, 1)
+	resourceChan := make(chan ResolvedResource, 1)
 
 	paramsMap := make(map[string]string)
 	for _, p := range rr.Spec.Params {

--- a/pkg/resolution/resolver/framework/reconciler_test.go
+++ b/pkg/resolution/resolver/framework/reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -249,6 +251,70 @@ func TestReconcile(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestResolveGoroutineLeak(t *testing.T) {
+	const numRequests = 5
+
+	paramMap := map[string]*framework.FakeResolvedResource{
+		"bar": {WaitFor: 200 * time.Millisecond},
+	}
+
+	requests := make([]*v1beta1.ResolutionRequest, numRequests)
+	for i := range numRequests {
+		requests[i] = &v1beta1.ResolutionRequest{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "resolution.tekton.dev/v1beta1",
+				Kind:       "ResolutionRequest",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              fmt.Sprintf("rr-%d", i),
+				Namespace:         "foo",
+				CreationTimestamp: metav1.Time{Time: time.Now()},
+				Labels: map[string]string{
+					resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
+				},
+			},
+			Spec: v1beta1.ResolutionRequestSpec{
+				Params: []pipelinev1.Param{{
+					Name:  framework.FakeParamName,
+					Value: *pipelinev1.NewStructuredValues("bar"),
+				}},
+			},
+		}
+	}
+
+	d := test.Data{
+		ResolutionRequests: requests,
+	}
+
+	fakeResolver := &framework.FakeResolver{
+		ForParam: paramMap,
+		Timeout:  50 * time.Millisecond,
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	testAssets, cancel := getResolverFrameworkController(ctx, t, d, fakeResolver, setClockOnReconciler)
+	defer cancel()
+
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	for _, rr := range requests {
+		_ = testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(rr))
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	leaked := after - before
+	if leaked >= numRequests {
+		t.Errorf("goroutine leak detected: %d goroutines leaked after %d timed-out resolutions (before=%d, after=%d)",
+			leaked, numRequests, before, after)
 	}
 }
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This is a cherry pick PR of #10098
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

