### PR TITLE
[Cherry-pick Release-v1.9.x] fix(pipelinerun): use generateName for anonymous pipeline label

### DIFF
--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -281,6 +281,10 @@ func getPipelineTagName(pr *v1.PipelineRun) string {
 	case pr.Spec.PipelineRef != nil && pr.Spec.PipelineRef.Name != "":
 		pipelineName = pr.Spec.PipelineRef.Name
 	case pr.Spec.PipelineSpec != nil:
+		if pr.ObjectMeta.GenerateName == "" {
+			break
+		}
+		fallthrough
 	default:
 		if len(pr.Labels) > 0 {
 			pipelineLabel, hasPipelineLabel := pr.Labels[pipeline.PipelineLabelKey]

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -871,3 +871,70 @@ func TestRecordRunningPipelineRunsNoCondition(t *testing.T) {
 	}
 	metricstest.CheckLastValueData(t, "running_pipelineruns", map[string]string{}, 0)
 }
+
+func TestGetPipelineTagName(t *testing.T) {
+	tests := []struct {
+		name     string
+		pr       *v1.PipelineRun
+		expected string
+	}{
+		{
+			name: "with pipeline ref",
+			pr: &v1.PipelineRun{
+				Spec: v1.PipelineRunSpec{
+					PipelineRef: &v1.PipelineRef{Name: "test-pipeline"},
+				},
+			},
+			expected: "test-pipeline",
+		},
+		{
+			name: "with pipeline spec",
+			pr: &v1.PipelineRun{
+				Spec: v1.PipelineRunSpec{
+					PipelineSpec: &v1.PipelineSpec{},
+				},
+			},
+			expected: "anonymous",
+		},
+		{
+			name: "with pipeline spec and generateName",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						pipeline.PipelineLabelKey: "some-pipeline",
+					},
+					Name:         "some-pipeline-abc123",
+					GenerateName: "some-pipeline-",
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineSpec: &v1.PipelineSpec{},
+				},
+			},
+			expected: "some-pipeline",
+		},
+		{
+			name: "with pipeline label",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						pipeline.PipelineLabelKey: "pipeline-label",
+					},
+				},
+			},
+			expected: "pipeline-label",
+		},
+		{
+			name:     "empty",
+			pr:       &v1.PipelineRun{},
+			expected: "anonymous",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getPipelineTagName(tt.pr); got != tt.expected {
+				t.Errorf("getPipelineTagName() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -42,6 +42,7 @@ import (
 	ctrl "github.com/tektoncd/pipeline/pkg/controller"
 	"github.com/tektoncd/pipeline/pkg/internal/affinityassistant"
 	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
+	"github.com/tektoncd/pipeline/pkg/names"
 	"github.com/tektoncd/pipeline/pkg/pipelinerunmetrics"
 	tknreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/apiserver"
@@ -1560,7 +1561,13 @@ func propagatePipelineNameLabelToPipelineRun(pr *v1.PipelineRun) error {
 	case pr.Spec.PipelineRef != nil && pr.Spec.PipelineRef.Name != "":
 		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pr.Spec.PipelineRef.Name
 	case pr.Spec.PipelineSpec != nil:
-		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pr.Name
+		// Use sanitized GenerateName for anonymous pipelines to reduce cardinality while
+		// still allowing categorization
+		if pr.GenerateName != "" {
+			pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = names.SimpleNameGenerator.RestrictLength(pr.GenerateName)
+		} else {
+			pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pr.Name
+		}
 	case pr.Spec.PipelineRef != nil && pr.Spec.PipelineRef.Resolver != "":
 		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pr.Name
 
@@ -1689,7 +1696,10 @@ func storePipelineSpecAndMergeMeta(ctx context.Context, pr *v1.PipelineRun, ps *
 
 		// Propagate labels from Pipeline to PipelineRun. PipelineRun labels take precedences over Pipeline.
 		pr.ObjectMeta.Labels = kmap.Union(meta.Labels, pr.ObjectMeta.Labels)
-		if len(meta.Name) > 0 {
+		// Only overwrite the pipeline label from meta.Name if the label has not already been set,
+		// or if GenerateName is not in use. When GenerateName is set, propagatePipelineNameLabelToPipelineRun
+		// has already assigned the correct label from GenerateName.
+		if len(meta.Name) > 0 && (pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] == "" || meta.GenerateName == "") {
 			pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = meta.Name
 		}
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -6981,6 +6981,7 @@ metadata:
   annotations:
     io.annotation: value
 `)
+
 	refSource := &v1.RefSource{
 		URI: "abc.com",
 		Digest: map[string]string{
@@ -7004,6 +7005,23 @@ metadata:
 	}
 	want.ObjectMeta.Labels["tekton.dev/pipeline"] = pr.ObjectMeta.Name
 
+	prWithGeneratedName := pr.DeepCopy()
+	prWithGeneratedName.GenerateName = pr.Name + "-"
+	prWithGeneratedName.ObjectMeta.Labels["tekton.dev/pipeline"] = pr.Name
+	prWithGeneratedName.Spec.PipelineSpec = ps.DeepCopy()
+	prWithGeneratedName.Name = prWithGeneratedName.GenerateName + "abc123"
+
+	wantForGeneratedName := prWithGeneratedName.DeepCopy()
+	wantForGeneratedName.Status = v1.PipelineRunStatus{
+		PipelineRunStatusFields: v1.PipelineRunStatusFields{
+			PipelineSpec: ps.DeepCopy(),
+			Provenance: &v1.Provenance{
+				RefSource:    refSource.DeepCopy(),
+				FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
+			},
+		},
+	}
+
 	type args struct {
 		pipelineSpec       *v1.PipelineSpec
 		resolvedObjectMeta *resolutionutil.ResolvedObjectMeta
@@ -7011,12 +7029,14 @@ metadata:
 
 	tests := []struct {
 		name            string
+		pr              *v1.PipelineRun
 		reconcile1Args  *args
 		reconcile2Args  *args
 		wantPipelineRun *v1.PipelineRun
 	}{
 		{
 			name: "spec and source are available in the same reconcile",
+			pr:   pr,
 			reconcile1Args: &args{
 				pipelineSpec: &ps,
 				resolvedObjectMeta: &resolutionutil.ResolvedObjectMeta{
@@ -7032,6 +7052,7 @@ metadata:
 		},
 		{
 			name: "spec comes in the first reconcile and source comes in next reconcile",
+			pr:   pr,
 			reconcile1Args: &args{
 				pipelineSpec: &ps,
 				resolvedObjectMeta: &resolutionutil.ResolvedObjectMeta{
@@ -7046,22 +7067,38 @@ metadata:
 			},
 			wantPipelineRun: want,
 		},
+		{
+			name: "pipelineRun name is not overwritten when generateName is used with pipelineSpec",
+			pr:   prWithGeneratedName,
+			reconcile1Args: &args{
+				pipelineSpec: &ps,
+				resolvedObjectMeta: &resolutionutil.ResolvedObjectMeta{
+					ObjectMeta: &prWithGeneratedName.ObjectMeta,
+					RefSource:  refSource.DeepCopy(),
+				},
+			},
+			reconcile2Args: &args{
+				pipelineSpec:       &ps,
+				resolvedObjectMeta: &resolutionutil.ResolvedObjectMeta{},
+			},
+			wantPipelineRun: wantForGeneratedName,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// mock first reconcile
-			if err := storePipelineSpecAndMergeMeta(t.Context(), pr, tc.reconcile1Args.pipelineSpec, tc.reconcile1Args.resolvedObjectMeta); err != nil {
+			if err := storePipelineSpecAndMergeMeta(t.Context(), tc.pr, tc.reconcile1Args.pipelineSpec, tc.reconcile1Args.resolvedObjectMeta); err != nil {
 				t.Errorf("storePipelineSpec() error = %v", err)
 			}
-			if d := cmp.Diff(tc.wantPipelineRun, pr); d != "" {
+			if d := cmp.Diff(tc.wantPipelineRun, tc.pr); d != "" {
 				t.Fatal(diff.PrintWantGot(d))
 			}
 
 			// mock second reconcile
-			if err := storePipelineSpecAndMergeMeta(t.Context(), pr, tc.reconcile2Args.pipelineSpec, tc.reconcile2Args.resolvedObjectMeta); err != nil {
+			if err := storePipelineSpecAndMergeMeta(t.Context(), tc.pr, tc.reconcile2Args.pipelineSpec, tc.reconcile2Args.resolvedObjectMeta); err != nil {
 				t.Errorf("storePipelineSpec() error = %v", err)
 			}
-			if d := cmp.Diff(tc.wantPipelineRun, pr); d != "" {
+			if d := cmp.Diff(tc.wantPipelineRun, tc.pr); d != "" {
 				t.Fatal(diff.PrintWantGot(d))
 			}
 		})
@@ -18610,5 +18647,93 @@ spec:
 	// Verify its status was updated
 	if !reconciledTekton.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
 		t.Errorf("Expected Tekton-managed PipelineRun to be running, but it was not")
+	}
+}
+
+func TestPropagatePipelineNameLabelToPipelineRun_AnonymousPipeline(t *testing.T) {
+	tcs := []struct {
+		name      string
+		pr        *v1.PipelineRun
+		wantLabel string
+	}{
+		{
+			name: "pipelineSpec with no name and no generateName uses pipelinerun name",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-pipelinerun",
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineSpec: &v1.PipelineSpec{},
+				},
+			},
+			wantLabel: "my-pipelinerun",
+		},
+		{
+			name: "pipelineSpec with generateName uses trimmed generateName prefix",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "my-pipeline-abcde",
+					GenerateName: "my-pipeline-",
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineSpec: &v1.PipelineSpec{},
+				},
+			},
+			wantLabel: "my-pipeline",
+		},
+		{
+			name: "pipelineSpec with generateName that has no trailing hyphen is used as-is",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "my-pipeline-abcde",
+					GenerateName: "my-pipeline",
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineSpec: &v1.PipelineSpec{},
+				},
+			},
+			wantLabel: "my-pipeline",
+		},
+		{
+			name: "existing pipeline label is preserved and not overwritten",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "my-pipelinerun",
+					GenerateName: "my-pipeline-",
+					Labels: map[string]string{
+						pipeline.PipelineLabelKey: "already-set",
+					},
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineSpec: &v1.PipelineSpec{},
+				},
+			},
+			wantLabel: "already-set",
+		},
+		{
+			name: "pipelineRef with name uses pipeline name not generateName",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "my-pipelinerun-abcde",
+					GenerateName: "my-pipelinerun-",
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineRef: &v1.PipelineRef{Name: "the-pipeline"},
+				},
+			},
+			wantLabel: "the-pipeline",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := propagatePipelineNameLabelToPipelineRun(tc.pr); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := tc.pr.Labels[pipeline.PipelineLabelKey]
+			if got != tc.wantLabel {
+				t.Errorf("pipeline label = %q, want %q", got, tc.wantLabel)
+			}
+		})
 	}
 }

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -568,6 +568,9 @@ func IsPartOfPipeline(tr *v1.TaskRun) (bool, string, string) {
 	pipelineRunLabel, hasPipelineRunLabel := tr.Labels[pipeline.PipelineRunLabelKey]
 
 	if hasPipelineLabel && hasPipelineRunLabel {
+		if pipelineLabel == pipelineRunLabel {
+			pipelineLabel = anonymous
+		}
 		return true, pipelineLabel, pipelineRunLabel
 	}
 

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -542,6 +542,92 @@ func TestRecordTaskRunDurationCount(t *testing.T) {
 		expectedCount:    1,
 		beforeCondition:  nil,
 		countWithReason:  true,
+	}, {
+		name: "for succeeded taskrun in anonymous pipelinerun (no generateName)",
+		taskRun: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "taskrun-1",
+				Namespace: "ns",
+				Labels: map[string]string{
+					pipeline.PipelineLabelKey:    "pipelinerun-1",
+					pipeline.PipelineRunLabelKey: "pipelinerun-1",
+				},
+			},
+			Spec: v1.TaskRunSpec{
+				TaskRef: &v1.TaskRef{Name: "task-1"},
+			},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					StartTime:      &startTime,
+					CompletionTime: &completionTime,
+				},
+			},
+		},
+		metricName: "pipelinerun_taskrun_duration_seconds",
+		expectedDurationTags: map[string]string{
+			"pipeline":    "anonymous",
+			"pipelinerun": "pipelinerun-1",
+			"task":        "task-1",
+			"taskrun":     "taskrun-1",
+			"namespace":   "ns",
+			"status":      "success",
+		},
+		expectedCountTags: map[string]string{
+			"status": "success",
+		},
+		expectedDuration: 60,
+		expectedCount:    1,
+		beforeCondition:  nil,
+		countWithReason:  false,
+	}, {
+		name: "for succeeded taskrun in pipelinerun with generateName-derived pipeline label",
+		taskRun: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "taskrun-1",
+				Namespace: "ns",
+				Labels: map[string]string{
+					pipeline.PipelineLabelKey:    "my-pipeline",
+					pipeline.PipelineRunLabelKey: "my-pipeline-abcde",
+				},
+			},
+			Spec: v1.TaskRunSpec{
+				TaskRef: &v1.TaskRef{Name: "task-1"},
+			},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					StartTime:      &startTime,
+					CompletionTime: &completionTime,
+				},
+			},
+		},
+		metricName: "pipelinerun_taskrun_duration_seconds",
+		expectedDurationTags: map[string]string{
+			"pipeline":    "my-pipeline",
+			"pipelinerun": "my-pipeline-abcde",
+			"task":        "task-1",
+			"taskrun":     "taskrun-1",
+			"namespace":   "ns",
+			"status":      "success",
+		},
+		expectedCountTags: map[string]string{
+			"status": "success",
+		},
+		expectedDuration: 60,
+		expectedCount:    1,
+		beforeCondition:  nil,
+		countWithReason:  false,
 	}} {
 		t.Run(c.name, func(t *testing.T) {
 			unregisterMetrics()
@@ -899,6 +985,47 @@ func TestTaskRunIsOfPipelinerun(t *testing.T) {
 		name:          "no",
 		tr:            &v1.TaskRun{},
 		expectedValue: false,
+	}, {
+		name: "anonymous pipeline label",
+		tr: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					pipeline.PipelineLabelKey:    "anonymous",
+					pipeline.PipelineRunLabelKey: "pipelinerun-xyz",
+				},
+			},
+		},
+		expectedValue:         true,
+		expetectedPipeline:    "anonymous",
+		expetectedPipelineRun: "pipelinerun-xyz",
+	}, {
+		name: "pipeline label same as pipelinerun",
+		tr: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					pipeline.PipelineLabelKey:    "my-pipelinerun",
+					pipeline.PipelineRunLabelKey: "my-pipelinerun",
+				},
+			},
+		},
+		expectedValue:         true,
+		expetectedPipeline:    "anonymous",
+		expetectedPipelineRun: "my-pipelinerun",
+	}, {
+		// When the PipelineRun used generateName, the label is based on the
+		// generateName instead of "anonymous" or the pipelineRun name.
+		name: "generateName-derived pipeline label",
+		tr: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					pipeline.PipelineLabelKey:    "my-pipeline",
+					pipeline.PipelineRunLabelKey: "my-pipeline-abcde",
+				},
+			},
+		},
+		expectedValue:         true,
+		expetectedPipeline:    "my-pipeline",
+		expetectedPipelineRun: "my-pipeline-abcde",
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION


# Changes
This PR is a cherry pick of #9826 
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
