### PR TITLE
docs(security): document workspace isolation across trust boundaries

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,151 @@
+<!--
+---
+linkTitle: "Security"
+weight: 313
+---
+-->
+
+# Security Best Practices
+
+- [Overview](#overview)
+- [Workspace isolation across trust boundaries](#workspace-isolation-across-trust-boundaries)
+  - [Trust model](#trust-model)
+  - [Recommended pattern: per-run `Workspaces`](#recommended-pattern-per-run-workspaces)
+  - [Avoid sharing PVCs across trust boundaries](#avoid-sharing-pvcs-across-trust-boundaries)
+  - [`ReadWriteMany` PVCs](#readwritemany-pvcs)
+  - [Checklist](#checklist)
+
+## Overview
+
+Tekton Pipelines runs `Tasks` and `Pipelines` as Kubernetes workloads. Security
+properties such as namespace isolation, RBAC, admission control, service account
+permissions, storage access, and network access are provided by Kubernetes and
+by the platform configuration around Tekton.
+
+This page describes security best practices for authoring and operating Tekton
+`TaskRuns` and `PipelineRuns` where lower-trust workloads could affect
+higher-trust workloads.
+
+## Workspace isolation across trust boundaries
+
+`Workspaces` are a way for `TaskRuns` and `PipelineRuns` to mount Kubernetes
+volumes. They can be used to share source, build outputs, caches, credentials,
+and other files between `Tasks`. When a workspace is backed by a
+`PersistentVolumeClaim`, the security properties of that workspace are the
+security properties of the underlying Kubernetes volume.
+
+Treat every shared workspace as part of the trust model for the `Tasks` and
+`PipelineRuns` that can mount it. For example, a `PipelineRun` that validates an
+untrusted pull request and a `PipelineRun` that builds or publishes a trusted
+release should not share the same writeable PVC.
+
+### Trust model
+
+Tekton does not enforce filesystem-level isolation between separate
+`PipelineRuns` that intentionally mount the same persistent workspace. If two
+`PipelineRuns` bind the same PVC to a workspace, the Pods created for both runs
+can access the same files according to the PVC access mode, Kubernetes volume
+permissions, and the container security context.
+
+This behavior is by design: workspace sharing is explicit and opt-in. It also
+means that isolation between trusted and untrusted workloads is the
+responsibility of the pipeline author and cluster operator. Use Kubernetes RBAC,
+namespaces, ServiceAccounts, and storage policy to limit which users and
+controllers can create `PipelineRuns` that reference sensitive PVCs.
+
+`readOnly` workspace bindings can prevent writes from that mount, but they do
+not make existing contents trustworthy. Do not treat a shared volume as safe for
+a higher-trust run only because the higher-trust run mounts it read-only.
+
+### Recommended pattern: per-run `Workspaces`
+
+Use `volumeClaimTemplate` when a `PipelineRun` needs a writeable persistent
+workspace but should not share files with other runs. A `volumeClaimTemplate`
+creates a new PVC for each `PipelineRun` or `TaskRun`, so data written by one run
+is not visible through the same workspace binding in another run.
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: validate-pr-
+spec:
+  pipelineRef:
+    name: validate-pr
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+```
+
+PVCs created from `volumeClaimTemplate` are automatically provisioned. Their
+cleanup behavior depends on the `PipelineRun` lifecycle and the configured
+Affinity Assistant mode. See [PVC Auto-Cleanup for Workspaces Mode](../affinityassistants.md#pvc-auto-cleanup-for-workspaces-mode)
+for details on cleanup after completion.
+
+### Avoid sharing PVCs across trust boundaries
+
+Only bind an existing `persistentVolumeClaim` to a workspace when every
+`PipelineRun` that can mount that claim belongs to the same trust domain and is
+allowed to read or modify the files on that volume.
+
+Avoid patterns like the following when the `PipelineRuns` are triggered by
+inputs at different trust levels, such as untrusted pull requests and trusted
+release automation:
+
+```yaml
+workspaces:
+  - name: artifacts
+    persistentVolumeClaim:
+      claimName: shared-artifacts-rwx
+```
+
+A shared PVC can allow one run to read files left by another run, modify files
+that a later run will consume, or race with another run that is reading or
+writing the same paths. A `subPath` on a shared PVC can help organize data, but
+it should not be treated as a security boundary between trust domains.
+
+If persistent data must cross a trust boundary, write it to a controlled storage
+or artifact system that performs the appropriate validation, signing, promotion,
+or access checks before a trusted pipeline consumes it.
+
+Step-level [Isolated `Workspaces`](../workspaces.md#isolated-workspaces) can limit
+which `Steps` and `Sidecars` inside one `Task` receive a workspace. That feature
+does not isolate separate `PipelineRuns` that bind the same PVC.
+
+### `ReadWriteMany` PVCs
+
+`ReadWriteMany` is a Kubernetes access mode that allows a volume to be mounted
+as read-write by multiple Nodes at the same time, when supported by the storage
+provider. Any Pod that is allowed to mount a `ReadWriteMany` PVC can access the
+same filesystem concurrently. This is Kubernetes volume behavior, not behavior
+specific to Tekton.
+
+Do not use `ReadWriteMany` as an isolation mechanism. It is useful for shared
+caches and coordinated workflows inside a single trust domain, but it increases
+the impact of accidentally sharing a PVC between unrelated or differently
+trusted `PipelineRuns`.
+
+`ReadWriteOnce` is also not a trust boundary. It limits where the volume can be
+mounted, but it does not clear previous contents or prevent a later run with
+access to the same PVC from reading or modifying those contents.
+
+### Checklist
+
+- Use `volumeClaimTemplate` for writeable workspaces that should be isolated per
+  `PipelineRun` or `TaskRun`.
+- Do not share an existing PVC between pipelines that run code, inputs, or
+  credentials from different trust levels.
+- Treat `ReadWriteMany` PVCs as concurrently shared filesystems accessible to
+  any Pod that can mount them.
+- Do not rely on `subPath`, access mode, or task ordering as a security boundary
+  between trusted and untrusted workloads.
+- Use separate namespaces, ServiceAccounts, RBAC, and storage classes or claims
+  for separate trust domains.
+- Promote artifacts across trust boundaries through systems that validate and
+  authorize the data before trusted pipelines consume it.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -26,6 +26,12 @@ This page describes security best practices for authoring and operating Tekton
 `TaskRuns` and `PipelineRuns` where lower-trust workloads could affect
 higher-trust workloads.
 
+The broader [Tekton Security Threat Model](threat-model.md) establishes the
+principle behind this guidance: Tekton relies on Kubernetes and the surrounding
+platform for isolation and enforcement, rather than acting as a security
+boundary itself. The workspace scenarios on this page are a worked example of
+that model.
+
 ## Workspace isolation across trust boundaries
 
 `Workspaces` are a way for `TaskRuns` and `PipelineRuns` to mount Kubernetes

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -12,6 +12,7 @@ weight: 405
   - [`Workspaces` in `Pipelines` and `PipelineRuns`](#workspaces-in-pipelines-and-pipelineruns)
   - [Optional `Workspaces`](#optional-workspaces)
   - [Isolated `Workspaces`](#isolated-workspaces)
+  - [Workspace isolation across trust boundaries](#workspace-isolation-across-trust-boundaries)
 - [Configuring `Workspaces`](#configuring-workspaces)
   - [Using `Workspaces` in `Tasks`](#using-workspaces-in-tasks)
     - [Isolating `Workspaces` to Specific `Steps` or `Sidecars`](#isolating-workspaces-to-specific-steps-or-sidecars)
@@ -109,8 +110,30 @@ authors can isolate `Workspaces` to only those `Steps` and `Sidecars` that requi
 them. The primary use-case for this is credentials but it can apply to any data that should have
 its access strictly limited to only specific container images.
 
+Isolated `Workspaces` limit access within a single `Task`. They do not provide
+storage isolation between separate `PipelineRuns` that bind the same
+`PersistentVolumeClaim`.
+
 See the section [Isolating `Workspaces` to Specific `Steps` or `Sidecars`](#isolating-workspaces-to-specific-steps-or-sidecars)
 for more info on this feature.
+
+### Workspace isolation across trust boundaries
+
+Tekton does not enforce filesystem-level isolation between `PipelineRuns` that
+intentionally bind the same persistent workspace. When two `PipelineRuns` mount
+the same `PersistentVolumeClaim`, each run's Pods can access the same files
+according to the PVC access mode, Kubernetes volume permissions, and container
+security context.
+
+Use `volumeClaimTemplate` when a `PipelineRun` needs a writeable persistent
+workspace that should be isolated from other runs. Avoid binding the same
+existing PVC to pipelines that operate at different trust levels, such as
+untrusted pull-request validation and trusted release automation. In particular,
+`ReadWriteMany` PVCs are shared Kubernetes filesystems that can be mounted by
+multiple Pods concurrently; Tekton does not add another isolation boundary on
+top of that behavior.
+
+For more guidance, see [Security Best Practices](./security/README.md#workspace-isolation-across-trust-boundaries).
 
 ## Configuring `Workspaces`
 
@@ -425,6 +448,8 @@ options differ for each type. `Workspaces` support the following fields:
 #### Using `PersistentVolumeClaims` as `VolumeSource`
 
 `PersistentVolumeClaim` volumes are a good choice for sharing data among `Tasks` within a `Pipeline`.
+If storage should be isolated for each run, use a `volumeClaimTemplate` instead of an existing
+`persistentVolumeClaim`.
 Beware that the [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
 configured for the `PersistentVolumeClaim` effects how you can use the volume for parallel `Tasks` in a `Pipeline`. See
 [Specifying `workspace` order in a `Pipeline` and Affinity Assistants](#specifying-workspace-order-in-a-pipeline-and-affinity-assistants) for more information about this.
@@ -435,6 +460,9 @@ There are two ways of using `PersistentVolumeClaims` as a `VolumeSource`.
 The `volumeClaimTemplate` is a template of a [`PersistentVolumeClaim` volume](https://kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim),
 created for each `PipelineRun` or `TaskRun`. When the volume is created from a template in a `PipelineRun` or `TaskRun` 
 it will be deleted when the `PipelineRun` or `TaskRun` is deleted.
+
+Use `volumeClaimTemplate` for writeable workspaces that should be isolated per run, especially when runs are triggered
+by inputs at different trust levels.
 
 ```yaml
 workspaces:
@@ -451,6 +479,10 @@ workspaces:
 ##### `persistentVolumeClaim`
 
 The `persistentVolumeClaim` field references an *existing* [`persistentVolumeClaim` volume](https://kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim). The example exposes only the subdirectory `my-subdir` from that `PersistentVolumeClaim`
+
+**Caution:** Binding an existing `PersistentVolumeClaim` can share data across `PipelineRuns`.
+Do not use the same PVC for pipelines that operate at different trust levels unless the sharing is intentional and safe
+for every workload that can mount the claim.
 
 ```yaml
 workspaces:
@@ -593,7 +625,8 @@ the storage solution that you are using.
   in some way before use. Dynamically provided volumes can usually not be used in read-only mode.
 
 * `ReadWriteMany` is the least commonly available Access Mode. If you use this access mode and these volumes are available
-  to all Nodes within your cluster, you may want to disable the Affinity Assistant.
+  to all Nodes within your cluster, you may want to disable the Affinity Assistant. Any Pod that is allowed to mount a
+  `ReadWriteMany` PVC can access the same filesystem concurrently, so do not share one across trust boundaries.
 
 ### Availability Zones
 `Persistent Volumes` are "zonal" in some cloud providers like GKE (i.e. they live within a single Availability Zone and cannot be accessed from a `pod` living in another Availability Zone). When using a workspace backed by a `PersistentVolumeClaim` (typically only available within a Data Center), the `TaskRun` `pods` can be scheduled to any Availability Zone in a regional cluster. This results in potential Availability Zone scheduling conflict when two `pods` requiring the same Volume are scheduled to different Availability Zones (see issue [#3480](https://github.com/tektoncd/pipeline/issues/3480) and [#5275](https://github.com/tektoncd/pipeline/issues/5275)).

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -451,7 +451,7 @@ options differ for each type. `Workspaces` support the following fields:
 If storage should be isolated for each run, use a `volumeClaimTemplate` instead of an existing
 `persistentVolumeClaim`.
 Beware that the [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
-configured for the `PersistentVolumeClaim` effects how you can use the volume for parallel `Tasks` in a `Pipeline`. See
+configured for the `PersistentVolumeClaim` affects how you can use the volume for parallel `Tasks` in a `Pipeline`. See
 [Specifying `workspace` order in a `Pipeline` and Affinity Assistants](#specifying-workspace-order-in-a-pipeline-and-affinity-assistants) for more information about this.
 There are two ways of using `PersistentVolumeClaims` as a `VolumeSource`.
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Documents workspace isolation best practices for PipelineRuns that operate across trust boundaries.

This adds guidance covering:
- using `volumeClaimTemplate` for per-run workspace isolation
- avoiding shared PVCs between pipelines at different trust levels
- clarifying that Tekton does not enforce filesystem-level isolation between runs that mount the same workspace
- calling out `ReadWriteMany` PVC behavior as Kubernetes volume behavior
- linking the new guidance from the existing workspace documentation

Fixes #10068

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

# Change Type
```
/kind documentation
```