### PR TITLE
Fix misleading timestamps for cancelled/unexecuted steps

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -375,6 +375,10 @@ func setTaskRunStatusBasedOnStepStatus(ctx context.Context, logger *zap.SugaredL
 				terminationReason = getTerminationReason(state.Terminated.Reason, terminationFromResults, exitCode)
 			}
 		}
+		if state.Terminated != nil && state.Terminated.Reason == v1.TaskRunReasonCancelled.String() {
+			state.Terminated.StartedAt = state.Terminated.FinishedAt
+			terminationReason = v1.TaskRunReasonCancelled.String()
+		}
 		stepState := v1.StepState{
 			ContainerState:    *state.DeepCopy(),
 			Name:              TrimStepPrefix(s.Name),

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -4520,3 +4520,63 @@ func Test_getFailureMessage_consistent_with_reason(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeTaskRunStatus_CancelledStepTimestamps(t *testing.T) {
+	podStatus := corev1.PodStatus{
+		Phase: corev1.PodFailed,
+		ContainerStatuses: []corev1.ContainerStatus{{
+			Name:    "step-cancelled",
+			ImageID: "image",
+			State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					ExitCode:   1,
+					Reason:     v1.TaskRunReasonCancelled.String(),
+					Message:    "Step step-cancelled terminated as pod test-pod is terminated",
+					StartedAt:  metav1.NewTime(time.Date(2025, 1, 10, 20, 7, 10, 0, time.UTC)),
+					FinishedAt: metav1.NewTime(time.Date(2025, 1, 10, 20, 7, 22, 0, time.UTC)),
+				},
+			},
+		}},
+	}
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod",
+			Namespace:         "foo",
+			CreationTimestamp: metav1.Now(),
+		},
+		Status: podStatus,
+	}
+
+	startTime := time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)
+	tr := v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "task-run",
+			Namespace: "foo",
+		},
+		Status: v1.TaskRunStatus{
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				StartTime: &metav1.Time{Time: startTime},
+			},
+		},
+	}
+
+	logger, _ := logging.NewLogger("", "status")
+	kubeclient := fakek8s.NewSimpleClientset()
+	got, _ := MakeTaskRunStatus(t.Context(), logger, tr, &pod, kubeclient, &v1.TaskSpec{})
+
+	if len(got.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(got.Steps))
+	}
+	step := got.Steps[0]
+	if step.Terminated == nil {
+		t.Fatal("expected Terminated state, got nil")
+	}
+	if !step.Terminated.StartedAt.Time.Equal(step.Terminated.FinishedAt.Time) {
+		t.Errorf("StartedAt (%v) != FinishedAt (%v); cancelled steps should have equal timestamps",
+			step.Terminated.StartedAt.Time, step.Terminated.FinishedAt.Time)
+	}
+	if step.TerminationReason != v1.TaskRunReasonCancelled.String() {
+		t.Errorf("TerminationReason = %q, want %q", step.TerminationReason, v1.TaskRunReasonCancelled.String())
+	}
+}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -1005,7 +1005,6 @@ func (c *Reconciler) updateStepStatusesFromPod(ctx context.Context, tr *v1.TaskR
 // terminateStepsInPod updates step states for TaskRun on TaskRun object since pod has been deleted for cancel or timeout
 func terminateStepsInPod(tr *v1.TaskRun, taskRunReason v1.TaskRunReason) {
 	for i, step := range tr.Status.Steps {
-		// If running, include StartedAt for when step began running
 		if step.Running != nil {
 			step.Terminated = &corev1.ContainerStateTerminated{
 				ExitCode:   1,
@@ -1020,10 +1019,11 @@ func terminateStepsInPod(tr *v1.TaskRun, taskRunReason v1.TaskRunReason) {
 			tr.Status.Steps[i] = step
 		}
 
+		// Waiting steps never started; synthesize StartedAt == FinishedAt == CompletionTime.
 		if step.Waiting != nil {
 			step.Terminated = &corev1.ContainerStateTerminated{
 				ExitCode:   1,
-				StartedAt:  tr.CreationTimestamp, // startedAt cannot be null due to CRD schema validation
+				StartedAt:  *tr.Status.CompletionTime,
 				FinishedAt: *tr.Status.CompletionTime,
 				// TODO(#7385): replace with more pod/container termination reason instead of overloading taskRunReason
 				Reason:  taskRunReason.String(),

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -5829,6 +5829,69 @@ status:
 	}
 }
 
+func TestTerminateStepsInPod_CancelledTimestamps(t *testing.T) {
+	completionTime := metav1.NewTime(time.Date(2025, 1, 10, 20, 8, 0, 0, time.UTC))
+	runningStartedAt := metav1.NewTime(time.Date(2025, 1, 10, 19, 55, 0, 0, time.UTC))
+
+	tests := []struct {
+		name        string
+		step        v1.StepState
+		wantStarted metav1.Time
+	}{
+		{
+			name: "running step preserves original StartedAt",
+			step: v1.StepState{
+				Name: "running-step",
+				ContainerState: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{
+						StartedAt: runningStartedAt,
+					},
+				},
+			},
+			wantStarted: runningStartedAt,
+		},
+		{
+			name: "waiting step gets StartedAt == FinishedAt == CompletionTime",
+			step: v1.StepState{
+				Name: "waiting-step",
+				ContainerState: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason: "PodInitializing",
+					},
+				},
+			},
+			wantStarted: completionTime,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &v1.TaskRun{
+				Status: v1.TaskRunStatus{
+					TaskRunStatusFields: v1.TaskRunStatusFields{
+						PodName:        "test-pod",
+						CompletionTime: &completionTime,
+						Steps:          []v1.StepState{tc.step},
+					},
+				},
+			}
+
+			terminateStepsInPod(tr, v1.TaskRunReasonCancelled)
+
+			step := tr.Status.Steps[0]
+			if step.Terminated == nil {
+				t.Fatalf("expected Terminated state, got nil")
+			}
+			if !step.Terminated.StartedAt.Time.Equal(tc.wantStarted.Time) {
+				t.Errorf("StartedAt = %v, want %v", step.Terminated.StartedAt.Time, tc.wantStarted.Time)
+			}
+			if !step.Terminated.FinishedAt.Time.Equal(completionTime.Time) {
+				t.Errorf("FinishedAt = %v, want %v", step.Terminated.FinishedAt.Time, completionTime.Time)
+			}
+		})
+	}
+}
+
 func Test_storeTaskSpecAndConfigSource(t *testing.T) {
 	tr := parse.MustParseV1TaskRun(t, `
 metadata:


### PR DESCRIPTION
# Summary
- Fix #8479: 
When a TaskRun is cancelled (e.g., due to pipeline timeout), steps that were not executed no longer receive misleading `startedAt`/`finishedAt` timestamps
- Previously, unexecuted steps got `startedAt` set to the container creation time (which was earlier than completed steps) and waiting steps got `startedAt` set to the TaskRun creation timestamp — both values were inaccurate and confusing
- Now, cancelled steps get `startedAt == finishedAt == CompletionTime`, which clearly indicates zero execution duration and does not violate step ordering
# Changes
- `pkg/reconciler/taskrun/taskrun.go`: In `terminateStepsInPod`, set `StartedAt = FinishedAt = CompletionTime` for both Running and Waiting steps (instead of using container creation time or TaskRun creation time). This is the primary fix.
- `pkg/pod/status.go`: Skip parsing non-JSON termination messages for cancelled steps (they always contain plain-text messages that fail JSON parsing), and set `startedAt = finishedAt` for consistency. This provides defense-in-depth for the `updateStepStatusesFromPod` code path.
- `pkg/pod/status_test.go`: Add a unit test for the cancelled step scenario in `MakeTaskRunStatus`.
## Why `startedAt = finishedAt = CompletionTime` instead of null?
The Tekton CRD schema validation rejects null values for `terminated.startedAt` and `terminated.finishedAt`. Setting both to `CompletionTime` satisfies the schema while clearly communicating "this step had zero meaningful execution time."
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
