### PR TITLE
feat(tracing): inject traceID and spanID into structured log output

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -190,6 +190,10 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 	span.SetAttributes(
 		attribute.String("pipelinerun", pr.Name), attribute.String("namespace", pr.Namespace),
 	)
+	if spanCtx := span.SpanContext(); spanCtx.IsValid() {
+		logger = logger.With(zap.String("traceID", spanCtx.TraceID().String()), zap.String("spanID", spanCtx.SpanID().String()))
+		ctx = logging.WithLogger(ctx, logger)
+	}
 
 	// Read the initial condition
 	before := pr.Status.GetCondition(apis.ConditionSucceeded)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -136,6 +136,10 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	defer span.End()
 
 	span.SetAttributes(attribute.String("taskrun", tr.Name), attribute.String("namespace", tr.Namespace))
+	if spanCtx := span.SpanContext(); spanCtx.IsValid() {
+		logger = logger.With(zap.String("traceID", spanCtx.TraceID().String()), zap.String("spanID", spanCtx.SpanID().String()))
+		ctx = logging.WithLogger(ctx, logger)
+	}
 	// Read the initial condition
 	before := tr.Status.GetCondition(apis.ConditionSucceeded)
 


### PR DESCRIPTION
## Summary

Fixes #9786

When tracing is enabled, inject the active `traceID` and `spanID` into the zap logger for `TaskRun` and `PipelineRun` reconcilers. This allows structured logs to be directly correlated with distributed traces in observability platforms (e.g. Jaeger/Tempo + Loki/CloudWatch) without manual timestamp matching.

- Augments the logger with `traceID` and `spanID` fields immediately after the reconcile span is started
- Stores the augmented logger back into `ctx` via `logging.WithLogger`, so all downstream log calls within the reconcile cycle automatically include the trace context
- Guard: only applied when `span.SpanContext().IsValid()` — no overhead when tracing is disabled or unsampled

**Example log output (with tracing enabled):**
```json
{"level":"info","ts":"...","traceID":"4bf92f3577b34da6a3ce929d0e0e4736","spanID":"00f067aa0ba902b7","msg":"taskrun done : my-taskrun"}
```

## Changes

- `pkg/reconciler/taskrun/taskrun.go` — augment logger after span start in `ReconcileKind`
- `pkg/reconciler/pipelinerun/pipelinerun.go` — same for PipelineRun

## Test plan

- [x] Existing unit tests pass (`go test ./pkg/reconciler/taskrun/... ./pkg/reconciler/pipelinerun/...` — 1841 tests)
- [ ] Manual verification: enable tracing, run a TaskRun/PipelineRun, confirm `traceID`/`spanID` fields appear in reconciler logs

```release-note
Inject traceID and spanID into structured log output for TaskRun and PipelineRun reconcilers when tracing is enabled, enabling log-to-trace correlation in observability platforms.
```