### PR TITLE
fix: make internal container resources opt-in

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -97,10 +97,12 @@ data:
     # Possible values include "1m", "5m", "10s", "1h", etc.
     # Example: default-maximum-resolution-timeout: "1m"
 
-    # default-container-resource-requirements allow users to update default resource requirements
-    # to a init-containers and containers of a pods create by the controller
-    # Onet: All the resource requirements are applied to init-containers and containers
-    # only if the existing resource requirements are empty.
+    # default-container-resource-requirements allow users to configure default resource
+    # requirements for init containers and containers in pods created by the controller.
+    # No resource requirements are applied by default when this key is unset.
+    # Note: All the resource requirements are applied to init-containers and containers
+    # only if the existing resource requirements are empty, except Tekton internal
+    # containers can be overridden by named entries such as prepare or place-scripts.
     # default-container-resource-requirements: |
     #   place-scripts: # updates resource requirements of a 'place-scripts' container
     #     requests:

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -178,7 +178,7 @@ _In the above example the environment variable `TEST_TEKTON` will not be overrid
 
 ## Configuring default resources requirements
 
-Resource requirements of containers created by the controller can be assigned default values. This allows to fully control the resources requirement of `TaskRun`.
+Resource requirements of containers created by the controller can be assigned default values. This allows you to fully control the resource requirements of `TaskRun` pods. Tekton does not apply resource requirements to its internal containers by default; configure this setting when your cluster policy requires requests or limits, for example in namespaces that enforce `ResourceQuota`.
 
 ```yaml
 apiVersion: v1
@@ -238,6 +238,74 @@ data:
 ```
 
 Any resource requirements set at the `Task` and `TaskRun` levels will override the default one specified in the `config-defaults` configmap.
+
+To make Tekton internal containers compatible with namespaces that require explicit requests and limits, configure named entries for `prepare`, `place-scripts`, `working-dir-initializer`, and `sidecar-tekton-log-results`, as in the following example:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: tekton-pipelines
+data:
+  default-container-resource-requirements: |
+    prepare:
+      requests:
+        cpu: "100m"
+        memory: "64Mi"
+      limits:
+        cpu: "100m"
+        memory: "64Mi"
+    place-scripts:
+      requests:
+        cpu: "100m"
+        memory: "32Mi"
+      limits:
+        cpu: "100m"
+        memory: "32Mi"
+    working-dir-initializer:
+      requests:
+        cpu: "100m"
+        memory: "16Mi"
+      limits:
+        cpu: "100m"
+        memory: "16Mi"
+    sidecar-tekton-log-results:
+      requests:
+        cpu: "50m"
+        memory: "32Mi"
+      limits:
+        cpu: "50m"
+        memory: "32Mi"
+```
+
+### Performance tuning
+
+CPU **limits** on init containers cause [CFS throttling](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-pods-with-resource-limits-are-run), which can significantly slow down TaskRun execution — especially for the `prepare` init container that copies the entrypoint binary into every pod.
+
+If your namespace does **not** require CPU limits, you can specify only `requests`. This lets init containers burst to use available CPU while still giving the scheduler a request signal:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: tekton-pipelines
+data:
+  default-container-resource-requirements: |
+    prepare:
+      requests:
+        cpu: "100m"
+        memory: "64Mi"
+    place-scripts:
+      requests:
+        cpu: "100m"
+        memory: "32Mi"
+    working-dir-initializer:
+      requests:
+        cpu: "100m"
+        memory: "16Mi"
+```
 
 ## Customizing basic execution parameters
 

--- a/docs/compute-resources.md
+++ b/docs/compute-resources.md
@@ -317,12 +317,12 @@ Kubernetes allows users to define [ResourceQuotas](https://kubernetes.io/docs/co
 which restrict the maximum resource requests and limits of all pods running in a namespace.
 
 Tekton's internal containers (`prepare`, `place-scripts`, `working-dir-initializer`,
-`sidecar-tekton-log-results`) ship with minimal default resource requests and limits so that pods can be
-scheduled in namespaces with ResourceQuotas without requiring a LimitRange. The default requests and limits
-are `10m` CPU / `32Mi` memory for `prepare`, `10m` CPU / `16Mi` memory for `working-dir-initializer`,
-`100m` CPU / `32Mi` memory for `place-scripts`, and `50m` CPU / `32Mi` memory for `sidecar-tekton-log-results`.
-These defaults can be overridden using the `default-container-resource-requirements` ConfigMap
-(see [Configuring default resources requirements](./additional-configs.md#configuring-default-resources-requirements)).
+`sidecar-tekton-log-results`) do not set resource requests or limits by default. This preserves the default
+Kubernetes scheduling behavior and avoids CPU limit based CFS throttling for the internal init containers.
+
+Namespaces that enforce ResourceQuotas might require every container, including Tekton internal containers,
+to set explicit requests or limits. In those namespaces, configure the `default-container-resource-requirements`
+ConfigMap with entries for the internal containers (see [Configuring default resources requirements](./additional-configs.md#configuring-default-resources-requirements)).
 
 `Step` and `Sidecar` resource requirements can be configured directly through the API, as described in
 [Task Resource Requirements](#task-resource-requirements). You can also deploy a LimitRange

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -37,7 +37,6 @@ import (
 	tknreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/spire"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
@@ -138,20 +137,6 @@ var (
 
 	// MaxActiveDeadlineSeconds is a maximum permitted value to be used for a task with no timeout
 	MaxActiveDeadlineSeconds = int64(math.MaxInt32)
-
-	// internalContainerDefaultCPU is the default CPU request for lightweight init containers (prepare, working-dir-initializer).
-	internalContainerDefaultCPU = resource.MustParse("10m")
-	// internalContainerDefaultScriptCPU is the default CPU request for the script materialization init container.
-	// This init container can process large inline scripts, so avoid throttling it as aggressively as the lightweight init containers.
-	internalContainerDefaultScriptCPU = resource.MustParse("100m")
-	// internalContainerDefaultSidecarCPU is the default CPU request for the results sidecar which runs continuously.
-	internalContainerDefaultSidecarCPU = resource.MustParse("50m")
-	// internalContainerDefaultPrepareMemory is the default memory request for the prepare init container.
-	internalContainerDefaultPrepareMemory = resource.MustParse("32Mi")
-	// internalContainerDefaultMemorySmall is the default memory request (16Mi) for working-dir-initializer.
-	internalContainerDefaultMemorySmall = resource.MustParse("16Mi")
-	// internalContainerDefaultMemoryMedium is the default memory request (32Mi) for place-scripts and results sidecar.
-	internalContainerDefaultMemoryMedium = resource.MustParse("32Mi")
 )
 
 // IsInternalContainer returns true if the container name is one of Tekton's
@@ -663,16 +648,6 @@ func entrypointInitContainer(image string, steps []v1.Step, securityContext Secu
 		WorkingDir:   "/",
 		Command:      command,
 		VolumeMounts: volumeMounts,
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    internalContainerDefaultCPU,
-				corev1.ResourceMemory: internalContainerDefaultPrepareMemory,
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    internalContainerDefaultCPU,
-				corev1.ResourceMemory: internalContainerDefaultPrepareMemory,
-			},
-		},
 	}
 	if securityContext.SetSecurityContext {
 		prepareInitContainer.SecurityContext = securityContext.GetSecurityContext(windows)
@@ -738,16 +713,6 @@ func createResultsSidecar(taskSpec v1.TaskSpec, image string, securityContext Se
 			{
 				Name:  "SIDECAR_LOG_POLLING_INTERVAL",
 				Value: pollingInterval.String(),
-			},
-		},
-		ComputeResources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    internalContainerDefaultSidecarCPU,
-				corev1.ResourceMemory: internalContainerDefaultMemoryMedium,
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    internalContainerDefaultSidecarCPU,
-				corev1.ResourceMemory: internalContainerDefaultMemoryMedium,
 			},
 		},
 	}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -480,16 +480,6 @@ func TestPodBuild(t *testing.T) {
 						Args:         []string{filepath.Join(pipeline.WorkspaceDir, "test")},
 						WorkingDir:   pipeline.WorkspaceDir,
 						VolumeMounts: implicitVolumeMounts,
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("10m"),
-								corev1.ResourceMemory: resource.MustParse("16Mi"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("10m"),
-								corev1.ResourceMemory: resource.MustParse("16Mi"),
-							},
-						},
 					},
 				},
 				Containers: []corev1.Container{{
@@ -599,16 +589,6 @@ func TestPodBuild(t *testing.T) {
 						Image:        "busybox",
 						Command:      []string{"sh"},
 						VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("32Mi"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("32Mi"),
-							},
-						},
 						Args: []string{"-c", `scriptfile="/tekton/scripts/sidecar-script-0-9l9zj"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
@@ -1066,16 +1046,6 @@ _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
 						VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("32Mi"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("32Mi"),
-							},
-						},
 					},
 				},
 				Containers: []corev1.Container{{
@@ -1194,16 +1164,6 @@ _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
 						VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("32Mi"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("32Mi"),
-							},
-						},
 					},
 				},
 				Containers: []corev1.Container{{
@@ -2089,16 +2049,6 @@ _EOF_
 						"-step-results",
 						"{}",
 					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
-					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
@@ -2178,16 +2128,6 @@ _EOF_
 						"-step-results",
 						"{\"step-name\":[\"step-foo\"]}",
 					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
-					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
@@ -2260,16 +2200,6 @@ _EOF_
 						"",
 						"-step-results",
 						"{}",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
 					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
@@ -2347,16 +2277,6 @@ _EOF_
 						"step-name",
 						"-step-results",
 						"{}",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
 					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
@@ -2440,16 +2360,6 @@ _EOF_
 						"-step-results",
 						"{\"step-name\":[\"step-foo\"]}",
 					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
-					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
@@ -2525,16 +2435,6 @@ _EOF_
 						"step-name",
 						"-step-results",
 						"{}",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-						},
 					},
 					VolumeMounts: append([]corev1.VolumeMount{
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
@@ -2814,16 +2714,6 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 		Image:        "busybox",
 		Command:      []string{"sh"},
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-		},
 		Args: []string{"-c", `tmpfile="/tekton/debug/scripts/debug-continue"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << 'debug-continue-heredoc-randomly-generated-9l9zj'
@@ -3545,16 +3435,6 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:   "/",
 			Command:      []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo"},
 			VolumeMounts: []corev1.VolumeMount{binMount, internalStepsMount},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-			},
 		},
 	}, {
 		name: "nothing-special-two-steps",
@@ -3569,16 +3449,6 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:   "/",
 			Command:      []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
 			VolumeMounts: []corev1.VolumeMount{binMount, internalStepsMount},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-			},
 		},
 	}, {
 		name: "nothing-special-two-steps-security-context",
@@ -3595,16 +3465,6 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:   "/",
 			Command:      []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
 			VolumeMounts: []corev1.VolumeMount{binMount, internalStepsMount},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-			},
 			SecurityContext: SecurityContextConfig{
 				SetSecurityContext:        true,
 				SetReadOnlyRootFilesystem: true,
@@ -3624,16 +3484,6 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:   "/",
 			Command:      []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
 			VolumeMounts: []corev1.VolumeMount{binMount, internalStepsMount},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-			},
 		},
 	}, {
 		name: "nothing-special-two-steps-windows-security-context",
@@ -3646,21 +3496,11 @@ func TestPrepareInitContainers(t *testing.T) {
 		setSecurityContextReadOnlyRootFilesystem: true,
 		windows:                                  true,
 		want: corev1.Container{
-			Name:         "prepare",
-			Image:        images.EntrypointImage,
-			WorkingDir:   "/",
-			Command:      []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
-			VolumeMounts: []corev1.VolumeMount{binMount, internalStepsMount},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-			},
+			Name:            "prepare",
+			Image:           images.EntrypointImage,
+			WorkingDir:      "/",
+			Command:         []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
+			VolumeMounts:    []corev1.VolumeMount{binMount, internalStepsMount},
 			SecurityContext: WindowsSecurityContext,
 		},
 	}}

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -101,16 +101,6 @@ func convertScripts(shellImageLinux string, shellImageWin string, steps []v1.Ste
 		Command:      []string{shellCommand},
 		Args:         []string{shellArg, ""},
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    internalContainerDefaultScriptCPU,
-				corev1.ResourceMemory: internalContainerDefaultMemoryMedium,
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    internalContainerDefaultScriptCPU,
-				corev1.ResourceMemory: internalContainerDefaultMemoryMedium,
-			},
-		},
 	}
 
 	if securityContext.SetSecurityContext {

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestConvertScripts_NothingToConvert_EmptySidecars(t *testing.T) {
@@ -159,17 +158,7 @@ IyEvYmluL3NoCnNldCAtZQpuby1zaGViYW5n
 _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-		},
+		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 	}
 	want := []corev1.Container{{
@@ -475,17 +464,7 @@ else
 fi
 debug-fail-continue-heredoc-randomly-generated-6nl7g
 `},
-				VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("100m"),
-						corev1.ResourceMemory: resource.MustParse("32Mi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("100m"),
-						corev1.ResourceMemory: resource.MustParse("32Mi"),
-					},
-				},
+				VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
 				SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 			},
 			wantSteps: []corev1.Container{{
@@ -628,17 +607,7 @@ else
 fi
 debug-beforestep-fail-continue-heredoc-randomly-generated-6nl7g
 `},
-				VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("100m"),
-						corev1.ResourceMemory: resource.MustParse("32Mi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("100m"),
-						corev1.ResourceMemory: resource.MustParse("32Mi"),
-					},
-				},
+				VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
 				SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 			},
 			wantSteps: []corev1.Container{{
@@ -721,17 +690,7 @@ IyEvYmluL3NoCnNpZGVjYXItMQ==
 _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-		},
+		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 	}
 	want := []corev1.Container{{
@@ -818,17 +777,7 @@ script-3
 no-shebang
 "@ | Out-File -FilePath /tekton/scripts/script-3-mssqb.cmd
 `},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-		},
+		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{
@@ -911,17 +860,7 @@ script-3
 sidecar-1
 "@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-mssqb
 `},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-		},
+		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{
@@ -983,17 +922,7 @@ sidecar-1`,
 sidecar-1
 "@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-9l9zj
 `},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-		},
+		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{

--- a/pkg/pod/workingdir_init.go
+++ b/pkg/pod/workingdir_init.go
@@ -68,16 +68,6 @@ func workingDirInit(workingdirinitImage string, stepContainers []corev1.Containe
 		Args:         relativeDirs,
 		WorkingDir:   pipeline.WorkspaceDir,
 		VolumeMounts: implicitVolumeMounts,
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    internalContainerDefaultCPU,
-				corev1.ResourceMemory: internalContainerDefaultMemorySmall,
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    internalContainerDefaultCPU,
-				corev1.ResourceMemory: internalContainerDefaultMemorySmall,
-			},
-		},
 	}
 	if securityContext.SetSecurityContext {
 		c.SecurityContext = securityContext.GetSecurityContext(windows)

--- a/pkg/pod/workingdir_init_test.go
+++ b/pkg/pod/workingdir_init_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestWorkingDirInit(t *testing.T) {
@@ -66,16 +65,6 @@ func TestWorkingDirInit(t *testing.T) {
 			Args:         []string{"/workspace/bbb", "aaa", "zzz"},
 			WorkingDir:   pipeline.WorkspaceDir,
 			VolumeMounts: implicitVolumeMounts,
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
-				},
-			},
 		},
 	}, {
 		desc: "workingDirs are unique and sorted, absolute dirs are ignored, + securitycontext",
@@ -97,22 +86,12 @@ func TestWorkingDirInit(t *testing.T) {
 		setSecurityContext:             true,
 		setSecurityContextReadOnlyRoot: true,
 		want: &corev1.Container{
-			Name:         "working-dir-initializer",
-			Image:        images.WorkingDirInitImage,
-			Command:      []string{"/ko-app/workingdirinit"},
-			Args:         []string{"/workspace/bbb", "aaa", "zzz"},
-			WorkingDir:   pipeline.WorkspaceDir,
-			VolumeMounts: implicitVolumeMounts,
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
-				},
-			},
+			Name:            "working-dir-initializer",
+			Image:           images.WorkingDirInitImage,
+			Command:         []string{"/ko-app/workingdirinit"},
+			Args:            []string{"/workspace/bbb", "aaa", "zzz"},
+			WorkingDir:      pipeline.WorkspaceDir,
+			VolumeMounts:    implicitVolumeMounts,
 			SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 		},
 	}, {
@@ -140,16 +119,6 @@ func TestWorkingDirInit(t *testing.T) {
 			Args:         []string{"/workspace/bbb", "aaa", "zzz"},
 			WorkingDir:   pipeline.WorkspaceDir,
 			VolumeMounts: implicitVolumeMounts,
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
-				},
-			},
 		},
 	}, {
 		desc: "workingDirs are unique and sorted, absolute dirs are ignored, uses windows, + securityContext",
@@ -172,22 +141,12 @@ func TestWorkingDirInit(t *testing.T) {
 		setSecurityContext:             true,
 		setSecurityContextReadOnlyRoot: true,
 		want: &corev1.Container{
-			Name:         "working-dir-initializer",
-			Image:        images.WorkingDirInitImage,
-			Command:      []string{"/ko-app/workingdirinit"},
-			Args:         []string{"/workspace/bbb", "aaa", "zzz"},
-			WorkingDir:   pipeline.WorkspaceDir,
-			VolumeMounts: implicitVolumeMounts,
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
-				},
-			},
+			Name:            "working-dir-initializer",
+			Image:           images.WorkingDirInitImage,
+			Command:         []string{"/ko-app/workingdirinit"},
+			Args:            []string{"/workspace/bbb", "aaa", "zzz"},
+			WorkingDir:      pipeline.WorkspaceDir,
+			VolumeMounts:    implicitVolumeMounts,
 			SecurityContext: WindowsSecurityContext,
 		},
 	}} {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -352,16 +352,6 @@ func placeToolsInitContainer(steps []string) corev1.Container {
 		WorkingDir: "/",
 		Name:       "prepare",
 		Image:      "override-with-entrypoint:latest",
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-			},
-		},
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Make Tekton internal container resource requirements opt-in through `default-container-resource-requirements` instead of applying hardcoded requests and limits by default.

This restores the default behavior where Tekton internal containers do not set CPU limits unless an admin configures them, avoiding CFS quota throttling in the default case. Clusters that need ResourceQuota compatibility can still configure explicit requests and limits for `prepare`, `place-scripts`, `working-dir-initializer`, and `sidecar-tekton-log-results` through `config-defaults`.

This PR also updates docs and examples for:

- ResourceQuota-compatible requests+limits configuration
- requests-only configuration for clusters that want scheduling requests without CPU limits
- clarifying that no internal container resources are applied when the config key is unset

Alternative to #10153.

Fixes #10152.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required: Tekton no longer applies default resource requests or limits to internal containers (`prepare`, `place-scripts`, `working-dir-initializer`, and `sidecar-tekton-log-results`) when `default-container-resource-requirements` is unset. Clusters that rely on these defaults for ResourceQuota compatibility must configure explicit internal container resources in the `config-defaults` ConfigMap.
```

# Testing

```bash
go test ./pkg/pod ./pkg/internal/defaultresourcerequirements ./pkg/reconciler/taskrun -count=1
```