### PR TITLE
Add agent workflow context

### DIFF
--- a/.agents/skills/tekton-pipeline-discovery
+++ b/.agents/skills/tekton-pipeline-discovery
@@ -1,0 +1,1 @@
+../../skills/tekton-pipeline-discovery

--- a/.claude/skills/tekton-pipeline-discovery
+++ b/.claude/skills/tekton-pipeline-discovery
@@ -1,0 +1,1 @@
+../../skills/tekton-pipeline-discovery

--- a/.codex/skills/tekton-pipeline-discovery
+++ b/.codex/skills/tekton-pipeline-discovery
@@ -1,0 +1,1 @@
+../../skills/tekton-pipeline-discovery

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ cpu.prof
 # AI assistant context files
 .assistant
 .claude
+.agentready/
 
 # Beads / Dolt files (added by bd init)
 .dolt/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Agent notes for Tekton Pipelines
+
+If you're an agent working in this repo, start here. This file is meant to orient you quickly; it does not replace the project docs or maintainer judgment.
+
+## Ground rules
+
+- These notes apply to the whole repo.
+- Do not add more `AGENTS.md` files unless a maintainer asks.
+- Keep changes narrow and easy to review.
+- Prefer the smallest test that proves the change.
+- Do not hand-edit generated files or `vendor/`; use the matching update script or dependency workflow.
+- When in doubt, follow nearby code and ask before inventing a new pattern.
+
+## Repo shape
+
+- `cmd/`: binaries such as controller, webhook, entrypoint, resolver, and events.
+- `pkg/apis/`: API types, defaults, validation, conversion, and generated clients.
+- `pkg/reconciler/`: TaskRun, PipelineRun, CustomRun, resolver, event, and notification reconcilers.
+- `pkg/pod`, `pkg/workspace`, `pkg/substitution`: helpers used by the reconcilers.
+- `internal/`: private implementation packages; prefer this for new non-API helpers.
+- `config/`: install manifests and CRDs. Many files here are generated.
+- `test/`: e2e tests, conformance tests, helpers, and presubmit scripts.
+- `docs/`: user-facing and developer documentation.
+
+## Before changing code
+
+- Read `CONTRIBUTING.md`, `DEVELOPMENT.md`, `test/README.md`, and the docs for the area you are touching.
+- For API changes, read `api_compatibility_policy.md` first and expect codegen/OpenAPI updates.
+- For reconciler changes, add or update package tests with fake clients before reaching for e2e tests.
+- For e2e changes, follow the annotations and categories in `test/README.md`.
+
+## Useful checks
+
+- Format Go: `gofmt -w <files>`.
+- Test one package: `go test ./path/to/package`.
+- Test one case: `go test ./path/to/package -run TestName`.
+- Run common packages: `go test ./pkg/...`.
+- Run generated-code check: `./hack/verify-codegen.sh`.
+- Update generated code when needed: `./hack/update-codegen.sh`.
+- Run the local agent-context check: `./hack/verify-agent-readiness.sh`.
+
+## More context
+
+- Repo map for agents: `docs/agents/agent-context.md`.
+- Discovery skill: `skills/tekton-pipeline-discovery/SKILL.md`.
+- Skill discovery symlinks live under `.agents/`, `.claude/`, and `.codex/`.

--- a/docs/agents/agent-context.md
+++ b/docs/agents/agent-context.md
@@ -1,0 +1,58 @@
+# Tekton Pipelines repo map for agents
+
+Use this as a map after you read `AGENTS.md`. It points you toward the right code and docs; it is not another rule file.
+
+The source-of-truth docs are still `README.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `api_compatibility_policy.md`, and `test/README.md`.
+
+## What this repo does
+
+Tekton Pipelines defines Kubernetes-native CI/CD APIs and the controllers that run them. The main resources are `Task`, `TaskRun`, `Pipeline`, `PipelineRun`, `CustomRun`, and resolver objects. The main binaries are the controller, webhook, entrypoint, events controller, remote resolvers, and small helper images.
+
+## Runtime path
+
+1. A user creates Tekton resources through the Kubernetes API.
+2. Webhooks default, validate, and convert those resources.
+3. Reconcilers watch resources through generated informers.
+4. TaskRun reconciliation builds Pods and entrypoint config.
+5. PipelineRun reconciliation resolves the graph and creates child runs.
+6. Resolver controllers fetch remote task and pipeline definitions.
+7. Event and notification controllers publish run state changes.
+
+## Where to look
+
+| Path | Use it for |
+| --- | --- |
+| `cmd/controller` | Controller binary setup and reconciler wiring. |
+| `cmd/webhook` | Defaulting, validation, and conversion webhooks. |
+| `cmd/entrypoint` | The process wrapper injected into step containers. |
+| `pkg/apis/pipeline` | API types, defaults, validation, and conversions. |
+| `pkg/client` | Generated clients, listers, informers, and reconcilers. |
+| `pkg/reconciler/taskrun` | TaskRun reconciliation, Pod creation, and TaskRun status. |
+| `pkg/reconciler/pipelinerun` | PipelineRun graph resolution and child run orchestration. |
+| `pkg/reconciler/resolution` | Remote resolution request handling. |
+| `pkg/reconciler/events`, `pkg/reconciler/notifications` | CloudEvents and notification controllers. |
+| `pkg/pod` | Pod and entrypoint construction helpers. |
+| `internal` | Private helpers. Prefer this for new non-API packages. |
+| `config` | Install manifests and CRDs. |
+| `test` | E2E, conformance, and test utilities. |
+| `hack` | Codegen, verification, release, and local-cluster scripts. |
+| `skills/tekton-pipeline-discovery` | Repo-specific discovery skill for agents. |
+
+## Common change paths
+
+- API or CRD changes: read `api_compatibility_policy.md`; run the generated-code and OpenAPI updates.
+- Webhook changes: add or update validation/defaulting/conversion tests under `pkg/apis/...`.
+- Reconciler changes: start with fake-client unit tests; add e2e coverage when behavior changes across controllers or Pods.
+- Generated files: run the matching `hack/update-*` script instead of editing generated output by hand.
+- E2E tests: keep `@test:execution=parallel` or `serial` annotations correct.
+
+## Useful targeted checks
+
+```sh
+./hack/verify-agent-readiness.sh
+go test ./pkg/apis/pipeline/v1 ./pkg/apis/pipeline/v1beta1
+go test ./pkg/reconciler/taskrun ./pkg/reconciler/pipelinerun
+./hack/verify-codegen.sh
+```
+
+Start narrow. Broaden the test run only when the touched area needs it.

--- a/hack/verify-agent-readiness.sh
+++ b/hack/verify-agent-readiness.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Verify repository metadata used by coding agents.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+max_agents_lines=60
+agents_file="AGENTS.md"
+skill_dir="skills/tekton-pipeline-discovery"
+skill_file="${skill_dir}/SKILL.md"
+expected_link_target="../../skills/tekton-pipeline-discovery"
+skill_links=(
+  ".agents/skills/tekton-pipeline-discovery"
+  ".claude/skills/tekton-pipeline-discovery"
+  ".codex/skills/tekton-pipeline-discovery"
+)
+
+if [[ ! -f "${agents_file}" ]]; then
+  echo "${agents_file} is missing" >&2
+  exit 1
+fi
+
+agents_lines=$(wc -l < "${agents_file}" | tr -d ' ')
+if (( agents_lines > max_agents_lines )); then
+  echo "${agents_file} has ${agents_lines} lines; maximum is ${max_agents_lines}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${skill_file}" ]]; then
+  echo "${skill_file} is missing" >&2
+  exit 1
+fi
+
+for skill_link in "${skill_links[@]}"; do
+  if [[ ! -L "${skill_link}" ]]; then
+    echo "${skill_link} must be a symlink" >&2
+    exit 1
+  fi
+
+  actual_target=$(readlink "${skill_link}")
+  if [[ "${actual_target}" != "${expected_link_target}" ]]; then
+    echo "${skill_link} points to ${actual_target}; want ${expected_link_target}" >&2
+    exit 1
+  fi
+
+  if [[ ! -d "${skill_link}" ]]; then
+    echo "${skill_link} does not resolve to a directory" >&2
+    exit 1
+  fi
+done
+
+echo "agent readiness checks passed (${agents_file}: ${agents_lines}/${max_agents_lines} lines)"

--- a/skills/tekton-pipeline-discovery/SKILL.md
+++ b/skills/tekton-pipeline-discovery/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: tekton-pipeline-discovery
+description: Use this when you need to find your way around tektoncd/pipeline before editing, reviewing, or debugging Tekton Pipelines code.
+---
+
+# Tekton Pipeline Discovery
+
+Use this skill for the first pass through the repo. It should help you find the right files quickly without turning into a second set of project rules.
+
+## Start here
+
+1. Read `AGENTS.md`.
+2. Use `docs/agents/agent-context.md` as the repo map.
+3. Then read the docs for the area you are touching. The common ones are `CONTRIBUTING.md`, `DEVELOPMENT.md`, `api_compatibility_policy.md`, `test/README.md`, and files under `docs/developers/`.
+
+## Working notes
+
+- Keep the change small enough that a maintainer can review it without guessing your intent.
+- Test the package you touched before running broad suites.
+- Prefer new private helpers under `internal/` unless the code is intentionally public API.
+- Do not hand-edit generated code or `vendor/`.
+- For CRD/API behavior, check compatibility before changing fields, defaults, status, labels, or generated clients.
+- For e2e changes, follow the categories and annotations in `test/README.md`.
+
+## Common commands
+
+```sh
+go test ./pkg/...                         # broad package tests
+./hack/verify-codegen.sh                  # generated-code consistency
+./hack/verify-agent-readiness.sh          # local AGENTS.md and skill discovery check
+```
+
+## PR notes
+
+- Follow `.github/pull_request_template.md`.
+- Keep the `release-note` block accurate; use `NONE` only when there is no user-facing impact.
+- Use `Fixes #...` only when the PR fully resolves the issue.
+- For agent-context-only docs changes, `./hack/verify-agent-readiness.sh` is usually the right targeted check.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adds a small first-pass context layer for coding agents working in this repo.

The goal is not to create a new set of project rules. It gives agents a short place to start, a repo map for finding the right code, and a discovery skill that points back to the real docs and existing workflows.

This PR adds:

- `AGENTS.md` as the concise entry point for agents working in this repository
- `docs/agents/agent-context.md` as a repo map for architecture, workflows, and important code areas
- `skills/tekton-pipeline-discovery/SKILL.md` as a repo-specific discovery hook that points agents back to `AGENTS.md`, the repo map, and source docs
- Discovery symlinks under `.agents/`, `.claude/`, and `.codex/` so compatible agents can find the repo skill
- `hack/verify-agent-readiness.sh` for local/manual validation that `AGENTS.md` stays under 60 lines and skill discovery symlinks are intact
- `.agentready/` in `.gitignore` for local AgentReady reports

Fixes #10138

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
