### PR TITLE
chore: remove stale TODO referencing closed issue #4546

### DIFF
--- a/pkg/apis/pipeline/v1beta1/container_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/container_conversion.go
@@ -137,9 +137,7 @@ func (s StepTemplate) convertTo(ctx context.Context, sink *v1.StepTemplate) {
 	sink.VolumeDevices = s.VolumeDevices
 	sink.ImagePullPolicy = s.ImagePullPolicy
 	sink.SecurityContext = s.SecurityContext
-	// TODO(#4546): Handle deprecated fields
-	// Name, Ports, LivenessProbe, ReadinessProbe, StartupProbe, Lifecycle, TerminationMessagePath
-	// TerminationMessagePolicy, Stdin, StdinOnce, TTY
+
 }
 
 func (s *StepTemplate) convertFrom(ctx context.Context, source *v1.StepTemplate) {

--- a/pkg/apis/pipeline/v1beta1/container_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/container_conversion.go
@@ -137,7 +137,6 @@ func (s StepTemplate) convertTo(ctx context.Context, sink *v1.StepTemplate) {
 	sink.VolumeDevices = s.VolumeDevices
 	sink.ImagePullPolicy = s.ImagePullPolicy
 	sink.SecurityContext = s.SecurityContext
-
 }
 
 func (s *StepTemplate) convertFrom(ctx context.Context, source *v1.StepTemplate) {


### PR DESCRIPTION
# Changes
Removes a stale TODO comment in container_conversion.go that references 
issue #4546 which has since been closed. The comment was no longer 
relevant as the referenced issue was resolved.

Relates to #9492

# Submitter Checklist
- [x] Follows the commit message standard
- [x] Has a kind label

# Release Notes
```release-note
NONE
```
