### PR TITLE
fix(events): reduce TaskRun notification identifier logging and document trace exposure

### DIFF
--- a/config/config-tracing.yaml
+++ b/config/config-tracing.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE: Exported traces may include Kubernetes resource identifiers (e.g. TaskRun/PipelineRun
+# names and namespaces) as span attributes. Treat the trace backend as a trusted observability
+# system. See docs/developers/tracing.md for details.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/docs/developers/tracing.md
+++ b/docs/developers/tracing.md
@@ -31,3 +31,20 @@ The configmap `config/config-tracing.yaml` contains the configuration for tracin
 * enabled: Set this to true to enable tracing
 * endpoint: API endpoint for jaeger collector to send the traces. By default the endpoint is configured to be `http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces`.
 * credentialsSecret: Name of the secret which contains `username` and `password` to authenticate against the endpoint
+
+## Security considerations for multi-tenant environments
+
+Exported spans from the TaskRun and PipelineRun reconciliation paths include
+Kubernetes resource identifiers — specifically resource names and namespaces —
+as span attributes. These identifiers are user-controlled and in some
+deployments may encode tenant names, customer names, repository names, branch
+names, ticket IDs, or internal environment names.
+
+Trace collectors and backends can have different access controls and retention
+policies than the Kubernetes API or CloudEvents sink. Operators should treat
+their trace backend as a trusted observability system with access controls
+equivalent to or stricter than the CloudEvents sink.
+
+Before enabling tracing in multi-tenant environments, review your trace backend
+retention and access control policies to ensure that resource identifiers
+exposed in span attributes are appropriately protected.

--- a/pkg/reconciler/notifications/runtimeobject.go
+++ b/pkg/reconciler/notifications/runtimeobject.go
@@ -51,7 +51,7 @@ func ReconcileRunObject(ctx context.Context, e EventClientsProvider, readOnlyRun
 	ctx = cloudevent.ToContext(ctx, e.GetCloudEventsClient())
 	ctx = cache.ToContext(ctx, e.GetCacheClient())
 
-	logger.Infof("reconciling %s", readOnlyRun.GetObjectMeta().GetName())
+	logger.Debugf("reconciling %s", readOnlyRun.GetObjectMeta().GetName())
 
 	condition := readOnlyRun.GetStatusCondition().GetCondition(apis.ConditionSucceeded)
 	logger.Debugf("%s %s, condition: %s", readOnlyRun.GetObjectKind().GroupVersionKind().Kind, readOnlyRun.GetObjectMeta().GetName(), condition)

--- a/pkg/reconciler/notifications/taskrun/reconciler.go
+++ b/pkg/reconciler/notifications/taskrun/reconciler.go
@@ -79,7 +79,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	defer span.End()
 
 	logger := logging.FromContext(ctx)
-	logger.Infof("Reconciling TaskRun notifications for %s/%s", tr.Namespace, tr.Name)
+	logger.Debugf("Reconciling TaskRun notifications for %s/%s", tr.Namespace, tr.Name)
 
 	// We pass 'r' as it satisfies the EventClientsProvider interface.
 	err := notifications.ReconcileRunObject(ctx, r, tr)


### PR DESCRIPTION
Fixes #10103

## Changes

Reduces default logging verbosity in the TaskRun notification reconciliation
path and adds documentation warning operators that exported traces may include
Kubernetes resource identifiers.

Previously, the notification path introduced in #9912 logged TaskRun and run
object identifiers at INFO level by default. TaskRun names are user-controlled
and can encode tenant names, customer names, branch names, ticket IDs, or
internal environment names. Logs and trace backends can have different access
controls and retention policies than the Kubernetes API or CloudEvents sink.
This PR closes that gap with a minimal log level demotion and updated docs.

**Changes made:**

- `pkg/reconciler/notifications/taskrun/reconciler.go` — demote identifier
  log from `Infof` to `Debugf` to avoid emitting TaskRun name/namespace
  at default log level
- `pkg/reconciler/notifications/runtimeobject.go` — demote identifier
  log from `Infof` to `Debugf` to avoid emitting run object name
  at default log level
- `docs/developers/tracing.md` — add warning that exported spans include
  Kubernetes resource identifiers and that trace backends should be treated
  as trusted observability systems
- `config/config-tracing.yaml` — add brief comment noting resource identifier
  exposure and pointing to tracing docs

Follows the existing logging conventions in `pkg/reconciler/taskrun/taskrun.go`
and `pkg/reconciler/pipelinerun/pipelinerun.go`.

## Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

## Release Notes

```release-note
Reduced default log verbosity in the TaskRun notification path introduced
by #9912. Identifier logs (TaskRun name/namespace) are now emitted at debug
level only. Added documentation warning that exported traces may include
Kubernetes resource identifiers and that trace backends should be treated
as trusted observability systems.
```

/kind bug