### PR TITLE
test(resolvers): cover resolved resource validation kinds

### DIFF
--- a/pkg/resolution/resolver/framework/interface_test.go
+++ b/pkg/resolution/resolver/framework/interface_test.go
@@ -1,0 +1,147 @@
+/*
+ Copyright 2026 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package framework_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+)
+
+func TestValidateResolvedResourceAllowsTektonKinds(t *testing.T) {
+	testCases := []struct {
+		name       string
+		apiVersion string
+		kind       string
+	}{
+		{
+			name:       "v1 PipelineRun",
+			apiVersion: pipelinev1.SchemeGroupVersion.String(),
+			kind:       pipelineapi.PipelineRunControllerName,
+		}, {
+			name:       "v1 Pipeline",
+			apiVersion: pipelinev1.SchemeGroupVersion.String(),
+			kind:       pipelineapi.PipelineControllerName,
+		}, {
+			name:       "v1 TaskRun",
+			apiVersion: pipelinev1.SchemeGroupVersion.String(),
+			kind:       pipelineapi.TaskRunControllerName,
+		}, {
+			name:       "v1 Task",
+			apiVersion: pipelinev1.SchemeGroupVersion.String(),
+			kind:       pipelineapi.TaskControllerName,
+		}, {
+			name:       "v1beta1 PipelineRun",
+			apiVersion: pipelinev1beta1.SchemeGroupVersion.String(),
+			kind:       pipelineapi.PipelineRunControllerName,
+		}, {
+			name:       "v1beta1 Pipeline",
+			apiVersion: pipelinev1beta1.SchemeGroupVersion.String(),
+			kind:       pipelineapi.PipelineControllerName,
+		}, {
+			name:       "v1beta1 TaskRun",
+			apiVersion: pipelinev1beta1.SchemeGroupVersion.String(),
+			kind:       pipelineapi.TaskRunControllerName,
+		}, {
+			name:       "v1beta1 Task",
+			apiVersion: pipelinev1beta1.SchemeGroupVersion.String(),
+			kind:       pipelineapi.TaskControllerName,
+		}, {
+			name:       "v1alpha1 Run",
+			apiVersion: pipelinev1alpha1.SchemeGroupVersion.String(),
+			kind:       pipelineapi.RunControllerName,
+		}, {
+			name:       "v1beta1 CustomRun",
+			apiVersion: pipelinev1beta1.SchemeGroupVersion.String(),
+			kind:       pipelineapi.CustomRunControllerName,
+		}, {
+			name:       "v1beta1 StepAction",
+			apiVersion: pipelinev1beta1.SchemeGroupVersion.String(),
+			kind:       pipelinev1beta1.StepActionKind,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource := &framework.FakeResolvedResource{
+				Content: resolvedResourceContent(tc.apiVersion, tc.kind),
+			}
+
+			if err := framework.ValidateResolvedResource(resource); err != nil {
+				t.Fatalf("ValidateResolvedResource() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateResolvedResourceRejectsUnsupportedData(t *testing.T) {
+	testCases := []struct {
+		name        string
+		content     string
+		wantErrText string
+	}{
+		{
+			name:        "unsupported Tekton kind",
+			content:     resolvedResourceContent(pipelinev1.SchemeGroupVersion.String(), "UnsupportedKind"),
+			wantErrText: "resolved data is not of a supported type",
+		}, {
+			name:        "unsupported group and kind",
+			content:     resolvedResourceContent("apps/v1", "Deployment"),
+			wantErrText: "resolved data is not of a supported type",
+		}, {
+			name:        "non Kubernetes yaml object",
+			content:     "token: top-secret\nurl: https://example.com/resource.yaml\n",
+			wantErrText: "resolved data is not of a supported type",
+		}, {
+			name:        "non Kubernetes json object",
+			content:     `{"token":"top-secret","url":"https://example.com/resource.yaml"}`,
+			wantErrText: "resolved data is not of a supported type",
+		}, {
+			name:        "string data",
+			content:     "not a kubernetes object",
+			wantErrText: "decoding error",
+		}, {
+			name:        "binary data",
+			content:     string([]byte{0xff, 0x00, 0x01}),
+			wantErrText: "decoding error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource := &framework.FakeResolvedResource{Content: tc.content}
+
+			err := framework.ValidateResolvedResource(resource)
+			if err == nil {
+				t.Fatal("ValidateResolvedResource() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrText) {
+				t.Fatalf("ValidateResolvedResource() error = %v, want error containing %q", err, tc.wantErrText)
+			}
+		})
+	}
+}
+
+func resolvedResourceContent(apiVersion, kind string) string {
+	return fmt.Sprintf("apiVersion: %s\nkind: %s\n", apiVersion, kind)
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adds direct unit coverage for `ValidateResolvedResource` after #10242 expanded the resolver framework allow-list.

This adds table-driven tests for:

- allowed Tekton kinds: `PipelineRun`, `Pipeline`, `TaskRun`, `Task`, `Run`, `CustomRun`, and `StepAction`
- unsupported resolved resources: a non-Tekton Kubernetes kind and an unsupported Tekton kind

This intentionally leaves the `VerificationPolicy` question out of scope for this draft, per the follow-up discussion.

Refs #10249

Tested with:

```sh
go test ./pkg/resolution/resolver/framework ./pkg/remoteresolution/resolver/framework
```

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind cleanup
/area resolution
