### PR TITLE
[release-v1.3.x] Fix golangci-lint action step for large diff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        fetch-depth: 0
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
       with:
         go-version-file: "go.mod"
@@ -59,8 +61,7 @@ jobs:
       with:
         version: v2.1.6
         install-mode: goinstall
-        only-new-issues: true
-        args: --timeout=10m
+        args: --new-from-merge-base=origin/${{ github.base_ref }} --timeout=10m
     - name: yamllint
       run: |
         apt update && apt install -y yamllint


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Backport of the golangci-lint large-diff fix to `release-v1.3.x` (cherry-pick of `e5925dd8989e` from `main`, adapted to the older `golangci-lint-action`/`checkout` versions pinned on this branch).

The lint job on `release-v1.3.x` uses `only-new-issues: true`, which relies on the GitHub PR diff API to filter new-vs-existing lint issues. That API is capped at 300 files and returns `406 too_large` for big PRs (e.g. dependency bumps that touch vendored code). When the diff can't be fetched, the action falls back to linting the **entire repo** and fails on pre-existing issues.

This replaces `only-new-issues: true` with `--new-from-merge-base=origin/${{ github.base_ref }}`, which computes new issues locally via git (hence the added `fetch-depth: 0`), avoiding the API limit entirely.

`release-v1.6.x`, `release-v1.9.x`, and `release-v1.12.x` already carry the equivalent fix. Concretely this unblocks lint on PRs like #9883 (a `go-containerregistry` bump touching 301 files).

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```