### PR TITLE
Added distributed tracing support for when expression evaluation

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -795,8 +795,9 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	}
 
 	// Evaluate the CEL of PipelineTask after the variable substitutions and validations.
+	// tracer := c.tracerProvider.Tracer(TracerName)
 	for _, rpt := range pipelineRunFacts.State {
-		err := rpt.EvaluateCEL()
+		err := rpt.EvaluateCEL(ctx)
 		if err != nil {
 			logger.Errorf("Error evaluating CEL %s: %v", pr.Name, err)
 			pr.Status.MarkFailed(string(v1.PipelineRunReasonCELEvaluationFailed),
@@ -927,10 +928,10 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	after = pr.Status.GetCondition(apis.ConditionSucceeded)
 	pr.Status.StartTime = pipelineRunFacts.State.AdjustStartTime(pr.Status.StartTime)
 
-	pr.Status.ChildReferences = pipelineRunFacts.GetChildReferences()
+	pr.Status.ChildReferences = pipelineRunFacts.GetChildReferences(ctx)
 
-	pr.Status.SkippedTasks = pipelineRunFacts.GetSkippedTasks()
-	pipelineTaskStatus := pipelineRunFacts.GetPipelineTaskStatus()
+	pr.Status.SkippedTasks = pipelineRunFacts.GetSkippedTasks(ctx)
+	pipelineTaskStatus := pipelineRunFacts.GetPipelineTaskStatus(ctx)
 	finalPipelineTaskStatus := pipelineRunFacts.GetPipelineFinalTaskStatus()
 	pipelineTaskStatus = kmap.Union(pipelineTaskStatus, finalPipelineTaskStatus)
 
@@ -964,7 +965,7 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 	recorder := controller.GetEventRecorder(ctx)
 
 	// nextRpts holds a list of pipeline tasks which should be executed next
-	nextRpts, err := pipelineRunFacts.DAGExecutionQueue()
+	nextRpts, err := pipelineRunFacts.DAGExecutionQueue(ctx)
 	if err != nil {
 		logger.Errorf("Error getting potential next tasks for valid pipelinerun %s: %v", pr.Name, err)
 		return controller.NewPermanentError(err)
@@ -1000,10 +1001,10 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 		}
 	}
 	// GetFinalTasks only returns final tasks when a DAG is complete
-	fNextRpts := pipelineRunFacts.GetFinalTasks()
+	fNextRpts := pipelineRunFacts.GetFinalTasks(ctx)
 	if len(fNextRpts) != 0 {
 		// apply the runtime context just before creating taskRuns for final tasks in queue
-		resources.ApplyPipelineTaskStateContext(fNextRpts, pipelineRunFacts.GetPipelineTaskStatus())
+		resources.ApplyPipelineTaskStateContext(fNextRpts, pipelineRunFacts.GetPipelineTaskStatus(ctx))
 
 		// Before creating TaskRun for scheduled final task, check if it's consuming a task result
 		// Resolve and apply task result wherever applicable, report warning in case resolution fails
@@ -1015,7 +1016,7 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 			}
 			resources.ApplyTaskResults(resources.PipelineRunState{rpt}, resolvedResultRefs)
 
-			if err := rpt.EvaluateCEL(); err != nil {
+			if err := rpt.EvaluateCEL(ctx); err != nil {
 				logger.Errorf("Final task %q is not executed, due to error evaluating CEL %s: %v", rpt.PipelineTask.Name, pr.Name, err)
 				pr.Status.MarkFailed(string(v1.PipelineRunReasonCELEvaluationFailed),
 					"Error evaluating CEL %s: %v", pr.Name, pipelineErrors.WrapUserError(err))
@@ -1028,7 +1029,7 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 
 	// If FinallyStartTime is not set, and one or more final tasks has been created
 	// Try to set the FinallyStartTime of this PipelineRun
-	if pr.Status.FinallyStartTime == nil && pipelineRunFacts.IsFinalTaskStarted() {
+	if pr.Status.FinallyStartTime == nil && pipelineRunFacts.IsFinalTaskStarted(ctx) {
 		c.setFinallyStartedTimeIfNeeded(pr, pipelineRunFacts)
 	}
 
@@ -1039,7 +1040,7 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.Pipeline
 			c.setFinallyStartedTimeIfNeeded(pr, pipelineRunFacts)
 		}
 
-		if rpt == nil || rpt.Skip(pipelineRunFacts).IsSkipped || rpt.IsFinallySkipped(pipelineRunFacts).IsSkipped {
+		if rpt == nil || rpt.Skip(ctx, pipelineRunFacts).IsSkipped || rpt.IsFinallySkipped(ctx, pipelineRunFacts).IsSkipped {
 			continue
 		}
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -511,7 +511,6 @@ func (t *ResolvedPipelineTask) Skip(ctx context.Context, facts *PipelineRunFacts
 // skipBecauseWhenExpressionsEvaluatedToFalse confirms that the when expressions have completed evaluating, and
 // it returns true if any of the when expressions evaluate to false
 func (t *ResolvedPipelineTask) skipBecauseWhenExpressionsEvaluatedToFalse(ctx context.Context, facts *PipelineRunFacts) bool {
-
 	_, span := otel.Tracer("TracerName").Start(ctx, "skipBecauseWhenExpressionsEvaluatedToFalse")
 	defer span.End()
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -34,6 +34,9 @@ import (
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"github.com/tektoncd/pipeline/pkg/resolution/resource"
 	"github.com/tektoncd/pipeline/pkg/substitution"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
@@ -101,8 +104,13 @@ type ResolvedPipelineTask struct {
 }
 
 // EvaluateCEL evaluate the CEL expressions, and store the evaluated results in EvaluatedCEL
-func (t *ResolvedPipelineTask) EvaluateCEL() error {
+func (t *ResolvedPipelineTask) EvaluateCEL(ctx context.Context) error {
+	_, span := otel.Tracer("TracerName").Start(ctx, "EvaluateCEL")
+	defer span.End()
+
 	if t.PipelineTask != nil {
+		span.SetAttributes(attribute.String("PipelineTask", t.PipelineTask.Name))
+
 		// Each call to this function will reset this field to prevent additional CELs.
 		t.EvaluatedCEL = make(map[string]bool)
 		for _, we := range t.PipelineTask.When {
@@ -111,31 +119,48 @@ func (t *ResolvedPipelineTask) EvaluateCEL() error {
 			}
 			_, ok := t.EvaluatedCEL[we.CEL]
 			if !ok {
+
+				_, exprSpan := otel.Tracer("TracerName").Start(ctx, "EvaluateWhenExpression")
+				exprSpan.SetAttributes(attribute.String("CEL", we.CEL))
 				// Create a program environment configured with the standard library of CEL functions and macros
 				// The error is omitted because not environment declarations are passed in.
 				env, _ := cel.NewEnv()
 				// Parse and Check the CEL to get the Abstract Syntax Tree
 				ast, iss := env.Compile(we.CEL)
 				if iss.Err() != nil {
+					exprSpan.SetStatus(codes.Error, "Parse and Check the CEL error")
+					exprSpan.RecordError(iss.Err())
+					exprSpan.End()
 					return iss.Err()
 				}
 				// Generate an evaluatable instance of the Ast within the environment
 				prg, err := env.Program(ast)
 				if err != nil {
+					exprSpan.SetStatus(codes.Error, "Generate an evaluatable instance error")
+					exprSpan.RecordError(err)
+					exprSpan.End()
 					return err
 				}
 				// Evaluate the CEL expression
 				out, _, err := prg.Eval(map[string]interface{}{})
 				if err != nil {
+					exprSpan.SetStatus(codes.Error, "Evaluate the CEL expression error")
+					exprSpan.RecordError(err)
+					exprSpan.End()
 					return err
 				}
 
 				b, ok := out.Value().(bool)
 				if ok {
 					t.EvaluatedCEL[we.CEL] = b
+					exprSpan.SetAttributes(attribute.Bool("CEL.result", b))
 				} else {
-					return fmt.Errorf("The CEL expression %s is not evaluated to a boolean", we.CEL)
+					err := fmt.Errorf("The CEL expression %s is not evaluated to a boolean", we.CEL)
+					exprSpan.RecordError(err)
+					exprSpan.End()
+					return err
 				}
+				exprSpan.End()
 			}
 		}
 	}
@@ -143,8 +168,8 @@ func (t *ResolvedPipelineTask) EvaluateCEL() error {
 }
 
 // isDone returns true only if the task is skipped, succeeded or failed
-func (t ResolvedPipelineTask) isDone(facts *PipelineRunFacts) bool {
-	return t.Skip(facts).IsSkipped || t.isSuccessful() || t.isFailure() || t.isValidationFailed(facts.ValidationFailedTask)
+func (t ResolvedPipelineTask) isDone(ctx context.Context, facts *PipelineRunFacts) bool {
+	return t.Skip(ctx, facts).IsSkipped || t.isSuccessful() || t.isFailure() || t.isValidationFailed(facts.ValidationFailedTask)
 }
 
 // IsRunning returns true only if the task is neither succeeded, cancelled nor failed
@@ -419,21 +444,21 @@ func (t ResolvedPipelineTask) haveAnyCustomRunsFailed() bool {
 	return false
 }
 
-func (t *ResolvedPipelineTask) checkParentsDone(facts *PipelineRunFacts) bool {
+func (t *ResolvedPipelineTask) checkParentsDone(ctx context.Context, facts *PipelineRunFacts) bool {
 	if facts.isFinalTask(t.PipelineTask.Name) {
 		return true
 	}
 	stateMap := facts.State.ToMap()
 	node := facts.TasksGraph.Nodes[t.PipelineTask.Name]
 	for _, p := range node.Prev {
-		if !stateMap[p.Key].isDone(facts) {
+		if !stateMap[p.Key].isDone(ctx, facts) {
 			return false
 		}
 	}
 	return true
 }
 
-func (t *ResolvedPipelineTask) skip(facts *PipelineRunFacts) TaskSkipStatus {
+func (t *ResolvedPipelineTask) skip(ctx context.Context, facts *PipelineRunFacts) TaskSkipStatus {
 	var skippingReason v1.SkippingReason
 
 	switch {
@@ -445,15 +470,15 @@ func (t *ResolvedPipelineTask) skip(facts *PipelineRunFacts) TaskSkipStatus {
 		skippingReason = v1.GracefullyCancelledSkip
 	case facts.IsGracefullyStopped():
 		skippingReason = v1.GracefullyStoppedSkip
-	case t.skipBecauseWhenExpressionsEvaluatedToFalse(facts):
+	case t.skipBecauseWhenExpressionsEvaluatedToFalse(ctx, facts):
 		skippingReason = v1.WhenExpressionsSkip
-	case t.skipBecauseParentTaskWasSkipped(facts):
+	case t.skipBecauseParentTaskWasSkipped(ctx, facts):
 		skippingReason = v1.ParentTasksSkip
-	case t.skipBecauseResultReferencesAreMissing(facts):
+	case t.skipBecauseResultReferencesAreMissing(ctx, facts):
 		skippingReason = v1.MissingResultsSkip
-	case t.skipBecausePipelineRunPipelineTimeoutReached(facts):
+	case t.skipBecausePipelineRunPipelineTimeoutReached(ctx, facts):
 		skippingReason = v1.PipelineTimedOutSkip
-	case t.skipBecausePipelineRunTasksTimeoutReached(facts):
+	case t.skipBecausePipelineRunTasksTimeoutReached(ctx, facts):
 		skippingReason = v1.TasksTimedOutSkip
 	case t.skipBecauseEmptyArrayInMatrixParams():
 		skippingReason = v1.EmptyArrayInMatrixParams
@@ -473,21 +498,29 @@ func (t *ResolvedPipelineTask) skip(facts *PipelineRunFacts) TaskSkipStatus {
 // (3) its parent task was skipped
 // (4) Pipeline is in stopping state (one of the PipelineTasks failed)
 // (5) Pipeline is gracefully cancelled or stopped
-func (t *ResolvedPipelineTask) Skip(facts *PipelineRunFacts) TaskSkipStatus {
+func (t *ResolvedPipelineTask) Skip(ctx context.Context, facts *PipelineRunFacts) TaskSkipStatus {
 	if facts.SkipCache == nil {
 		facts.SkipCache = make(map[string]TaskSkipStatus)
 	}
 	if _, cached := facts.SkipCache[t.PipelineTask.Name]; !cached {
-		facts.SkipCache[t.PipelineTask.Name] = t.skip(facts)
+		facts.SkipCache[t.PipelineTask.Name] = t.skip(ctx, facts)
 	}
 	return facts.SkipCache[t.PipelineTask.Name]
 }
 
 // skipBecauseWhenExpressionsEvaluatedToFalse confirms that the when expressions have completed evaluating, and
 // it returns true if any of the when expressions evaluate to false
-func (t *ResolvedPipelineTask) skipBecauseWhenExpressionsEvaluatedToFalse(facts *PipelineRunFacts) bool {
-	if t.checkParentsDone(facts) {
-		if !t.PipelineTask.When.AllowsExecution(t.EvaluatedCEL) {
+func (t *ResolvedPipelineTask) skipBecauseWhenExpressionsEvaluatedToFalse(ctx context.Context, facts *PipelineRunFacts) bool {
+
+	_, span := otel.Tracer("TracerName").Start(ctx, "skipBecauseWhenExpressionsEvaluatedToFalse")
+	defer span.End()
+
+	if t.checkParentsDone(ctx, facts) {
+		allows := t.PipelineTask.When.AllowsExecution(t.EvaluatedCEL)
+		span.SetAttributes(attribute.Bool("when_allows_execution", allows))
+
+		if !allows {
+			span.SetAttributes(attribute.String("when_skip_reason", "whenExpressionSkip"))
 			return true
 		}
 	}
@@ -500,12 +533,12 @@ func (t *ResolvedPipelineTask) skipBecauseWhenExpressionsEvaluatedToFalse(facts 
 //	    if yes, it ignores this parent skip and continue evaluating other parent tasks
 //	    if no, it returns true to skip the current task because this parent task was skipped
 //	if no, it continues checking the other parent tasks
-func (t *ResolvedPipelineTask) skipBecauseParentTaskWasSkipped(facts *PipelineRunFacts) bool {
+func (t *ResolvedPipelineTask) skipBecauseParentTaskWasSkipped(ctx context.Context, facts *PipelineRunFacts) bool {
 	stateMap := facts.State.ToMap()
 	node := facts.TasksGraph.Nodes[t.PipelineTask.Name]
 	for _, p := range node.Prev {
 		parentTask := stateMap[p.Key]
-		if parentSkipStatus := parentTask.Skip(facts); parentSkipStatus.IsSkipped {
+		if parentSkipStatus := parentTask.Skip(ctx, facts); parentSkipStatus.IsSkipped {
 			// if the parent task was skipped due to its `when` expressions,
 			// then we should ignore that and continue evaluating if we should skip because of other parent tasks
 			if parentSkipStatus.SkippingReason == v1.WhenExpressionsSkip {
@@ -519,14 +552,14 @@ func (t *ResolvedPipelineTask) skipBecauseParentTaskWasSkipped(facts *PipelineRu
 
 // skipBecauseResultReferencesAreMissing checks if the task references results that cannot be resolved, which is a
 // reason for skipping the task, and applies result references if found
-func (t *ResolvedPipelineTask) skipBecauseResultReferencesAreMissing(facts *PipelineRunFacts) bool {
-	if t.checkParentsDone(facts) && t.hasResultReferences() {
+func (t *ResolvedPipelineTask) skipBecauseResultReferencesAreMissing(ctx context.Context, facts *PipelineRunFacts) bool {
+	if t.checkParentsDone(ctx, facts) && t.hasResultReferences() {
 		resolvedResultRefs, pt, err := ResolveResultRefs(facts.State, PipelineRunState{t})
 		rpt := facts.State.ToMap()[pt]
 		if rpt != nil {
 			if err != nil &&
 				(t.PipelineTask.OnError == v1.PipelineTaskContinue ||
-					(t.IsFinalTask(facts) || rpt.Skip(facts).SkippingReason == v1.WhenExpressionsSkip)) {
+					(t.IsFinalTask(facts) || rpt.Skip(ctx, facts).SkippingReason == v1.WhenExpressionsSkip)) {
 				return true
 			}
 		}
@@ -538,8 +571,8 @@ func (t *ResolvedPipelineTask) skipBecauseResultReferencesAreMissing(facts *Pipe
 
 // skipBecausePipelineRunPipelineTimeoutReached returns true if the task shouldn't be launched because the elapsed time since
 // the PipelineRun started is greater than the PipelineRun's pipeline timeout
-func (t *ResolvedPipelineTask) skipBecausePipelineRunPipelineTimeoutReached(facts *PipelineRunFacts) bool {
-	if t.checkParentsDone(facts) {
+func (t *ResolvedPipelineTask) skipBecausePipelineRunPipelineTimeoutReached(ctx context.Context, facts *PipelineRunFacts) bool {
+	if t.checkParentsDone(ctx, facts) {
 		if facts.TimeoutsState.PipelineTimeout != nil && *facts.TimeoutsState.PipelineTimeout != config.NoTimeoutDuration && facts.TimeoutsState.StartTime != nil {
 			// If the elapsed time since the PipelineRun's start time is greater than the PipelineRun's Pipeline timeout, skip.
 			return facts.TimeoutsState.Clock.Since(*facts.TimeoutsState.StartTime) > *facts.TimeoutsState.PipelineTimeout
@@ -551,8 +584,8 @@ func (t *ResolvedPipelineTask) skipBecausePipelineRunPipelineTimeoutReached(fact
 
 // skipBecausePipelineRunTasksTimeoutReached returns true if the task shouldn't be launched because the elapsed time since
 // the PipelineRun started is greater than the PipelineRun's tasks timeout
-func (t *ResolvedPipelineTask) skipBecausePipelineRunTasksTimeoutReached(facts *PipelineRunFacts) bool {
-	if t.checkParentsDone(facts) && !t.IsFinalTask(facts) {
+func (t *ResolvedPipelineTask) skipBecausePipelineRunTasksTimeoutReached(ctx context.Context, facts *PipelineRunFacts) bool {
+	if t.checkParentsDone(ctx, facts) && !t.IsFinalTask(facts) {
 		if facts.TimeoutsState.TasksTimeout != nil && *facts.TimeoutsState.TasksTimeout != config.NoTimeoutDuration && facts.TimeoutsState.StartTime != nil {
 			// If the elapsed time since the PipelineRun's start time is greater than the PipelineRun's Tasks timeout, skip.
 			return facts.TimeoutsState.Clock.Since(*facts.TimeoutsState.StartTime) > *facts.TimeoutsState.TasksTimeout
@@ -564,8 +597,8 @@ func (t *ResolvedPipelineTask) skipBecausePipelineRunTasksTimeoutReached(facts *
 
 // skipBecausePipelineRunFinallyTimeoutReached returns true if the task shouldn't be launched because the elapsed time since
 // finally tasks started being executed is greater than the PipelineRun's finally timeout
-func (t *ResolvedPipelineTask) skipBecausePipelineRunFinallyTimeoutReached(facts *PipelineRunFacts) bool {
-	if t.checkParentsDone(facts) && t.IsFinalTask(facts) {
+func (t *ResolvedPipelineTask) skipBecausePipelineRunFinallyTimeoutReached(ctx context.Context, facts *PipelineRunFacts) bool {
+	if t.checkParentsDone(ctx, facts) && t.IsFinalTask(facts) {
 		if facts.TimeoutsState.FinallyTimeout != nil && *facts.TimeoutsState.FinallyTimeout != config.NoTimeoutDuration && facts.TimeoutsState.FinallyStartTime != nil {
 			// If the elapsed time since the PipelineRun's finally start time is greater than the PipelineRun's finally timeout, skip.
 			return facts.TimeoutsState.Clock.Since(*facts.TimeoutsState.FinallyStartTime) > *facts.TimeoutsState.FinallyTimeout
@@ -594,21 +627,21 @@ func (t *ResolvedPipelineTask) IsFinalTask(facts *PipelineRunFacts) bool {
 }
 
 // IsFinallySkipped returns true if a finally task is not executed and skipped due to task result validation failure
-func (t *ResolvedPipelineTask) IsFinallySkipped(facts *PipelineRunFacts) TaskSkipStatus {
+func (t *ResolvedPipelineTask) IsFinallySkipped(ctx context.Context, facts *PipelineRunFacts) TaskSkipStatus {
 	var skippingReason v1.SkippingReason
 
 	switch {
 	case t.isScheduled():
 		skippingReason = v1.None
-	case facts.checkDAGTasksDone() && facts.isFinalTask(t.PipelineTask.Name):
+	case facts.checkDAGTasksDone(ctx) && facts.isFinalTask(t.PipelineTask.Name):
 		switch {
-		case t.skipBecauseResultReferencesAreMissing(facts):
+		case t.skipBecauseResultReferencesAreMissing(ctx, facts):
 			skippingReason = v1.MissingResultsSkip
-		case t.skipBecauseWhenExpressionsEvaluatedToFalse(facts):
+		case t.skipBecauseWhenExpressionsEvaluatedToFalse(ctx, facts):
 			skippingReason = v1.WhenExpressionsSkip
-		case t.skipBecausePipelineRunPipelineTimeoutReached(facts):
+		case t.skipBecausePipelineRunPipelineTimeoutReached(ctx, facts):
 			skippingReason = v1.PipelineTimedOutSkip
-		case t.skipBecausePipelineRunFinallyTimeoutReached(facts):
+		case t.skipBecausePipelineRunFinallyTimeoutReached(ctx, facts):
 			skippingReason = v1.FinallyTimedOutSkip
 		case t.skipBecauseEmptyArrayInMatrixParams():
 			skippingReason = v1.EmptyArrayInMatrixParams

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1445,7 +1445,7 @@ func TestIsSkipped(t *testing.T) {
 				if rpt == nil {
 					t.Fatalf("Could not get task %s from the state: %v", taskName, tc.state)
 				}
-				if d := cmp.Diff(isSkipped, rpt.Skip(&facts).IsSkipped); d != "" {
+				if d := cmp.Diff(isSkipped, rpt.Skip(context.Background(), &facts).IsSkipped); d != "" {
 					t.Errorf("Didn't get expected isSkipped from task %s: %s", taskName, diff.PrintWantGot(d))
 				}
 			}
@@ -2555,7 +2555,7 @@ func TestSkipBecauseParentTaskWasSkipped(t *testing.T) {
 				if rpt == nil {
 					t.Fatalf("Could not get task %s from the state: %v", taskName, tc.state)
 				}
-				if d := cmp.Diff(isSkipped, rpt.skipBecauseParentTaskWasSkipped(&facts)); d != "" {
+				if d := cmp.Diff(isSkipped, rpt.skipBecauseParentTaskWasSkipped(context.Background(), &facts)); d != "" {
 					t.Errorf("Didn't get expected isSkipped from task %s: %s", taskName, diff.PrintWantGot(d))
 				}
 			}
@@ -3493,7 +3493,7 @@ func TestResolvedPipelineRunTask_IsFinallySkipped(t *testing.T) {
 			for i := range state {
 				if i > 0 { // first one is a dag task that produces a result
 					finallyTaskName := state[i].PipelineTask.Name
-					if d := cmp.Diff(tc.expected[finallyTaskName], state[i].IsFinallySkipped(facts).IsSkipped); d != "" {
+					if d := cmp.Diff(tc.expected[finallyTaskName], state[i].IsFinallySkipped(context.Background(), facts).IsSkipped); d != "" {
 						t.Fatalf("Didn't get expected isFinallySkipped from finally task %s: %s", finallyTaskName, diff.PrintWantGot(d))
 					}
 				}
@@ -3623,7 +3623,7 @@ func TestResolvedPipelineRunTask_IsFinallySkippedByCondition(t *testing.T) {
 			}
 
 			for _, state := range tc.state[1:] {
-				got := state.IsFinallySkipped(facts)
+				got := state.IsFinallySkipped(context.Background(), facts)
 				if d := cmp.Diff(tc.want, got); d != "" {
 					t.Errorf("IsFinallySkipped: %s", diff.PrintWantGot(d))
 				}
@@ -5676,7 +5676,7 @@ func TestEvaluateCEL_valid(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.rpt.EvaluateCEL()
+			err := tc.rpt.EvaluateCEL(context.Background())
 			if err != nil {
 				t.Fatalf("Got unexpected err:%v", err)
 			}
@@ -5713,7 +5713,7 @@ func TestEvaluateCEL_invalid(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.rpt.EvaluateCEL()
+			err := tc.rpt.EvaluateCEL(context.Background())
 			if err == nil {
 				t.Fatalf("Expected err but got nil")
 			}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -273,12 +273,12 @@ func (state PipelineRunState) GetRunsResults() map[string][]v1beta1.CustomRunRes
 
 // GetChildReferences returns a slice of references, including version, kind, name, and pipeline task name, for all
 // child PipelineRuns, TaskRuns and Runs in the state.
-func (facts *PipelineRunFacts) GetChildReferences() []v1.ChildStatusReference {
+func (facts *PipelineRunFacts) GetChildReferences(ctx context.Context) []v1.ChildStatusReference {
 	var childRefs []v1.ChildStatusReference
 
 	for _, rpt := range facts.State {
 		// try to replace the parameters of the reference result of when expression in the TaskRun that has ended
-		if rpt.isDone(facts) {
+		if rpt.isDone(ctx, facts) {
 			resolvedResultRefs, _, err := ResolveResultRefs(facts.State, PipelineRunState{rpt})
 			if err == nil {
 				ApplyTaskResults(facts.State, resolvedResultRefs)
@@ -456,7 +456,7 @@ func (facts *PipelineRunFacts) IsGracefullyStopped() bool {
 }
 
 // DAGExecutionQueue returns a list of DAG tasks which needs to be scheduled next
-func (facts *PipelineRunFacts) DAGExecutionQueue() (PipelineRunState, error) {
+func (facts *PipelineRunFacts) DAGExecutionQueue(ctx context.Context) (PipelineRunState, error) {
 	var tasks PipelineRunState
 	// when pipelinerun is cancelled or gracefully cancelled, do not schedule any new tasks,
 	// and only wait for all running tasks to complete (without exhausting retries).
@@ -465,7 +465,7 @@ func (facts *PipelineRunFacts) DAGExecutionQueue() (PipelineRunState, error) {
 	}
 	// candidateTasks is initialized to DAG root nodes to start pipeline execution
 	// candidateTasks is derived based on successfully finished tasks and/or skipped tasks
-	candidateTasks, err := dag.GetCandidateTasks(facts.TasksGraph, facts.completedOrSkippedDAGTasks()...)
+	candidateTasks, err := dag.GetCandidateTasks(facts.TasksGraph, facts.completedOrSkippedDAGTasks(ctx)...)
 	if err != nil {
 		return tasks, err
 	}
@@ -501,12 +501,12 @@ func (facts *PipelineRunFacts) GetTaskNames() sets.String {
 
 // GetFinalTasks returns a list of final tasks which needs to be executed next
 // GetFinalTasks returns final tasks only when all DAG tasks have finished executing or have been skipped
-func (facts *PipelineRunFacts) GetFinalTasks() PipelineRunState {
+func (facts *PipelineRunFacts) GetFinalTasks(ctx context.Context) PipelineRunState {
 	tasks := PipelineRunState{}
 	finalCandidates := sets.NewString()
 	// check either pipeline has finished executing all DAG pipelineTasks,
 	// where "finished executing" means succeeded, failed, or skipped.
-	if facts.checkDAGTasksDone() {
+	if facts.checkDAGTasksDone(ctx) {
 		// return list of tasks with all final tasks
 		for _, t := range facts.State {
 			if facts.isFinalTask(t.PipelineTask.Name) {
@@ -519,10 +519,10 @@ func (facts *PipelineRunFacts) GetFinalTasks() PipelineRunState {
 }
 
 // IsFinalTaskStarted returns true if all DAG pipelineTasks is finished and one or more final tasks have been created.
-func (facts *PipelineRunFacts) IsFinalTaskStarted() bool {
+func (facts *PipelineRunFacts) IsFinalTaskStarted(ctx context.Context) bool {
 	// check either pipeline has finished executing all DAG pipelineTasks,
 	// where "finished executing" means succeeded, failed, or skipped.
-	if facts.checkDAGTasksDone() {
+	if facts.checkDAGTasksDone(ctx) {
 		// return list of tasks with all final tasks
 		for _, t := range facts.State {
 			if facts.isFinalTask(t.PipelineTask.Name) && t.isScheduled() {
@@ -555,7 +555,7 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, p
 		// If there are finally tasks that haven't completed yet, allow the pipeline to keep
 		// running so that finally tasks can execute. Only fail immediately if there are no
 		// finally tasks or all finally tasks have already completed.
-		if !facts.hasFinalTasks() || facts.checkFinalTasksDone() {
+		if !facts.hasFinalTasks() || facts.checkFinalTasksDone(ctx) {
 			return &apis.Condition{
 				Type:    apis.ConditionSucceeded,
 				Status:  corev1.ConditionFalse,
@@ -568,7 +568,7 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, p
 
 	// report the count in PipelineRun Status
 	// get the count of successful tasks, failed tasks, cancelled tasks, skipped task, and incomplete tasks
-	s := facts.getPipelineTasksCount()
+	s := facts.getPipelineTasksCount(ctx)
 	// completed task is a collection of successful, failed, cancelled tasks
 	// (skipped tasks and validation failed tasks are reported separately)
 	cmTasks := s.Succeeded + s.Failed + s.Cancelled + s.IgnoredFailed
@@ -644,7 +644,7 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, p
 
 	// Not all tasks (regular + finally) have finished.... Must keep running then....
 	switch {
-	case pr.HaveTasksTimedOut(ctx, c) && facts.hasFinalTasks() && !facts.checkFinalTasksDone():
+	case pr.HaveTasksTimedOut(ctx, c) && facts.hasFinalTasks() && !facts.checkFinalTasksDone(ctx):
 		// Tasks have timed out but finally tasks are still running
 		reason = v1.PipelineRunReasonTimedOutRunningFinally.String()
 	case pr.IsGracefullyCancelled():
@@ -653,7 +653,7 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, p
 	case pr.IsGracefullyStopped():
 		// Transition pipeline into running finally state, when graceful stop is in progress
 		reason = v1.PipelineRunReasonStoppedRunningFinally.String()
-	case s.Cancelled > 0 || (s.Failed > 0 && facts.checkFinalTasksDone()):
+	case s.Cancelled > 0 || (s.Failed > 0 && facts.checkFinalTasksDone(ctx)):
 		// Transition pipeline into stopping state when one of the tasks(dag/final) cancelled or one of the dag tasks failed
 		// for a pipeline with final tasks, single dag task failure does not transition to interim stopping state
 		// pipeline stays in running state until all final tasks are done before transitioning to failed state
@@ -671,25 +671,25 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, p
 }
 
 // GetSkippedTasks constructs a list of SkippedTask struct to be included in the PipelineRun Status
-func (facts *PipelineRunFacts) GetSkippedTasks() []v1.SkippedTask {
+func (facts *PipelineRunFacts) GetSkippedTasks(ctx context.Context) []v1.SkippedTask {
 	var skipped []v1.SkippedTask
 	for _, rpt := range facts.State {
-		if rpt.Skip(facts).IsSkipped {
+		if rpt.Skip(ctx, facts).IsSkipped {
 			skippedTask := v1.SkippedTask{
 				Name:            rpt.PipelineTask.Name,
-				Reason:          rpt.Skip(facts).SkippingReason,
+				Reason:          rpt.Skip(ctx, facts).SkippingReason,
 				WhenExpressions: rpt.PipelineTask.When,
 			}
 			skipped = append(skipped, skippedTask)
 		}
-		if rpt.IsFinallySkipped(facts).IsSkipped {
+		if rpt.IsFinallySkipped(ctx, facts).IsSkipped {
 			skippedTask := v1.SkippedTask{
 				Name:   rpt.PipelineTask.Name,
-				Reason: rpt.IsFinallySkipped(facts).SkippingReason,
+				Reason: rpt.IsFinallySkipped(ctx, facts).SkippingReason,
 			}
 			// include the when expressions only when the finally task was skipped because
 			// its when expressions evaluated to false (not because results variables were missing)
-			if rpt.IsFinallySkipped(facts).SkippingReason == v1.WhenExpressionsSkip {
+			if rpt.IsFinallySkipped(ctx, facts).SkippingReason == v1.WhenExpressionsSkip {
 				skippedTask.WhenExpressions = rpt.PipelineTask.When
 			}
 			skipped = append(skipped, skippedTask)
@@ -701,7 +701,7 @@ func (facts *PipelineRunFacts) GetSkippedTasks() []v1.SkippedTask {
 // GetPipelineTaskStatus returns the status of a PipelineTask depending on its child
 // PipelineRun/TaskRun/CustomRun. The checks are implemented such that the finally tasks
 // are requesting status of the dag tasks.
-func (facts *PipelineRunFacts) GetPipelineTaskStatus() map[string]string {
+func (facts *PipelineRunFacts) GetPipelineTaskStatus(ctx context.Context) map[string]string {
 	// construct a map of tasks.<pipelineTask>.status and its state
 	tStatus := make(map[string]string)
 	for _, t := range facts.State {
@@ -725,7 +725,7 @@ func (facts *PipelineRunFacts) GetPipelineTaskStatus() map[string]string {
 
 	// initialize aggregate status of all dag tasks to None
 	aggregateStatus := PipelineTaskStateNone
-	if facts.checkDAGTasksDone() {
+	if facts.checkDAGTasksDone(ctx) {
 		// all dag pipeline tasks are done, change the aggregate status to succeeded
 		// will reset it to failed/skipped if needed
 		aggregateStatus = v1.PipelineRunReasonSuccessful.String()
@@ -750,7 +750,7 @@ func (facts *PipelineRunFacts) GetPipelineTaskStatus() map[string]string {
 				}
 				// if any of the dag task skipped, change the aggregate status to completed
 				// but continue checking for any other failure
-				if t.Skip(facts).IsSkipped {
+				if t.Skip(ctx, facts).IsSkipped {
 					aggregateStatus = v1.PipelineRunReasonCompleted.String()
 				}
 			}
@@ -787,11 +787,11 @@ func (facts *PipelineRunFacts) GetPipelineFinalTaskStatus() map[string]string {
 
 // completedOrSkippedTasks returns a list of the names of all of the PipelineTasks in state
 // which have completed or skipped
-func (facts *PipelineRunFacts) completedOrSkippedDAGTasks() []string {
+func (facts *PipelineRunFacts) completedOrSkippedDAGTasks(ctx context.Context) []string {
 	tasks := []string{}
 	for _, t := range facts.State {
 		if facts.isDAGTask(t.PipelineTask.Name) {
-			if t.isDone(facts) {
+			if t.isDone(ctx, facts) {
 				tasks = append(tasks, t.PipelineTask.Name)
 			}
 		}
@@ -801,10 +801,10 @@ func (facts *PipelineRunFacts) completedOrSkippedDAGTasks() []string {
 
 // checkTasksDone returns true if all tasks from the specified graph are finished executing
 // a task is considered done if it has failed/succeeded/skipped
-func (facts *PipelineRunFacts) checkTasksDone(d *dag.Graph) bool {
+func (facts *PipelineRunFacts) checkTasksDone(ctx context.Context, d *dag.Graph) bool {
 	for _, t := range facts.State {
 		if isTaskInGraph(t.PipelineTask.Name, d) {
-			if !t.isDone(facts) {
+			if !t.isDone(ctx, facts) {
 				return false
 			}
 		}
@@ -813,13 +813,13 @@ func (facts *PipelineRunFacts) checkTasksDone(d *dag.Graph) bool {
 }
 
 // check if all DAG tasks done executing (succeeded, failed, or skipped)
-func (facts *PipelineRunFacts) checkDAGTasksDone() bool {
-	return facts.checkTasksDone(facts.TasksGraph)
+func (facts *PipelineRunFacts) checkDAGTasksDone(ctx context.Context) bool {
+	return facts.checkTasksDone(ctx, facts.TasksGraph)
 }
 
 // check if all finally tasks done executing (succeeded or failed)
-func (facts *PipelineRunFacts) checkFinalTasksDone() bool {
-	return facts.checkTasksDone(facts.FinalTasksGraph)
+func (facts *PipelineRunFacts) checkFinalTasksDone(ctx context.Context) bool {
+	return facts.checkTasksDone(ctx, facts.FinalTasksGraph)
 }
 
 // hasFinalTasks returns true if the Pipeline has any finally tasks defined
@@ -828,7 +828,7 @@ func (facts *PipelineRunFacts) hasFinalTasks() bool {
 }
 
 // getPipelineTasksCount returns the count of successful tasks, failed tasks, cancelled tasks, skipped task, and incomplete tasks
-func (facts *PipelineRunFacts) getPipelineTasksCount() pipelineRunStatusCount {
+func (facts *PipelineRunFacts) getPipelineTasksCount(ctx context.Context) pipelineRunStatusCount {
 	s := pipelineRunStatusCount{
 		Skipped:             0,
 		Succeeded:           0,
@@ -860,16 +860,16 @@ func (facts *PipelineRunFacts) getPipelineTasksCount() pipelineRunStatusCount {
 		case t.isValidationFailed(facts.ValidationFailedTask):
 			s.ValidationFailed++
 		// increment skipped and skipped due to timeout counters since the task was skipped due to the pipeline, tasks, or finally timeout being reached before the task was launched
-		case t.Skip(facts).SkippingReason == v1.PipelineTimedOutSkip ||
-			t.Skip(facts).SkippingReason == v1.TasksTimedOutSkip ||
-			t.IsFinallySkipped(facts).SkippingReason == v1.FinallyTimedOutSkip:
+		case t.Skip(ctx, facts).SkippingReason == v1.PipelineTimedOutSkip ||
+			t.Skip(ctx, facts).SkippingReason == v1.TasksTimedOutSkip ||
+			t.IsFinallySkipped(ctx, facts).SkippingReason == v1.FinallyTimedOutSkip:
 			s.Skipped++
 			s.SkippedDueToTimeout++
 		// increment skip counter since the task is skipped
-		case t.Skip(facts).IsSkipped:
+		case t.Skip(ctx, facts).IsSkipped:
 			s.Skipped++
 		// checking if any finally tasks were referring to invalid/missing task results
-		case t.IsFinallySkipped(facts).IsSkipped:
+		case t.IsFinallySkipped(ctx, facts).IsSkipped:
 			s.Skipped++
 		// increment incomplete counter since the task is pending and not executed yet
 		default:

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -214,12 +215,12 @@ func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 				},
 			}
 
-			isDone := facts.checkTasksDone(d)
+			isDone := facts.checkTasksDone(context.Background(), d)
 			if d := cmp.Diff(tc.expected, isDone); d != "" {
 				t.Errorf("Didn't get expected checkTasksDone %s", diff.PrintWantGot(d))
 			}
 			for i, pt := range tc.state {
-				isDone = pt.isDone(&facts)
+				isDone = pt.isDone(context.Background(), &facts)
 				if d := cmp.Diff(tc.ptExpected[i], isDone); d != "" {
 					t.Errorf("Didn't get expected (ResolvedPipelineTask) isDone %s", diff.PrintWantGot(d))
 				}
@@ -1098,7 +1099,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 					Clock: testClock,
 				},
 			}
-			queue, err := facts.DAGExecutionQueue()
+			queue, err := facts.DAGExecutionQueue(context.Background())
 			if err != nil {
 				t.Errorf("unexpected error getting DAG execution queue: %s", err)
 			}
@@ -1188,7 +1189,7 @@ func TestDAGExecutionQueueSequentialTasks(t *testing.T) {
 					Clock: testClock,
 				},
 			}
-			queue, err := facts.DAGExecutionQueue()
+			queue, err := facts.DAGExecutionQueue(context.Background())
 			if err != nil {
 				t.Errorf("unexpected error getting DAG execution queue but got error %s", err)
 			}
@@ -1281,7 +1282,7 @@ func TestDAGExecutionQueueSequentialRuns(t *testing.T) {
 					Clock: testClock,
 				},
 			}
-			queue, err := facts.DAGExecutionQueue()
+			queue, err := facts.DAGExecutionQueue(context.Background())
 			if err != nil {
 				t.Errorf("unexpected error getting DAG execution queue but got error %s", err)
 			}
@@ -1380,7 +1381,7 @@ func TestDAGExecutionQueueSequentialChildPipelines(t *testing.T) {
 					Clock: testClock,
 				},
 			}
-			queue, err := facts.DAGExecutionQueue()
+			queue, err := facts.DAGExecutionQueue(context.Background())
 			if err != nil {
 				t.Errorf("unexpected error getting DAG execution queue but got error %s", err)
 			}
@@ -1480,7 +1481,7 @@ func TestPipelineRunState_CompletedOrSkippedDAGTasks(t *testing.T) {
 					Clock: testClock,
 				},
 			}
-			names := facts.completedOrSkippedDAGTasks()
+			names := facts.completedOrSkippedDAGTasks(context.Background())
 			if d := cmp.Diff(tc.expectedNames, names); d != "" {
 				t.Errorf("Expected to get completed names %v but got something different %s", tc.expectedNames, diff.PrintWantGot(d))
 			}
@@ -1711,7 +1712,7 @@ func TestPipelineRunState_GetFinalTasksAndNames(t *testing.T) {
 					Clock: testClock,
 				},
 			}
-			next := facts.GetFinalTasks()
+			next := facts.GetFinalTasks(context.Background())
 			if d := cmp.Diff(tc.expectedFinalTasks, next); d != "" {
 				t.Errorf("Didn't get expected final Tasks for %s (%s): %s", tc.name, tc.desc, diff.PrintWantGot(d))
 			}
@@ -1792,7 +1793,7 @@ func TestPipelineRunState_IsFinalTaskStarted(t *testing.T) {
 					Clock: testClock,
 				},
 			}
-			started := facts.IsFinalTaskStarted()
+			started := facts.IsFinalTaskStarted(context.Background())
 			if d := cmp.Diff(tc.expectedFinalTaskStarted, started); d != "" {
 				t.Errorf("Didn't get expected (IsFinalTaskStarted) started for %s (%s):%s", tc.name, tc.desc, diff.PrintWantGot(d))
 			}
@@ -3007,7 +3008,7 @@ func TestPipelineRunFacts_GetPipelineTaskStatus(t *testing.T) {
 					Clock: testClock,
 				},
 			}
-			s := facts.GetPipelineTaskStatus()
+			s := facts.GetPipelineTaskStatus(context.Background())
 			if d := cmp.Diff(tc.expectedStatus, s); d != "" {
 				t.Fatalf("Test failed: %s Mismatch in pipelineTask execution state %s", tc.name, diff.PrintWantGot(d))
 			}
@@ -3226,7 +3227,7 @@ func TestPipelineRunFacts_GetSkippedTasks(t *testing.T) {
 					Clock: testClock,
 				},
 			}
-			actualSkippedTasks := facts.GetSkippedTasks()
+			actualSkippedTasks := facts.GetSkippedTasks(context.Background())
 			if d := cmp.Diff(tc.expectedSkippedTasks, actualSkippedTasks); d != "" {
 				t.Fatalf("Mismatch skipped tasks %s", diff.PrintWantGot(d))
 			}
@@ -5089,7 +5090,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				TimeoutsState: PipelineRunTimeoutsState{
 					Clock: testClock,
 				},
-			}).GetChildReferences()
+			}).GetChildReferences(context.Background())
 			if d := cmp.Diff(tc.childRefs, childRefs); d != "" {
 				t.Errorf("Didn't get expected child references for %s: %s", tc.name, diff.PrintWantGot(d))
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

**Add tracing support for when expression evaluation**

This change introduces distributed tracing for when expression evaluation in PipelineRuns, enabling better observability of conditional task execution.

**Files Modified:**

1. pipelinerun.go - Added context propagation for tracing spans 
2. pipelinerunresolution.go - Added context propagation and span creation for methods mainly `EvaluateCEL` `skipBecauseWhenExpressionsEvaluatedToFalse`
3. pipelinerunresolution_test.go - Test functions updated to pass context
4. pipelinerunstate.go - Added ctx parameter to methods
5. pipelinerunstate_test.go - Test functions updated to pass context


Closes Issue [9782](https://github.com/tektoncd/pipeline/issues/9782)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
When expression evaluation will have distributed tracing support.
```
/kind feature