### PR TITLE
chore: remove stale TODOs referencing closed issues #4723 and #6097

### DIFF
--- a/pkg/reconciler/taskrun/validate_taskrun.go
+++ b/pkg/reconciler/taskrun/validate_taskrun.go
@@ -79,7 +79,6 @@ func missingParamsNames(neededParams sets.String, providedParams sets.String, pa
 	return missingParamsNamesWithNoDefaults
 }
 func wrongTypeParamsNames(params []v1.Param, matrix v1.Params, neededParamsTypes map[string]v1.ParamType) []string {
-
 	var wrongTypeParamNames []string
 	for _, param := range params {
 		if _, ok := neededParamsTypes[param.Name]; !ok {
@@ -303,7 +302,6 @@ func mismatchedTypesResults(tr *v1.TaskRun, specResults []v1.TaskResult) map[str
 	}
 
 	// collect mismatched types for results, and correct results in filteredResults
-	
 	for _, trr := range tr.Status.Results {
 		needed, ok := neededTypes[trr.Name]
 		if ok && needed != string(trr.Type) {

--- a/pkg/reconciler/taskrun/validate_taskrun.go
+++ b/pkg/reconciler/taskrun/validate_taskrun.go
@@ -79,8 +79,7 @@ func missingParamsNames(neededParams sets.String, providedParams sets.String, pa
 	return missingParamsNamesWithNoDefaults
 }
 func wrongTypeParamsNames(params []v1.Param, matrix v1.Params, neededParamsTypes map[string]v1.ParamType) []string {
-	// TODO(#4723): validate that $(task.taskname.result.resultname) is invalid for array and object type.
-	// It should be used to refer string and need to add [*] to refer to array or object.
+
 	var wrongTypeParamNames []string
 	for _, param := range params {
 		if _, ok := neededParamsTypes[param.Name]; !ok {
@@ -304,7 +303,7 @@ func mismatchedTypesResults(tr *v1.TaskRun, specResults []v1.TaskResult) map[str
 	}
 
 	// collect mismatched types for results, and correct results in filteredResults
-	// TODO(#6097): Validate if the emitted results are defined in taskspec
+	
 	for _, trr := range tr.Status.Results {
 		needed, ok := neededTypes[trr.Name]
 		if ok && needed != string(trr.Type) {


### PR DESCRIPTION
# Changes
Removes two stale TODO comments in `pkg/reconciler/taskrun/validate_taskrun.go` 
referencing issues #4723 and #6097 which have both been closed as completed.

- Line 82-83: TODO(#4723) — closed July 2022 as part of TEP-0075/0076 implementation
- Line 307: TODO(#6097) — closed February 2023, fixed by #6129

Relates to #9492

# Submitter Checklist
- [x] Follows the commit message standard
- [x] Has a kind label

# Release Notes
```release-note
NONE
```