### PR TITLE
feat(notifications): add tracing spans to PipelineRun notifications reconciler

### DIFF
--- a/pkg/reconciler/notifications/pipelinerun/reconciler.go
+++ b/pkg/reconciler/notifications/pipelinerun/reconciler.go
@@ -24,13 +24,26 @@ import (
 	pipelinerunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/pipelinerun"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/notifications"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
+)
+
+const (
+	// TracerName is the name of the tracer for the pipelinerun notifications reconciler.
+	TracerName = "PipelineRunNotificationsReconciler"
 )
 
 // Reconciler implements controller.Reconciler for PipelineRun resources.
 type Reconciler struct {
 	cloudEventClient cloudevent.CEClient
 	cacheClient      *bc.BigCache
+
+	// tracerProvider is used to create spans for distributed tracing.
+	tracerProvider trace.TracerProvider
 }
 
 // NewReconciler creates a new Reconciler with the given clients.
@@ -38,6 +51,7 @@ func NewReconciler(ceClient cloudevent.CEClient, cacheClient *bc.BigCache) *Reco
 	return &Reconciler{
 		cloudEventClient: ceClient,
 		cacheClient:      cacheClient,
+		tracerProvider:   otel.GetTracerProvider(),
 	}
 }
 
@@ -54,5 +68,21 @@ var _ pipelinerunreconciler.Interface = (*Reconciler)(nil)
 
 // ReconcileKind observes the resource conditions and triggers notifications accordingly.
 func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgreconciler.Event {
-	return notifications.ReconcileRunObject(ctx, c, pr)
+	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "ReconcileKind",
+		trace.WithAttributes(
+			attribute.String("pipelinerun.name", pr.Name),
+			attribute.String("pipelinerun.namespace", pr.Namespace),
+		),
+	)
+	defer span.End()
+
+	logger := logging.FromContext(ctx)
+	logger.Infof("Reconciling PipelineRun notifications for %s/%s", pr.Namespace, pr.Name)
+
+	err := notifications.ReconcileRunObject(ctx, c, pr)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+	return err
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add distributed tracing to the PipelineRun notifications reconciler, completing tracing coverage across all three notification reconcilers (TaskRun, CustomRun, PipelineRun).

**Context:** The TaskRun notifications reconciler already has tracing, and the CustomRun notifications reconciler was added in #10097. The PipelineRun reconciler was the remaining gap, where `ReconcileKind` delegated to `notifications.ReconcileRunObject` without a span.

- Add a `tracerProvider trace.TracerProvider` field, set to `otel.GetTracerProvider()` in `NewReconciler`
- Wrap `ReconcileKind` in a span carrying `pipelinerun.name` and `pipelinerun.namespace` attributes
- Record errors on the span (`span.SetStatus` + `span.RecordError`)
- Add a `TracerName = "PipelineRunNotificationsReconciler"` constant

The pattern mirrors `pkg/reconciler/notifications/taskrun/reconciler.go`. No behaviour change; `NewReconciler`'s signature is unchanged, so existing tests pass without modification.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
