### PR TITLE
feat(tracing): inject traceID and spanID into structured log output

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -190,6 +190,10 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 	span.SetAttributes(
 		attribute.String("pipelinerun", pr.Name), attribute.String("namespace", pr.Namespace),
 	)
+	if spanCtx := span.SpanContext(); spanCtx.IsValid() {
+		logger = logger.With(zap.String("traceID", spanCtx.TraceID().String()), zap.String("spanID", spanCtx.SpanID().String()))
+		ctx = logging.WithLogger(ctx, logger)
+	}
 
 	// Read the initial condition
 	before := pr.Status.GetCondition(apis.ConditionSucceeded)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -136,6 +136,10 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	defer span.End()
 
 	span.SetAttributes(attribute.String("taskrun", tr.Name), attribute.String("namespace", tr.Namespace))
+	if spanCtx := span.SpanContext(); spanCtx.IsValid() {
+		logger = logger.With(zap.String("traceID", spanCtx.TraceID().String()), zap.String("spanID", spanCtx.SpanID().String()))
+		ctx = logging.WithLogger(ctx, logger)
+	}
 	// Read the initial condition
 	before := tr.Status.GetCondition(apis.ConditionSucceeded)
 


### PR DESCRIPTION
# Changes

When tracing is enabled, inject the active `traceID` and `spanID` into the zap logger for `TaskRun` and `PipelineRun` reconcilers. This allows structured logs to be directly correlated with distributed traces in observability platforms (e.g. Jaeger/Tempo + Loki/CloudWatch) without manual timestamp matching.

- Augments the logger with `traceID` and `spanID` fields immediately after the reconcile span is started
- Stores the augmented logger back into `ctx` via `logging.WithLogger`, so all downstream log calls within the reconcile cycle automatically include the trace context
- Guard: only applied when `span.SpanContext().IsValid()` — no overhead when tracing is disabled or unsampled

Fixes #9786

**Example log output (with tracing enabled):**
```json
{"level":"info","ts":"...","traceID":"4bf92f3577b34da6a3ce929d0e0e4736","spanID":"00f067aa0ba902b7","msg":"taskrun done : my-taskrun"}
```

**Files changed:**
- `pkg/reconciler/taskrun/taskrun.go` — augment logger after span start in `ReconcileKind`
- `pkg/reconciler/pipelinerun/pipelinerun.go` — same for PipelineRun

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Inject traceID and spanID into structured log output for TaskRun and PipelineRun reconcilers when tracing is enabled, enabling log-to-trace correlation in observability platforms.
```