### PR TITLE
[Cherry-pick Release-v1.6.x] fix: convert pod latency metric to histogram and remove pod label

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -22,6 +22,7 @@ We expose several kinds of exporters, including Prometheus, Google Stackdriver, 
 | `tekton_pipelines_controller_running_taskruns` | Gauge |                                                 | experimental |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_quota` | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
 | `tekton_pipelines_controller_running_taskruns_throttled_by_node`  | Gauge | <br> `namespace`=&lt;pipelinerun-namespace&gt; | experimental |
+| `tekton_pipelines_controller_taskruns_pod_latency_milliseconds_[bucket, sum, count]` | Histogram | `namespace`=&lt;taskrun-namespace&gt; <br> `*task`=&lt;task_name&gt; <br> `*taskrun`=&lt;taskrun_name&gt; | experimental |
 | `tekton_pipelines_controller_client_latency_[bucket, sum, count]` | Histogram |                                                 | experimental |
 
 The Labels/Tag marked as "*" are optional. And there's a choice between Histogram and LastValue(Gauge) for pipelinerun and taskrun duration metrics.

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -53,7 +53,6 @@ var (
 	namespaceTag   = tag.MustNewKey("namespace")
 	statusTag      = tag.MustNewKey("status")
 	reasonTag      = tag.MustNewKey("reason")
-	podTag         = tag.MustNewKey("pod")
 
 	trDurationView                             *view.View
 	prTRDurationView                           *view.View
@@ -251,8 +250,8 @@ func viewRegister(cfg *config.Metrics) error {
 	podLatencyView = &view.View{
 		Description: podLatency.Description(),
 		Measure:     podLatency,
-		Aggregation: view.LastValue(),
-		TagKeys:     append([]tag.Key{namespaceTag, podTag}, trunTag...),
+		Aggregation: view.Distribution(5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000),
+		TagKeys:     append([]tag.Key{namespaceTag}, trunTag...),
 	}
 	return view.Register(
 		trDurationView,
@@ -553,7 +552,6 @@ func (r *Recorder) RecordPodLatency(ctx context.Context, pod *corev1.Pod, tr *v1
 		ctx,
 		append([]tag.Mutator{
 			tag.Insert(namespaceTag, tr.Namespace),
-			tag.Insert(podTag, pod.Name),
 		},
 			r.insertTaskTag(taskName, tr.Name)...)...)
 	if err != nil {

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -791,7 +791,6 @@ func TestRecordPodLatency(t *testing.T) {
 			},
 		},
 		expectedTags: map[string]string{
-			"pod":       "test-taskrun-pod-123456",
 			"task":      "task-1",
 			"taskrun":   "test-taskrun",
 			"namespace": "foo",
@@ -814,7 +813,6 @@ func TestRecordPodLatency(t *testing.T) {
 			},
 		},
 		expectedTags: map[string]string{
-			"pod":       "test-taskrun-pod-123456",
 			"task":      "task-remote",
 			"taskrun":   "test-taskrun",
 			"namespace": "foo",
@@ -837,7 +835,6 @@ func TestRecordPodLatency(t *testing.T) {
 			},
 		},
 		expectedTags: map[string]string{
-			"pod":       "test-taskrun-pod-123456",
 			"task":      anonymous,
 			"taskrun":   "test-taskrun",
 			"namespace": "foo",
@@ -870,9 +867,9 @@ func TestRecordPodLatency(t *testing.T) {
 				t.Error("RecordPodLatency wanted error, got nil")
 			} else if !td.expectingError {
 				if err != nil {
-					t.Errorf("RecordPodLatency: %v", err)
+					t.Fatalf("RecordPodLatency: %v", err)
 				}
-				metricstest.CheckLastValueData(t, "taskruns_pod_latency_milliseconds", td.expectedTags, td.expectedValue)
+				metricstest.CheckDistributionData(t, "taskruns_pod_latency_milliseconds", td.expectedTags, 1, td.expectedValue, td.expectedValue)
 			}
 		})
 	}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This is a cherry pick PR of #9530 
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
