### PR TITLE
chore: switch base image to ghcr.io/tektoncd/plumbing/static-base

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7
+defaultBaseImage: ghcr.io/tektoncd/plumbing/static-base@sha256:e150c89001e336b6a0200a6bac766a7b455e5573bf91c6c37f3ef8cf2fdccf0a
 baseImageOverrides:
   # Use the combined base image for images that should include Windows support.
   # The :latest tag is automatically replaced with the actual digest during releases by tekton/publish.yaml.

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -117,9 +117,9 @@ spec:
       fi
 
       # Combine Distroless with a Windows base image, used for the entrypoint image.
-      # Distroless is pinned to the last version based on Alpine 3.18. Newer versions are based on Alpine 3.19_alpha20230901.
+      # Static base image from tektoncd/plumbing, rebuilt daily.
       COMBINED_BASE_IMAGE=$(go run ./vendor/github.com/tektoncd/plumbing/cmd/combine/main.go \
-        cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7 \
+        ghcr.io/tektoncd/plumbing/static-base@sha256:e150c89001e336b6a0200a6bac766a7b455e5573bf91c6c37f3ef8cf2fdccf0a \
         mcr.microsoft.com/windows/nanoserver:ltsc2019 \
         mcr.microsoft.com/windows/nanoserver:ltsc2022 \
         ${COMBINED_BASE_IMAGE_BASE}/combined-base-image:latest)


### PR DESCRIPTION
# Changes

Switch `defaultBaseImage` to the Tekton-maintained static base image
(`ghcr.io/tektoncd/plumbing/static-base`), built and published from
[tektoncd/plumbing](https://github.com/tektoncd/plumbing/tree/main/tekton/images/static-base).

This image:
- Supports all four target architectures (amd64, arm64, s390x, ppc64le)
- Is rebuilt daily from Alpine packages via apko
- Includes CA certs, timezone data, and nonroot user (UID 65532)
- Is ~300KB per arch

Related: tektoncd/pipeline#9557, tektoncd/plumbing#3434

Replaces `cgr.dev/chainguard/static` in both `.ko.yaml` and `tekton/publish.yaml` (combined base image builder).

# Submitter Checklist

- [x] Has Docs if any changes are user facing
- [x] Has Tests included if any functionality added or changed
- [x] pre-commit Passed
- [x] Follows the commit message standard
- [x] Meets the Tekton contributor standards
- [x] Has a kind label.

/kind cleanup

# Release Notes

```release-note
NONE
```