### PR TITLE
Fix race condition in TestStepTimeout

### DIFF
--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -201,13 +201,19 @@ spec:
 		t.Logf("Error in taskRun %s status: %s\n", taskRun.Name, err)
 		t.Errorf("Expected: %s", failMsg)
 	}
-
-	tr, err := c.V1TaskRunClient.Get(ctx, taskRun.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Errorf("Error getting Taskrun: %v", err)
-	}
-	if tr == nil {
-		t.Fatalf("no TaskRun details available")
+	var tr *v1.TaskRun
+	if err := pollImmediateWithContext(ctx, func() (bool, error) {
+		got, getErr := c.V1TaskRunClient.Get(ctx, taskRun.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return true, getErr
+		}
+		if len(got.Status.Steps) < 3 {
+			return false, nil
+		}
+		tr = got
+		return true, nil
+	}); err != nil {
+		t.Fatalf("TaskRun %s step statuses were never fully populated (want 3): %v", taskRun.Name, err)
 	}
 	if tr.Status.Steps[0].Terminated == nil {
 		t.Errorf("step-no-timeout should have Completed.")


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Fixes #10053 

# Changes

`TestStepTimeout` intermittently panics with `index out of range [0] with length 0`

This e2e test intermittenly failed on several PRs  with the following error message:
```
--- FAIL: TestStepTimeout (120.09s) panic: runtime error: index out of range [0] with length 0 [recovered, repanicked]
```
Possible cause is a race condition where `WaitForTaskRunState` returns as soon as the
TaskRun's overall `ConditionSucceeded` is set to `False`, but the individual step
statuses (`Status.Steps`) may not be populated yet. The test then does a single
`Get` and directly accesses `Steps[0]`, which panics.

I replaced the single `Get` call with `pollImmediateWithContext` loop that
retries until all 3 step statuses are populated before asserting on them.

Tested this on a kind cluster and the test passed:
`=== NAME  TestStepTimeout
    timeout_test.go:228: Deleting namespace arendelle-d27mh
--- PASS: TestStepTimeout (18.04s)`


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
