### PR TITLE
fix: avoid spurious termination parse warning

### DIFF
--- a/pkg/termination/write.go
+++ b/pkg/termination/write.go
@@ -55,12 +55,23 @@ func writeMessage(path string, pro []result.RunResult, compress bool) error {
 	// if the file at path exists, concatenate the new values otherwise create it
 	fileContents, err := os.ReadFile(path)
 	if err == nil {
-		existing, parseErr := parseExisting(fileContents)
-		if parseErr != nil {
-			slog.Warn("Failed to parse existing termination message, previous results will be lost",
-				"error", parseErr, "path", path)
-		} else {
-			pro = append(existing, pro...)
+		// The termination message file can already exist but be empty before the
+		// entrypoint writes any results. Treat that the same as a missing file so
+		// steps do not emit a warning for normal first writes.
+		if len(bytes.TrimSpace(fileContents)) > 0 {
+			existing, parseErr := parseExisting(fileContents)
+			if parseErr != nil {
+				// When compression is disabled, invalid existing contents are simply
+				// overwritten by the new result payload. Avoid emitting a warning from
+				// the non-compression path. When compression is enabled, keep the warning
+				// because parsing failures might indicate a malformed compressed payload.
+				if compress {
+					slog.Warn("Failed to parse existing termination message, previous results will be lost",
+						"error", parseErr, "path", path)
+				}
+			} else {
+				pro = append(existing, pro...)
+			}
 		}
 	} else if !os.IsNotExist(err) {
 		return err

--- a/pkg/termination/write_test.go
+++ b/pkg/termination/write_test.go
@@ -17,6 +17,7 @@ package termination_test
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
@@ -63,6 +64,63 @@ func TestExistingFile(t *testing.T) {
 		if d := cmp.Diff(want, string(fileContents)); d != "" {
 			t.Fatalf("Diff %s", diff.PrintWantGot(d))
 		}
+	}
+}
+
+func TestWriteMessageDoesNotWarnForUnparseableExistingFile(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		existing string
+	}{
+		{
+			name:     "empty",
+			existing: "",
+		}, {
+			name:     "invalid json",
+			existing: "not-json",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile, err := os.CreateTemp(t.TempDir(), "tempFile")
+			if err != nil {
+				t.Fatal("Cannot create temporary file", err)
+			}
+			if _, err := tmpFile.WriteString(tt.existing); err != nil {
+				t.Fatalf("Cannot write existing contents: %v", err)
+			}
+			if err := tmpFile.Close(); err != nil {
+				t.Fatal("Cannot close temporary file", err)
+			}
+
+			var logOutput strings.Builder
+			oldLogger := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+			t.Cleanup(func() {
+				slog.SetDefault(oldLogger)
+			})
+
+			output := []result.RunResult{{
+				Key:   "key1",
+				Value: "hello",
+			}}
+
+			if err := termination.WriteMessage(tmpFile.Name(), output); err != nil {
+				t.Fatalf("WriteMessage: %v", err)
+			}
+
+			if strings.Contains(logOutput.String(), "Failed to parse existing termination message") {
+				t.Fatalf("WriteMessage logged parse warning for %s existing termination message: %s", tt.name, logOutput.String())
+			}
+
+			fileContents, err := os.ReadFile(tmpFile.Name())
+			if err != nil {
+				t.Fatalf("ReadFile: %v", err)
+			}
+			want := `[{"key":"key1","value":"hello"}]`
+			if d := cmp.Diff(want, string(fileContents)); d != "" {
+				t.Fatalf("Diff %s", diff.PrintWantGot(d))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When termination message compression is disabled, `WriteMessage` should not emit the warning added for compressed termination message parsing failures. This keeps ordinary step logs from showing compression-related warnings when the feature flag is not enabled.

This PR:

- skips parsing when the existing termination message file is empty
- only logs `Failed to parse existing termination message` from the compression-enabled write path
- adds unit coverage for empty and invalid existing termination message contents with compression disabled

Fixes #10159.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed spurious step log warnings about parsing existing termination messages when termination message compression is disabled.
```