### PR TITLE
fix: replace symlinks with subpath params in create-draft-release

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -468,17 +468,6 @@ spec:
               PREVIOUS="$(params.previousReleaseTag)"
               NAME="$(params.releaseName)"
 
-              # The create-draft-release-oci task expects:
-              #   <workspace>/repo    -> git checkout
-              #   <workspace>/release -> release artifacts
-              # The release pipeline uses:
-              #   <workspace>/git     -> git checkout
-              #   <workspace>/bucket/<versionTag> -> release artifacts
-              ln -sfn "${WORKAREA}/git" "${WORKAREA}/repo"
-              ln -sfn "${WORKAREA}/bucket/${VERSION}" "${WORKAREA}/release"
-              echo "Created workspace symlinks:"
-              ls -la "${WORKAREA}/repo" "${WORKAREA}/release"
-
               # Strip github.com/ prefix from package for the draft release task
               # (it expects org/repo format, e.g. tektoncd/pipeline)
               PACKAGE=$(echo "$(params.package)" | sed 's|^github\.com/||')
@@ -523,11 +512,8 @@ spec:
         params:
           - name: url
             value: https://github.com/tektoncd/plumbing
-          # Pinned to current HEAD. Update after tektoncd/plumbing#3169 merges
-          # (modernizes hub→gh, adds flexible path params, removing the need
-          # for the prepare-draft-release symlink task).
           - name: revision
-            value: c6ccd417b39dd9d0c3055795f00cbce051f6bc9e
+            value: 7abffd25eb2e578e6698a9ff13470d04906f79e6
           - name: pathInRepo
             value: tekton/resources/release/base/github_release_oci.yaml
       params:
@@ -543,6 +529,10 @@ spec:
           value: $(tasks.prepare-draft-release.results.previous-tag)
         - name: rekor-uuid
           value: $(tasks.wait-for-chains.results.rekor-uuid)
+        - name: source-subpath
+          value: git
+        - name: release-subpath
+          value: bucket/$(params.versionTag)
       workspaces:
         - name: shared
           workspace: workarea

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -396,10 +396,15 @@ spec:
 
                   if [ -n "${TRANSPARENCY}" ]; then
                     # URL format: https://rekor.sigstore.dev/api/v1/log/entries?logIndex=NNNN
-                    REKOR_UUID=$(echo "${TRANSPARENCY}" | grep -oE 'logIndex=[0-9]+' | cut -d= -f2)
+                    # Fetch the full entry UUID from the Rekor API (logIndex alone is not the UUID)
+                    REKOR_UUID=$(wget -qO- "${TRANSPARENCY}" | sed -n 's/.*"\([0-9a-f]\{64,\}\)".*/\1/p' | head -1)
                     if [ -z "${REKOR_UUID}" ]; then
-                      echo "WARNING: Could not extract logIndex from transparency URL: ${TRANSPARENCY}"
-                      REKOR_UUID="unknown"
+                      echo "WARNING: Could not fetch Rekor UUID from: ${TRANSPARENCY}"
+                      # Fall back to logIndex
+                      REKOR_UUID=$(echo "${TRANSPARENCY}" | grep -oE 'logIndex=[0-9]+' | cut -d= -f2)
+                      if [ -z "${REKOR_UUID}" ]; then
+                        REKOR_UUID="unknown"
+                      fi
                     fi
                     echo "Rekor UUID: ${REKOR_UUID}"
                     printf '%s' "${REKOR_UUID}" > "$(results.rekor-uuid.path)"


### PR DESCRIPTION
# Changes

Two fixes for the automated release pipeline:

## 1. Replace symlinks with subpath params in create-draft-release

The `create-draft-release` task from plumbing uses `workingDir` set to
`/workspace/shared/repo`. Tekton's init container tries to `mkdir` this
path, but `prepare-draft-release` created it as a symlink, causing
`file exists` errors and `PodCreationFailed`.

Update to use the newer plumbing task revision (`7abffd25`) which
supports `source-subpath` and `release-subpath` parameters, removing
the need for symlinks entirely.

This matches the fix already applied in tektoncd/operator#3366.

## 2. Fetch full Rekor UUID instead of logIndex

The `wait-for-chains` task was extracting just the `logIndex` number from
the Rekor transparency URL (e.g. `1732077376`), but the draft release
template expects the full hex entry UUID (e.g. `108e9186e8c5677a...`).
Now fetches the actual UUID from the Rekor API, falling back to logIndex
if the API call fails.

**Note:** This fix needs to be cherry-picked to active release branches
since `tekton/release-pipeline.yaml` is resolved from the release branch.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

/kind bug

# Release Notes

```release-note
NONE
```