### PR TITLE
fix(resolvers): Allow ResolutionRequests to resolve all Tekton kinds

### DIFF
--- a/pkg/remoteresolution/resolver/framework/reconciler_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_test.go
@@ -164,44 +164,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: errors.New("error getting \"Fake\" \"foo/rr\": resolved resource validation error: resolved data is not of a supported type, must be of Group: tekton.dev, Kinds: [Pipeline Task StepAction]"),
-		}, {
-			name: "known value invalid type",
-			inputRequest: &v1beta1.ResolutionRequest{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "resolution.tekton.dev/v1beta1",
-					Kind:       "ResolutionRequest",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "rr",
-					Namespace:         "foo",
-					CreationTimestamp: metav1.Time{Time: time.Now()},
-					Labels: map[string]string{
-						resolutioncommon.LabelKeyResolverType: resolutionframework.LabelValueFakeResolverType,
-					},
-				},
-				Spec: v1beta1.ResolutionRequestSpec{
-					Params: []pipelinev1.Param{{
-						Name:  resolutionframework.FakeParamName,
-						Value: *pipelinev1.NewStructuredValues("bar"),
-					}},
-				},
-				Status: v1beta1.ResolutionRequestStatus{},
-			},
-			paramMap: map[string]*resolutionframework.FakeResolvedResource{
-				"bar": {
-					Content:       "{\"apiVersion\": \"tekton.dev/v1\", \"kind\": \"PipelineRun\"}",
-					AnnotationMap: map[string]string{"foo": "bar"},
-					ContentSource: &pipelinev1.RefSource{
-						URI: "https://abc.com",
-						Digest: map[string]string{
-							"sha1": "xyz",
-						},
-						EntryPoint: "foo/bar",
-					},
-				},
-			},
-			expectedErr: errors.New("error getting \"Fake\" \"foo/rr\": resolved resource validation error: resolved data is not of a supported type, must be of Group: tekton.dev, Kinds: [Pipeline Task StepAction]"),
+			expectedErr: errors.New("error getting \"Fake\" \"foo/rr\": resolved resource validation error: resolved data is not of a supported type, must be of Group: tekton.dev, Kinds: [PipelineRun Pipeline TaskRun Task Run CustomRun StepAction]"),
 		}, {
 			name: "known value unknown type",
 			inputRequest: &v1beta1.ResolutionRequest{
@@ -238,7 +201,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: errors.New("error getting \"Fake\" \"foo/rr\": resolved resource validation error: resolved data is not of a supported type, must be of Group: tekton.dev, Kinds: [Pipeline Task StepAction]"),
+			expectedErr: errors.New("error getting \"Fake\" \"foo/rr\": resolved resource validation error: resolved data is not of a supported type, must be of Group: tekton.dev, Kinds: [PipelineRun Pipeline TaskRun Task Run CustomRun StepAction]"),
 		}, {
 			name: "unknown value",
 			inputRequest: &v1beta1.ResolutionRequest{

--- a/pkg/resolution/resolver/framework/reconciler.go
+++ b/pkg/resolution/resolver/framework/reconciler.go
@@ -72,9 +72,15 @@ var _ reconciler.LeaderAware = &Reconciler{}
 // the framework.TimedResolution interface.
 const defaultMaximumResolutionDuration = time.Minute
 
+// allowedResourceKinds lists the kinds of resources which
+// are allowed to be resolved by resolvers
 var allowedResourceKinds = []string{
+	pipelineapi.PipelineRunControllerName,
 	pipelineapi.PipelineControllerName,
+	pipelineapi.TaskRunControllerName,
 	pipelineapi.TaskControllerName,
+	pipelineapi.RunControllerName,
+	pipelineapi.CustomRunControllerName,
 	pipelinev1beta1.StepActionKind,
 }
 


### PR DESCRIPTION
# Changes
This change slightly loosens the restrictions for what kinds of objects may be resolved via ResolutionRequests from allowing only `Pipelines`, `Tasks`, and `StepActions` to allowing only known Tekton kinds (including *Runs).  Tekton controllers only create ResolutionRequests for Pipelines, Tasks, and StepActions. The original restriction was made under the assumption that the Tekton Controller was the only controller creating Resolution Requests. However some non-Tekton services in the cluster cluster use Tekton Resolvers to fetch things like PipelineRun definitions. This is arguably a reasonable use-case and previously-supported (though undocumented) behavior.

The security model of the original commit was to ensure irrelevant objects or sensitive data (such as source code, Secrets on disk, or binaries) would not be written into the ResolutionRequest's status.data field. This change preserves that security model while allowing the resolvers to remain somewhat flexible for synergistic use-cases. Also, in-cluster object resolution via the Cluster Resolver is still limited to just `tasks`, `pipelines`, and `stepactions` by the pre-existing, resolver-specific restriction.

See also: 0c1a6dea9bf5ba6533fa6ddc45f9e5d1cefc1d1f

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->



<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Before this change, ResolutionRequests could only resolve Pipelines, Tasks, and StepActions. After this change, ResolutionRequests can resolve PipelineRuns, Pipelines, TaskRuns, Tasks, Runs, CustomRuns, and StepActions.
```

/kind bug