### PR TITLE
fix(resolvers): skip re-resolution when ResolutionRequest data is already present

### DIFF
--- a/pkg/apis/resolution/v1beta1/resolution_request_lifecycle.go
+++ b/pkg/apis/resolution/v1beta1/resolution_request_lifecycle.go
@@ -48,6 +48,15 @@ func (rr *ResolutionRequest) IsDone() bool {
 	return !finalStateIsUnknown
 }
 
+// IsResolved returns true if the resolver has written data to the
+// ResolutionRequest's status. This is distinct from IsDone(), which
+// checks whether the pipeline controller has set the terminal
+// condition. Under load, the pipeline controller's queue may back up,
+// creating a window where IsResolved() is true but IsDone() is not.
+func (rr *ResolutionRequest) IsResolved() bool {
+	return rr.Status.Data != ""
+}
+
 // InitializeConditions set ths initial values of the conditions.
 func (s *ResolutionRequestStatus) InitializeConditions() {
 	resolutionRequestCondSet.Manage(s).InitializeConditions()

--- a/pkg/apis/resolution/v1beta1/resolution_request_lifecycle_test.go
+++ b/pkg/apis/resolution/v1beta1/resolution_request_lifecycle_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"testing"
+
+	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
+)
+
+func TestIsResolved(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{
+			name: "empty data is not resolved",
+			data: "",
+			want: false,
+		},
+		{
+			name: "populated data is resolved",
+			data: "some data",
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := &v1beta1.ResolutionRequest{
+				Status: v1beta1.ResolutionRequestStatus{
+					ResolutionRequestStatusFields: v1beta1.ResolutionRequestStatusFields{
+						Data: tc.data,
+					},
+				},
+			}
+			if got := rr.IsResolved(); got != tc.want {
+				t.Errorf("IsResolved() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/resolutionrequest/resolutionrequest.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest.go
@@ -56,7 +56,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, rr *v1beta1.ResolutionRe
 
 	maximumResolutionDuration := config.FromContextOrDefaults(ctx).Defaults.DefaultMaximumResolutionTimeout
 	switch {
-	case rr.Status.Data != "":
+	case rr.IsResolved():
 		rr.Status.MarkSucceeded()
 	case requestDuration(rr) > maximumResolutionDuration:
 		rr.Status.MarkFailed(resolutioncommon.ReasonResolutionTimedOut, timeoutMessage(maximumResolutionDuration))

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -99,7 +99,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return controller.NewPermanentError(err)
 	}
 
-	if rr.IsDone() {
+	// If the pipelines controller has a deep queue, resolvers may reprocess
+	// a ResolutionRequest before the pipelines controller marks the resolved
+	// request as Done.
+	if rr.IsResolved() || rr.IsDone() {
 		return nil
 	}
 

--- a/pkg/remoteresolution/resolver/framework/reconciler_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_test.go
@@ -457,6 +457,59 @@ func TestReconcile(t *testing.T) {
 			reconcilerTimeout: 1 * time.Second,
 			expectedErr:       errors.New("context deadline exceeded"),
 			transient:         true,
+		}, {
+			name: "resolved but not yet done should skip re-resolution",
+			inputRequest: &v1beta1.ResolutionRequest{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "resolution.tekton.dev/v1beta1",
+					Kind:       "ResolutionRequest",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "rr",
+					Namespace:         "foo",
+					CreationTimestamp: metav1.Time{Time: time.Now()},
+					Labels: map[string]string{
+						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
+					},
+				},
+				Spec: v1beta1.ResolutionRequestSpec{
+					Params: []pipelinev1.Param{{
+						Name:  resolutionframework.FakeParamName,
+						Value: *pipelinev1.NewStructuredValues("bar"),
+					}},
+				},
+				Status: v1beta1.ResolutionRequestStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionUnknown,
+						}},
+					},
+					ResolutionRequestStatusFields: v1beta1.ResolutionRequestStatusFields{
+						Data: base64.StdEncoding.Strict().EncodeToString(
+							[]byte(`{"apiVersion": "tekton.dev/v1", "kind": "Pipeline"}`),
+						),
+					},
+				},
+			},
+			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+				"bar": {
+					ErrorWith: "resolver should not have been called",
+				},
+			},
+			expectedStatus: &v1beta1.ResolutionRequestStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionUnknown,
+					}},
+				},
+				ResolutionRequestStatusFields: v1beta1.ResolutionRequestStatusFields{
+					Data: base64.StdEncoding.Strict().EncodeToString(
+						[]byte(`{"apiVersion": "tekton.dev/v1", "kind": "Pipeline"}`),
+					),
+				},
+			},
 		},
 	}
 

--- a/pkg/resolution/resolver/framework/reconciler.go
+++ b/pkg/resolution/resolver/framework/reconciler.go
@@ -96,7 +96,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return controller.NewPermanentError(err)
 	}
 
-	if rr.IsDone() {
+	// If the pipelines controller has a deep queue, resolvers may reprocess
+	// a ResolutionRequest before the pipelines controller marks the resolved
+	// request as Done.
+	if rr.IsResolved() || rr.IsDone() {
 		return nil
 	}
 

--- a/pkg/resolution/resolver/framework/reconciler_test.go
+++ b/pkg/resolution/resolver/framework/reconciler_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -206,6 +207,59 @@ func TestReconcile(t *testing.T) {
 			},
 			reconcilerTimeout: 1 * time.Second,
 			expectedErr:       errors.New("context deadline exceeded"),
+		}, {
+			name: "resolved but not yet done should skip re-resolution",
+			inputRequest: &v1beta1.ResolutionRequest{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "resolution.tekton.dev/v1beta1",
+					Kind:       "ResolutionRequest",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "rr",
+					Namespace:         "foo",
+					CreationTimestamp: metav1.Time{Time: time.Now()},
+					Labels: map[string]string{
+						resolutioncommon.LabelKeyResolverType: framework.LabelValueFakeResolverType,
+					},
+				},
+				Spec: v1beta1.ResolutionRequestSpec{
+					Params: []pipelinev1.Param{{
+						Name:  framework.FakeParamName,
+						Value: *pipelinev1.NewStructuredValues("bar"),
+					}},
+				},
+				Status: v1beta1.ResolutionRequestStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:   apis.ConditionSucceeded,
+							Status: corev1.ConditionUnknown,
+						}},
+					},
+					ResolutionRequestStatusFields: v1beta1.ResolutionRequestStatusFields{
+						Data: base64.StdEncoding.Strict().EncodeToString(
+							[]byte(`{"apiVersion": "tekton.dev/v1", "kind": "Pipeline"}`),
+						),
+					},
+				},
+			},
+			paramMap: map[string]*framework.FakeResolvedResource{
+				"bar": {
+					ErrorWith: "resolver should not have been called",
+				},
+			},
+			expectedStatus: &v1beta1.ResolutionRequestStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionUnknown,
+					}},
+				},
+				ResolutionRequestStatusFields: v1beta1.ResolutionRequestStatusFields{
+					Data: base64.StdEncoding.Strict().EncodeToString(
+						[]byte(`{"apiVersion": "tekton.dev/v1", "kind": "Pipeline"}`),
+					),
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Under load, the pipeline controller's queue backs up, creating a window where the resolver framework re-reconciles ResolutionRequests that already have `Status.Data` populated but have not been marked as Done yet. This causes hundreds of redundant reconciliations (observed: 31-517 resolve calls for 10 TaskRuns).

This PR adds an `IsResolved()` method on `ResolutionRequest` that checks `Status.Data != ""` and uses it in both resolver framework reconcilers to skip re-resolution when data is already present.

**What changed:**

- Added `IsResolved()` to `ResolutionRequest` lifecycle API with documentation explaining the relationship to `IsDone()` and the race window
- Both framework reconcilers (`pkg/remoteresolution/...` and `pkg/resolution/...`) now check `IsResolved() || IsDone()` instead of just `IsDone()`
- Pipeline controller's `resolutionrequest` reconciler uses `IsResolved()` instead of inline `rr.Status.Data != ""`

**Why no e2e regression test:**

A deterministic e2e regression test is not practical because the race depends on controller queue depth and timing. A non-deterministic reproducer is attached to the bug issue (#10113).

/kind bug

Fixes #10113
Related: #9520 (original proposal by @aThorp96)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. `/kind bug`
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Skip re-resolution of ResolutionRequests when Status.Data is already present, preventing hundreds of redundant reconciliations under load.
```
