### PR TITLE
[release-v1.2.x] fix: add automated draft release support to release pipeline

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -49,6 +49,12 @@ spec:
   - name: runTests
     description: If set to something other than "true", skip the build and test tasks
     default: "true"
+  - name: previousReleaseTag
+    description: Previous release tag for changelog generation (e.g. v1.8.0). If empty, auto-detected from git tags.
+    default: ""
+  - name: releaseName
+    description: Release name (e.g. "Devon Rex Dreadnought"). If empty, uses version tag.
+    default: ""
   workspaces:
     - name: workarea
       description: The workspace where the repo will be cloned.
@@ -280,3 +286,225 @@ spec:
               BASE_URL=$(echo ${BASE_URL} | sed 's,gs://,https://storage.googleapis.com/,g')
               echo "${BASE_URL}/release.yaml" > $(results.release.path)
               echo "${BASE_URL}/release.notag.yaml" > $(results.release-no-tag.path)
+
+    - name: wait-for-chains
+      runAfter: [publish-images]
+      timeout: "30m"
+      when:
+        - input: "$(workspaces.github-secret.bound)"
+          operator: in
+          values: ["true"]
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: namespace
+          value: $(context.pipelineRun.namespace)
+      taskSpec:
+        params:
+          - name: pipelineRunName
+          - name: namespace
+        results:
+          - name: rekor-uuid
+            description: Rekor UUID from Chains transparency log
+          - name: signed
+            description: Whether Chains signing succeeded (true, failed, or timeout)
+        steps:
+          - name: wait-and-extract
+            image: docker.io/alpine/k8s:1.32.2@sha256:15cfdf84d6de3559bc54d7479eb4e8aadbf71f6d7f08782cb1e91f3446f4b2d8
+            script: |
+              #!/bin/sh
+              set -e
+
+              NAMESPACE="$(params.namespace)"
+              PIPELINERUN="$(params.pipelineRunName)"
+
+              # Find the TaskRun name for publish-images
+              # The TaskRun name follows the pattern: <pipelinerun>-<taskname>-<random>
+              echo "Looking for publish-images TaskRun in PipelineRun ${PIPELINERUN}..."
+              TASKRUN_NAME=""
+              MAX_FIND_ATTEMPTS=10
+              FIND_ATTEMPT=0
+              while [ -z "${TASKRUN_NAME}" ] && [ $FIND_ATTEMPT -lt $MAX_FIND_ATTEMPTS ]; do
+                TASKRUN_NAME=$(kubectl get taskrun -n "${NAMESPACE}" \
+                  -l tekton.dev/pipelineRun="${PIPELINERUN}",tekton.dev/pipelineTask=publish-images \
+                  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+                if [ -z "${TASKRUN_NAME}" ]; then
+                  FIND_ATTEMPT=$((FIND_ATTEMPT + 1))
+                  echo "  Attempt ${FIND_ATTEMPT}/${MAX_FIND_ATTEMPTS} - TaskRun not found yet..."
+                  sleep 10
+                fi
+              done
+
+              if [ -z "${TASKRUN_NAME}" ]; then
+                echo "ERROR: Could not find publish-images TaskRun"
+                printf 'unknown' > "$(results.rekor-uuid.path)"
+                printf 'error' > "$(results.signed.path)"
+                # Don't fail the pipeline — the release artifacts are already published.
+                # The draft release can be created manually using the cheat sheet.
+                exit 0
+              fi
+
+              echo "Found TaskRun: ${TASKRUN_NAME}"
+              echo "Waiting for Chains to sign TaskRun ${TASKRUN_NAME}..."
+
+              MAX_ATTEMPTS=60  # 30 minutes with 30s interval
+              ATTEMPT=0
+              while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+                SIGNED=$(kubectl get taskrun "${TASKRUN_NAME}" -n "${NAMESPACE}" \
+                  -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/signed}' 2>/dev/null || echo "")
+
+                if [ "${SIGNED}" = "true" ] || [ "${SIGNED}" = "failed" ]; then
+                  echo "Chains signing status: ${SIGNED}"
+                  printf '%s' "${SIGNED}" > "$(results.signed.path)"
+
+                  # Extract Rekor UUID from transparency URL
+                  TRANSPARENCY=$(kubectl get taskrun "${TASKRUN_NAME}" -n "${NAMESPACE}" \
+                    -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/transparency}' 2>/dev/null || echo "")
+
+                  if [ -n "${TRANSPARENCY}" ]; then
+                    # URL format: https://rekor.sigstore.dev/api/v1/log/entries?logIndex=NNNN
+                    # Fetch the full entry UUID from the Rekor API (logIndex alone is not the UUID)
+                    REKOR_UUID=$(wget -qO- "${TRANSPARENCY}" | sed -n 's/.*"\([0-9a-f]\{64,\}\)".*/\1/p' | head -1)
+                    if [ -z "${REKOR_UUID}" ]; then
+                      echo "WARNING: Could not fetch Rekor UUID from: ${TRANSPARENCY}"
+                      # Fall back to logIndex
+                      REKOR_UUID=$(echo "${TRANSPARENCY}" | grep -oE 'logIndex=[0-9]+' | cut -d= -f2)
+                      if [ -z "${REKOR_UUID}" ]; then
+                        REKOR_UUID="unknown"
+                      fi
+                    fi
+                    echo "Rekor UUID: ${REKOR_UUID}"
+                    printf '%s' "${REKOR_UUID}" > "$(results.rekor-uuid.path)"
+                  else
+                    echo "WARNING: No transparency URL found"
+                    printf 'unknown' > "$(results.rekor-uuid.path)"
+                  fi
+                  exit 0
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                echo "  Attempt ${ATTEMPT}/${MAX_ATTEMPTS} - signing status: '${SIGNED:-pending}'"
+                sleep 30
+              done
+
+              echo "WARNING: Timed out waiting for Chains to sign"
+              printf 'timeout' > "$(results.signed.path)"
+              printf 'unknown' > "$(results.rekor-uuid.path)"
+              # Don't fail the pipeline — the release artifacts are already published.
+              # The draft release can be created manually using the cheat sheet.
+              exit 0
+
+    - name: prepare-draft-release
+      runAfter: [publish-to-bucket]
+      when:
+        - input: "$(workspaces.github-secret.bound)"
+          operator: in
+          values: ["true"]
+      params:
+        - name: package
+          value: $(params.package)
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: previousReleaseTag
+          value: $(params.previousReleaseTag)
+        - name: releaseName
+          value: $(params.releaseName)
+      workspaces:
+        - name: workarea
+          workspace: workarea
+      taskSpec:
+        params:
+          - name: package
+          - name: versionTag
+          - name: previousReleaseTag
+          - name: releaseName
+        results:
+          - name: package
+            description: The package in org/repo format (without github.com/ prefix)
+          - name: previous-tag
+            description: The previous release tag
+          - name: release-name
+            description: The release name to use
+        workspaces:
+          - name: workarea
+        steps:
+          - name: setup
+            image: docker.io/library/alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+            script: |
+              #!/bin/sh
+              set -e
+              apk add --no-cache git > /dev/null 2>&1
+
+              WORKAREA="$(workspaces.workarea.path)"
+              VERSION="$(params.versionTag)"
+              PREVIOUS="$(params.previousReleaseTag)"
+              NAME="$(params.releaseName)"
+
+              # Strip github.com/ prefix from package for the draft release task
+              # (it expects org/repo format, e.g. tektoncd/pipeline)
+              PACKAGE=$(echo "$(params.package)" | sed 's|^github\.com/||')
+              printf '%s' "${PACKAGE}" > "$(results.package.path)"
+              echo "Package: ${PACKAGE}"
+
+              # Detect previous tag if not provided
+              if [ -z "${PREVIOUS}" ]; then
+                git config --global --add safe.directory "${WORKAREA}/git"
+                git -C "${WORKAREA}/git" fetch --tags
+                PREVIOUS=$(git -C "${WORKAREA}/git" tag --sort=-v:refname | grep '^v[0-9]' | while read tag; do
+                  if [ "$(printf '%s\n%s' "$tag" "$VERSION" | sort -V | head -1)" = "$tag" ] && [ "$tag" != "$VERSION" ]; then
+                    echo "$tag"
+                    break
+                  fi
+                done)
+                if [ -z "${PREVIOUS}" ]; then
+                  echo "WARNING: Could not auto-detect previous tag"
+                  PREVIOUS="unknown"
+                fi
+                echo "Auto-detected previous tag: ${PREVIOUS}"
+              fi
+              printf '%s' "${PREVIOUS}" > "$(results.previous-tag.path)"
+
+              # Use provided name or fall back to version
+              if [ -z "${NAME}" ]; then
+                NAME="Release ${VERSION}"
+              fi
+              printf '%s' "${NAME}" > "$(results.release-name.path)"
+
+    - name: create-draft-release
+      runAfter: [prepare-draft-release, wait-for-chains]
+      when:
+        - input: "$(workspaces.github-secret.bound)"
+          operator: in
+          values: ["true"]
+        - input: "$(tasks.wait-for-chains.results.signed)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/plumbing
+          - name: revision
+            value: 7abffd25eb2e578e6698a9ff13470d04906f79e6
+          - name: pathInRepo
+            value: tekton/resources/release/base/github_release_oci.yaml
+      params:
+        - name: package
+          value: $(tasks.prepare-draft-release.results.package)
+        - name: git-revision
+          value: $(params.gitRevision)
+        - name: release-name
+          value: $(tasks.prepare-draft-release.results.release-name)
+        - name: release-tag
+          value: $(params.versionTag)
+        - name: previous-release-tag
+          value: $(tasks.prepare-draft-release.results.previous-tag)
+        - name: rekor-uuid
+          value: $(tasks.wait-for-chains.results.rekor-uuid)
+        - name: source-subpath
+          value: git
+        - name: release-subpath
+          value: bucket/$(params.versionTag)
+      workspaces:
+        - name: shared
+          workspace: workarea


### PR DESCRIPTION
# Changes

Cherry-pick of #10203 and #9420 adapted for `release-v1.2.x`.

Adds automated draft release support to the release pipeline:
- Add draft release tasks (`wait-for-chains`, `prepare-draft-release`, `create-draft-release`) with proper `source-subpath`/`release-subpath` params instead of symlinks
- Fetch full Rekor UUID from API instead of just logIndex number
- Add `previousReleaseTag`, `releaseName` params and optional `github-secret` workspace

This ensures the automated patch release pipeline (PAC incoming webhook) can create draft GitHub releases on this branch.

/kind bug

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```