### PR TITLE
ci: add missing issues:write permission to cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick-command.yaml
+++ b/.github/workflows/cherry-pick-command.yaml
@@ -22,6 +22,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   cherry-pick:

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7
+defaultBaseImage: ghcr.io/tektoncd/plumbing/static-base@sha256:e150c89001e336b6a0200a6bac766a7b455e5573bf91c6c37f3ef8cf2fdccf0a
 baseImageOverrides:
   # Use the combined base image for images that should include Windows support.
   # The :latest tag is automatically replaced with the actual digest during releases by tekton/publish.yaml.

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -117,9 +117,9 @@ spec:
       fi
 
       # Combine Distroless with a Windows base image, used for the entrypoint image.
-      # Distroless is pinned to the last version based on Alpine 3.18. Newer versions are based on Alpine 3.19_alpha20230901.
+      # Static base image from tektoncd/plumbing, rebuilt daily.
       COMBINED_BASE_IMAGE=$(go run ./vendor/github.com/tektoncd/plumbing/cmd/combine/main.go \
-        cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7 \
+        ghcr.io/tektoncd/plumbing/static-base@sha256:e150c89001e336b6a0200a6bac766a7b455e5573bf91c6c37f3ef8cf2fdccf0a \
         mcr.microsoft.com/windows/nanoserver:ltsc2019 \
         mcr.microsoft.com/windows/nanoserver:ltsc2022 \
         ${COMBINED_BASE_IMAGE_BASE}/combined-base-image:latest)


### PR DESCRIPTION
# Changes

The cherry-pick workflow calls tektoncd/plumbing's reusable workflow which requires `issues:write` permission for `peter-evans/create-or-update-comment` to post status comments on PRs. This permission was removed in 4b04bd15284c when scoping permissions to least privilege, causing `startup_failure` errors.

Fixes: https://github.com/tektoncd/pipeline/actions/runs/27333669212

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string \"action required\" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```