### PR TITLE
feat(tracing): add spans to PipelineRun cancel and timeout paths

### DIFF
--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -28,6 +28,7 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -73,16 +74,25 @@ func init() {
 }
 
 func cancelCustomRun(ctx context.Context, runName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := tracerFromContext(ctx).Start(ctx, "cancelCustomRun")
+	defer span.End()
+	span.SetAttributes(attribute.String("customrun", runName))
+
 	_, err := clientSet.TektonV1beta1().CustomRuns(namespace).Patch(ctx, runName, types.JSONPatchType, cancelCustomRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
 		// The resource may have been deleted in the meanwhile, but we should
 		// still be able to cancel the PipelineRun
 		return nil
 	}
+	recordSpanError(span, err)
 	return err
 }
 
 func cancelTaskRun(ctx context.Context, taskRunName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := tracerFromContext(ctx).Start(ctx, "cancelTaskRun")
+	defer span.End()
+	span.SetAttributes(attribute.String("taskrun", taskRunName))
+
 	_, err := clientSet.TektonV1().TaskRuns(namespace).Patch(ctx, taskRunName, types.JSONPatchType, cancelTaskRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
 		// The resource may have been deleted in the meanwhile, but we should
@@ -93,11 +103,19 @@ func cancelTaskRun(ctx context.Context, taskRunName string, namespace string, cl
 		// The TaskRun may have completed and the spec field is immutable, we should ignore this error.
 		return nil
 	}
+	recordSpanError(span, err)
 	return err
 }
 
 // cancelPipelineRun marks the PipelineRun as cancelled and any resolved TaskRun(s) too.
 func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface) error {
+	ctx, span := tracerFromContext(ctx).Start(ctx, "cancelPipelineRun")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("pipelinerun", pr.Name),
+		attribute.String("namespace", pr.Namespace),
+	)
+
 	errs := cancelPipelineTaskRuns(ctx, logger, pr, clientSet)
 
 	// If we successfully cancelled all the TaskRuns and Runs, we can consider the PipelineRun cancelled.
@@ -121,7 +139,9 @@ func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.Pi
 			Reason:  v1.PipelineRunReasonCouldntCancel.String(),
 			Message: fmt.Sprintf("PipelineRun %q was cancelled but had errors trying to cancel TaskRuns and/or Runs: %s", pr.Name, e),
 		})
-		return fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		err := fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		recordSpanError(span, err)
+		return err
 	}
 	return nil
 }
@@ -190,6 +210,13 @@ func getChildObjectsFromPRStatusForTaskNames(ctx context.Context, prs v1.Pipelin
 
 // gracefullyCancelPipelineRun marks any non-final resolved TaskRun(s) as cancelled and runs finally.
 func gracefullyCancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface) error {
+	ctx, span := tracerFromContext(ctx).Start(ctx, "gracefullyCancelPipelineRun")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("pipelinerun", pr.Name),
+		attribute.String("namespace", pr.Namespace),
+	)
+
 	errs := cancelPipelineTaskRuns(ctx, logger, pr, clientSet)
 
 	// If we successfully cancelled all the TaskRuns and Runs, we can proceed with the PipelineRun reconciliation to trigger finally.
@@ -202,7 +229,9 @@ func gracefullyCancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger,
 			Reason:  v1.PipelineRunReasonCouldntCancel.String(),
 			Message: fmt.Sprintf("PipelineRun %q was cancelled but had errors trying to cancel TaskRuns and/or Runs: %s", pr.Name, e),
 		})
-		return fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		err := fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		recordSpanError(span, err)
+		return err
 	}
 	return nil
 }

--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -76,7 +76,7 @@ func init() {
 func cancelCustomRun(ctx context.Context, runName string, namespace string, clientSet clientset.Interface) error {
 	ctx, span := tracerFromContext(ctx).Start(ctx, "cancelCustomRun")
 	defer span.End()
-	span.SetAttributes(attribute.String("customrun", runName))
+	span.SetAttributes(attribute.String("customrun", runName), attribute.String("namespace", namespace))
 
 	_, err := clientSet.TektonV1beta1().CustomRuns(namespace).Patch(ctx, runName, types.JSONPatchType, cancelCustomRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
@@ -91,7 +91,7 @@ func cancelCustomRun(ctx context.Context, runName string, namespace string, clie
 func cancelTaskRun(ctx context.Context, taskRunName string, namespace string, clientSet clientset.Interface) error {
 	ctx, span := tracerFromContext(ctx).Start(ctx, "cancelTaskRun")
 	defer span.End()
-	span.SetAttributes(attribute.String("taskrun", taskRunName))
+	span.SetAttributes(attribute.String("taskrun", taskRunName), attribute.String("namespace", namespace))
 
 	_, err := clientSet.TektonV1().TaskRuns(namespace).Patch(ctx, taskRunName, types.JSONPatchType, cancelTaskRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -28,6 +28,8 @@ import (
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -421,4 +423,77 @@ func TestGetChildObjectsFromPRStatusForTaskNames(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCancelPipelineRunEmitsSpan(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(sr))
+
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-cancelled", Namespace: "foo"},
+		Spec:       v1.PipelineRunSpec{Status: v1.PipelineRunSpecStatusCancelled},
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	cfg := config.NewStore(logtesting.TestLogger(t))
+	ctx = cfg.ToContext(ctx)
+	// Put a span on the context so the cancel helpers create their child spans
+	// against the recording provider.
+	ctx, root := tp.Tracer("test").Start(ctx, "root")
+	defer root.End()
+	c, _ := test.SeedTestData(t, ctx, test.Data{PipelineRuns: []*v1.PipelineRun{pr}})
+
+	if err := cancelPipelineRun(ctx, logtesting.TestLogger(t), pr, c.Pipeline); err != nil {
+		t.Fatalf("cancelPipelineRun returned an unexpected error: %v", err)
+	}
+
+	var found bool
+	for _, s := range sr.Ended() {
+		if s.Name() == "cancelPipelineRun" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a %q span to be recorded, got %v", "cancelPipelineRun", spanNames(sr.Ended()))
+	}
+}
+
+func TestTimeoutPipelineRunEmitsSpan(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(sr))
+
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timeout", Namespace: "foo"},
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	cfg := config.NewStore(logtesting.TestLogger(t))
+	ctx = cfg.ToContext(ctx)
+	// Put a span on the context so the timeout helpers create their child spans
+	// against the recording provider.
+	ctx, root := tp.Tracer("test").Start(ctx, "root")
+	defer root.End()
+	c, _ := test.SeedTestData(t, ctx, test.Data{PipelineRuns: []*v1.PipelineRun{pr}})
+
+	if err := timeoutPipelineRun(ctx, logtesting.TestLogger(t), pr, c.Pipeline); err != nil {
+		t.Fatalf("timeoutPipelineRun returned an unexpected error: %v", err)
+	}
+
+	var found bool
+	for _, s := range sr.Ended() {
+		if s.Name() == "timeoutPipelineRun" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a %q span to be recorded, got %v", "timeoutPipelineRun", spanNames(sr.Ended()))
+	}
+}
+
+func spanNames(spans []tracesdk.ReadOnlySpan) []string {
+	names := make([]string, 0, len(spans))
+	for _, s := range spans {
+		names = append(names, s.Name())
+	}
+	return names
 }

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -458,38 +458,6 @@ func TestCancelPipelineRunEmitsSpan(t *testing.T) {
 	}
 }
 
-func TestTimeoutPipelineRunEmitsSpan(t *testing.T) {
-	sr := tracetest.NewSpanRecorder()
-	tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(sr))
-
-	pr := &v1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timeout", Namespace: "foo"},
-	}
-
-	ctx, _ := ttesting.SetupFakeContext(t)
-	cfg := config.NewStore(logtesting.TestLogger(t))
-	ctx = cfg.ToContext(ctx)
-	// Put a span on the context so the timeout helpers create their child spans
-	// against the recording provider.
-	ctx, root := tp.Tracer("test").Start(ctx, "root")
-	defer root.End()
-	c, _ := test.SeedTestData(t, ctx, test.Data{PipelineRuns: []*v1.PipelineRun{pr}})
-
-	if err := timeoutPipelineRun(ctx, logtesting.TestLogger(t), pr, c.Pipeline); err != nil {
-		t.Fatalf("timeoutPipelineRun returned an unexpected error: %v", err)
-	}
-
-	var found bool
-	for _, s := range sr.Ended() {
-		if s.Name() == "timeoutPipelineRun" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected a %q span to be recorded, got %v", "timeoutPipelineRun", spanNames(sr.Ended()))
-	}
-}
-
 func spanNames(spans []tracesdk.ReadOnlySpan) []string {
 	names := make([]string, 0, len(spans))
 	for _, s := range spans {

--- a/pkg/reconciler/pipelinerun/timeout.go
+++ b/pkg/reconciler/pipelinerun/timeout.go
@@ -105,7 +105,7 @@ func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.P
 func timeoutCustomRun(ctx context.Context, customRunName string, namespace string, clientSet clientset.Interface) error {
 	ctx, span := tracerFromContext(ctx).Start(ctx, "timeoutCustomRun")
 	defer span.End()
-	span.SetAttributes(attribute.String("customrun", customRunName))
+	span.SetAttributes(attribute.String("customrun", customRunName), attribute.String("namespace", namespace))
 
 	_, err := clientSet.TektonV1beta1().CustomRuns(namespace).Patch(ctx, customRunName, types.JSONPatchType, timeoutCustomRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
@@ -118,7 +118,7 @@ func timeoutCustomRun(ctx context.Context, customRunName string, namespace strin
 func timeoutTaskRun(ctx context.Context, taskRunName string, namespace string, clientSet clientset.Interface) error {
 	ctx, span := tracerFromContext(ctx).Start(ctx, "timeoutTaskRun")
 	defer span.End()
-	span.SetAttributes(attribute.String("taskrun", taskRunName))
+	span.SetAttributes(attribute.String("taskrun", taskRunName), attribute.String("namespace", namespace))
 
 	_, err := clientSet.TektonV1().TaskRuns(namespace).Patch(ctx, taskRunName, types.JSONPatchType, timeoutTaskRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {

--- a/pkg/reconciler/pipelinerun/timeout.go
+++ b/pkg/reconciler/pipelinerun/timeout.go
@@ -25,6 +25,7 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	"gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -71,6 +72,13 @@ func init() {
 
 // timeoutPipelineRun marks the PipelineRun as timed out and any resolved TaskRun(s) too.
 func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.PipelineRun, clientSet clientset.Interface) error {
+	ctx, span := tracerFromContext(ctx).Start(ctx, "timeoutPipelineRun")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("pipelinerun", pr.Name),
+		attribute.String("namespace", pr.Namespace),
+	)
+
 	errs := timeoutPipelineTasks(ctx, logger, pr, clientSet)
 
 	// If we successfully timed out all the TaskRuns and Runs, we can consider the PipelineRun timed out.
@@ -87,24 +95,36 @@ func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.P
 			Reason:  v1.PipelineRunReasonCouldntTimeOut.String(),
 			Message: fmt.Sprintf("PipelineRun %q was timed out but had errors trying to time out TaskRuns and/or Runs: %s", pr.Name, e),
 		})
-		return fmt.Errorf("error(s) from timing out TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		err := fmt.Errorf("error(s) from timing out TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+		recordSpanError(span, err)
+		return err
 	}
 	return nil
 }
 
 func timeoutCustomRun(ctx context.Context, customRunName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := tracerFromContext(ctx).Start(ctx, "timeoutCustomRun")
+	defer span.End()
+	span.SetAttributes(attribute.String("customrun", customRunName))
+
 	_, err := clientSet.TektonV1beta1().CustomRuns(namespace).Patch(ctx, customRunName, types.JSONPatchType, timeoutCustomRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
 		return nil
 	}
+	recordSpanError(span, err)
 	return err
 }
 
 func timeoutTaskRun(ctx context.Context, taskRunName string, namespace string, clientSet clientset.Interface) error {
+	ctx, span := tracerFromContext(ctx).Start(ctx, "timeoutTaskRun")
+	defer span.End()
+	span.SetAttributes(attribute.String("taskrun", taskRunName))
+
 	_, err := clientSet.TektonV1().TaskRuns(namespace).Patch(ctx, taskRunName, types.JSONPatchType, timeoutTaskRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
 		return nil
 	}
+	recordSpanError(span, err)
 	return err
 }
 

--- a/pkg/reconciler/pipelinerun/timeout_test.go
+++ b/pkg/reconciler/pipelinerun/timeout_test.go
@@ -17,12 +17,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	_ "github.com/tektoncd/pipeline/pkg/pipelinerunmetrics/fake" // Make sure the pipelinerunmetrics are setup
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
@@ -300,5 +303,37 @@ func TestTimeoutPipelineRun(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestTimeoutPipelineRunEmitsSpan(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(sr))
+
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timeout", Namespace: "foo"},
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	cfg := config.NewStore(logtesting.TestLogger(t))
+	ctx = cfg.ToContext(ctx)
+	// Put a span on the context so the timeout helpers create their child spans
+	// against the recording provider.
+	ctx, root := tp.Tracer("test").Start(ctx, "root")
+	defer root.End()
+	c, _ := test.SeedTestData(t, ctx, test.Data{PipelineRuns: []*v1.PipelineRun{pr}})
+
+	if err := timeoutPipelineRun(ctx, logtesting.TestLogger(t), pr, c.Pipeline); err != nil {
+		t.Fatalf("timeoutPipelineRun returned an unexpected error: %v", err)
+	}
+
+	var found bool
+	for _, s := range sr.Ended() {
+		if s.Name() == "timeoutPipelineRun" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a %q span to be recorded, got %v", "timeoutPipelineRun", spanNames(sr.Ended()))
 	}
 }

--- a/pkg/reconciler/pipelinerun/tracing.go
+++ b/pkg/reconciler/pipelinerun/tracing.go
@@ -24,6 +24,7 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"knative.dev/pkg/logging"
@@ -99,4 +100,21 @@ func getMarshalledSpanFromContext(ctx context.Context) (string, error) {
 		return "", errors.New("marshalled spanContext size is too big")
 	}
 	return string(marshalled), nil
+}
+
+// tracerFromContext returns a tracer bound to the provider that created the
+// span already on ctx. Helpers such as the cancel and timeout paths run within
+// the reconcile context but do not have access to the Reconciler's
+// TracerProvider, so this keeps their spans on the same trace.
+func tracerFromContext(ctx context.Context) trace.Tracer {
+	return trace.SpanFromContext(ctx).TracerProvider().Tracer(TracerName)
+}
+
+// recordSpanError marks the span as failed and records the error, mirroring the
+// convention used by the notifications reconcilers.
+func recordSpanError(span trace.Span, err error) {
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Partially addresses #9783.

The PipelineRun cancel and timeout helpers had zero tracing, so when a run was cancelled or timed out the trace ended abruptly with no visibility into which children were patched or how long each child patch took.

This adds spans to the PipelineRun paths:

- `cancel.go`: `cancelPipelineRun` and `gracefullyCancelPipelineRun` get a span carrying `pipelinerun.name`/`pipelinerun.namespace`; `cancelTaskRun` and `cancelCustomRun` get their own short spans (with the child name) so per-child patch latency is visible. Errors are recorded on the span.
- `timeout.go`: same treatment for `timeoutPipelineRun` and the per-child `timeoutTaskRun`/`timeoutCustomRun`.

The helpers run within the reconcile context but do not hold the Reconciler's `TracerProvider`, so a small `childSpan` helper reuses the provider that created the span already on `ctx`, keeping the new spans on the same trace. Spans only, no behaviour change.

The TaskRun reconciler cancel/timeout paths can follow in a separate PR to keep this one focused, as mentioned in the issue thread.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add tracing spans to the PipelineRun cancel and timeout code paths, so cancellation and timeout of a run and its children are visible in distributed traces.
```
