### PR TITLE
fix: TaskRun stuck in Running when init container is OOMKilled with enableKubernetesSidecar

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -131,7 +131,7 @@ func MakeTaskRunStatus(ctx context.Context, logger *zap.SugaredLogger, tr v1.Tas
 	// are completed before considering the taskRun complete, in addition to the regular containers.
 	// This is because sidecars in Kubernetes can keep running after the main containers complete.
 	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
-		complete = complete && areInitContainersCompleted(ctx, pod)
+		complete = complete && areInitContainersDone(ctx, pod)
 	}
 
 	if complete {
@@ -710,8 +710,14 @@ func isMatchingAnyFilter(name string, filters []containerNameFilter) bool {
 	return false
 }
 
-// areInitContainersCompleted returns true if all init containers in the pod are completed.
-func areInitContainersCompleted(ctx context.Context, pod *corev1.Pod) bool {
+// areInitContainersDone returns true if all init containers in the pod are
+// done — either terminated normally or stopped because the pod failed.
+// When the pod has failed (e.g. an init container was OOMKilled), nothing
+// else will run, so there is nothing left to wait for.
+func areInitContainersDone(ctx context.Context, pod *corev1.Pod) bool {
+	if pod.Status.Phase == corev1.PodFailed {
+		return true
+	}
 	if len(pod.Status.InitContainerStatuses) == 0 ||
 		!(pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodSucceeded) {
 		return false

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -2710,6 +2710,46 @@ func TestMakeTaskRunStatus_KubernetesNativeSidecar(t *testing.T) {
 		want: v1.TaskRunStatus{
 			Status: statusSuccess(),
 		},
+	}, {
+		desc: "test init container OOM with kubernetes native sidecar",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pod",
+				Namespace:         "foo",
+				CreationTimestamp: metav1.Now(),
+			},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{
+					Name: "prepare",
+				}},
+				Containers: []corev1.Container{{
+					Name: "step-simple",
+				}},
+			},
+		},
+		podStatus: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name: "prepare",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 137,
+						Reason:   "OOMKilled",
+					},
+				},
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "step-simple",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason: "PodInitializing",
+					},
+				},
+			}},
+		},
+		want: v1.TaskRunStatus{
+			Status: statusFailure(v1.TaskRunReasonInitContainerOOM.String(), `init container failed, "prepare" exited with code 137: OOMKilled`),
+		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			if reflect.DeepEqual(c.pod, corev1.Pod{}) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes #10170

When `enableKubernetesSidecar` is `true`, `areInitContainersCompleted()` gates
the completion check. However, it only accepted `PodRunning` or `PodSucceeded`
phases, returning `false` for `PodFailed`. This caused the overall `complete`
flag to be `false` even when the pod had clearly failed (e.g. init container
OOMKilled), leaving the TaskRun stuck in `Running` until the pipeline timeout.

**Root cause:**

```go
complete := areContainersCompleted(ctx, pod) || isPodCompleted(pod)
// isPodCompleted returns true (pod phase is Failed) → complete = true

if config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
    complete = complete && areInitContainersCompleted(ctx, pod)
    // areInitContainersCompleted returns false (phase is Failed, not Running/Succeeded)
    // complete = true && false → false  ← BUG
}
```

**Fix:**
- Rename `areInitContainersCompleted` → `areInitContainersDone` (since "done"
  covers both success and failure, unlike "completed")
- Add early return for `PodFailed`: when the pod has failed, nothing else will
  run, so there is nothing left to wait for

Note: this only affects `enableKubernetesSidecar: true`. Without that flag, the
init container check is never applied, and `isPodCompleted()` correctly handles
`PodFailed`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix: TaskRun no longer gets stuck in Running when an init container (e.g. prepare) is OOMKilled while enableKubernetesSidecar is enabled. The TaskRun is now correctly marked as Failed immediately.
```