### PR TITLE
feat(tracing): add spans for task parameter and workspace substitution #9801

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -114,7 +114,6 @@ const (
 var (
 	// Check that our Reconciler implements taskrunreconciler.Interface
 	_ taskrunreconciler.Interface = (*Reconciler)(nil)
-
 	// Pod failure reasons that trigger failure of the TaskRun
 	// Note: ErrImagePull is intentionally not included as it's a transient state
 	// that Kubernetes will automatically retry before transitioning to ImagePullBackOff
@@ -753,7 +752,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1.TaskRun, rtr *resourc
 	// Get the randomized volume names assigned to workspace bindings
 	workspaceVolumes := workspace.CreateVolumes(tr.Spec.Workspaces)
 
-	ts, err := applyParamsContextsResultsAndWorkspaces(ctx, tr, rtr, workspaceVolumes)
+	ts, err := applyParamsContextsResultsAndWorkspaces(ctx, c, tr, rtr, workspaceVolumes)
 	if err != nil {
 		logger.Errorf("Error updating task spec parameters, contexts, results and workspaces: %s", err)
 		return err
@@ -1142,15 +1141,21 @@ func (c *Reconciler) createPod(ctx context.Context, ts *v1.TaskSpec, tr *v1.Task
 	return pod, nil
 }
 
-// applyParamsContextsResultsAndWorkspaces applies paramater, context, results and workspace substitutions to the TaskSpec.
-func applyParamsContextsResultsAndWorkspaces(ctx context.Context, tr *v1.TaskRun, rtr *resources.ResolvedTask, workspaceVolumes map[string]corev1.Volume) (*v1.TaskSpec, error) {
+// applyParamsContextsResultsAndWorkspaces applies parameter, context, results and workspace substitutions to the TaskSpec.
+func applyParamsContextsResultsAndWorkspaces(ctx context.Context, c *Reconciler, tr *v1.TaskRun, rtr *resources.ResolvedTask, workspaceVolumes map[string]corev1.Volume) (*v1.TaskSpec, error) {
+	tracer := c.tracerProvider.Tracer(TracerName)
+	ctx, span := tracer.Start(ctx, "applyParamsContextsResultsAndWorkspaces")
+	defer span.End()
+
 	ts := rtr.TaskSpec.DeepCopy()
 	var defaults []v1.ParamSpec
 	if len(ts.Params) > 0 {
 		defaults = append(defaults, ts.Params...)
 	}
 	// Apply parameter substitution from the taskrun.
+	_, paramSpan := tracer.Start(ctx, "ApplyParameters")
 	ts = resources.ApplyParameters(ts, tr, defaults...)
+	paramSpan.End()
 
 	// Apply context substitution from the taskrun
 	ts = resources.ApplyContexts(ts, rtr.TaskName, tr)
@@ -1182,8 +1187,9 @@ func applyParamsContextsResultsAndWorkspaces(ctx context.Context, tr *v1.TaskRun
 			ts.Workspaces = append(ts.Workspaces, v1.WorkspaceDeclaration{Name: trw.Name})
 		}
 	}
-	ts = resources.ApplyWorkspaces(ctx, ts, ts.Workspaces, tr.Spec.Workspaces, workspaceVolumes)
-
+	_, workspaceSpan := tracer.Start(ctx, "ApplyWorkspaces")
+	ts = resources.ApplyWorkspaces(ctx,ts, ts.Workspaces, tr.Spec.Workspaces, workspaceVolumes)
+	workspaceSpan.End()
 	return ts, nil
 }
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -1188,7 +1188,7 @@ func applyParamsContextsResultsAndWorkspaces(ctx context.Context, c *Reconciler,
 		}
 	}
 	_, workspaceSpan := tracer.Start(ctx, "ApplyWorkspaces")
-	ts = resources.ApplyWorkspaces(ctx,ts, ts.Workspaces, tr.Spec.Workspaces, workspaceVolumes)
+	ts = resources.ApplyWorkspaces(ctx, ts, ts.Workspaces, tr.Spec.Workspaces, workspaceVolumes)
 	workspaceSpan.End()
 	return ts, nil
 }

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -752,7 +752,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1.TaskRun, rtr *resourc
 	// Get the randomized volume names assigned to workspace bindings
 	workspaceVolumes := workspace.CreateVolumes(tr.Spec.Workspaces)
 
-	ts, err := applyParamsContextsResultsAndWorkspaces(ctx, c, tr, rtr, workspaceVolumes)
+	ts, err := applyParamsContextsResultsAndWorkspaces(ctx, c.tracerProvider.Tracer(TracerName), tr, rtr, workspaceVolumes)
 	if err != nil {
 		logger.Errorf("Error updating task spec parameters, contexts, results and workspaces: %s", err)
 		return err
@@ -1142,8 +1142,7 @@ func (c *Reconciler) createPod(ctx context.Context, ts *v1.TaskSpec, tr *v1.Task
 }
 
 // applyParamsContextsResultsAndWorkspaces applies parameter, context, results and workspace substitutions to the TaskSpec.
-func applyParamsContextsResultsAndWorkspaces(ctx context.Context, c *Reconciler, tr *v1.TaskRun, rtr *resources.ResolvedTask, workspaceVolumes map[string]corev1.Volume) (*v1.TaskSpec, error) {
-	tracer := c.tracerProvider.Tracer(TracerName)
+func applyParamsContextsResultsAndWorkspaces(ctx context.Context, tracer trace.Tracer, tr *v1.TaskRun, rtr *resources.ResolvedTask, workspaceVolumes map[string]corev1.Volume) (*v1.TaskSpec, error) {
 	ctx, span := tracer.Start(ctx, "applyParamsContextsResultsAndWorkspaces")
 	defer span.End()
 

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -4406,7 +4406,7 @@ spec:
 	}
 	ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 	workspaceVolumes := workspace.CreateVolumes(taskRun.Spec.Workspaces)
-	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, taskRun, rtr, workspaceVolumes)
+	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, r, taskRun, rtr, workspaceVolumes)
 	if err != nil {
 		t.Fatalf("update task spec threw error %v", err)
 	}
@@ -4514,7 +4514,7 @@ spec:
 
 	workspaceVolumes := workspace.CreateVolumes(taskRun.Spec.Workspaces)
 	ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
-	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, taskRun, rtr, workspaceVolumes)
+	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, r, taskRun, rtr, workspaceVolumes)
 	if err != nil {
 		t.Errorf("update task spec threw an error: %v", err)
 	}
@@ -4760,7 +4760,7 @@ spec:
 			}
 
 			workspaceVolumes := workspace.CreateVolumes(tr.Spec.Workspaces)
-			taskSpec, err := applyParamsContextsResultsAndWorkspaces(testAssets.Ctx, tr, rtr, workspaceVolumes)
+			taskSpec, err := applyParamsContextsResultsAndWorkspaces(testAssets.Ctx, r, tr, rtr, workspaceVolumes)
 			if err != nil {
 				t.Fatalf("update task spec threw error %v", err)
 			}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -4406,7 +4406,7 @@ spec:
 	}
 	ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
 	workspaceVolumes := workspace.CreateVolumes(taskRun.Spec.Workspaces)
-	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, r, taskRun, rtr, workspaceVolumes)
+	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, r.tracerProvider.Tracer(TracerName), taskRun, rtr, workspaceVolumes)
 	if err != nil {
 		t.Fatalf("update task spec threw error %v", err)
 	}
@@ -4514,7 +4514,7 @@ spec:
 
 	workspaceVolumes := workspace.CreateVolumes(taskRun.Spec.Workspaces)
 	ctx := cfgtesting.EnableAlphaAPIFields(t.Context())
-	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, r, taskRun, rtr, workspaceVolumes)
+	taskSpec, err := applyParamsContextsResultsAndWorkspaces(ctx, r.tracerProvider.Tracer(TracerName), taskRun, rtr, workspaceVolumes)
 	if err != nil {
 		t.Errorf("update task spec threw an error: %v", err)
 	}
@@ -4760,7 +4760,7 @@ spec:
 			}
 
 			workspaceVolumes := workspace.CreateVolumes(tr.Spec.Workspaces)
-			taskSpec, err := applyParamsContextsResultsAndWorkspaces(testAssets.Ctx, r, tr, rtr, workspaceVolumes)
+			taskSpec, err := applyParamsContextsResultsAndWorkspaces(testAssets.Ctx, r.tracerProvider.Tracer(TracerName), tr, rtr, workspaceVolumes)
 			if err != nil {
 				t.Fatalf("update task spec threw error %v", err)
 			}

--- a/pkg/reconciler/taskrun/tracing_test.go
+++ b/pkg/reconciler/taskrun/tracing_test.go
@@ -14,13 +14,16 @@ limitations under the License.
 package taskrun
 
 import (
+	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"testing"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -119,5 +122,58 @@ func TestInitTracing(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestReconcilerApplyPathsEmitSpans(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := tracesdk.NewTracerProvider(tracesdk.WithSyncer(exporter))
+
+	taskSpec := &v1.TaskSpec{
+		Steps: []v1.Step{{Name: "s", Image: "foo"}},
+	}
+
+	tr := &v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: "ns",
+		},
+		Spec: v1.TaskRunSpec{
+			TaskSpec: taskSpec,
+		},
+	}
+
+	rtr := &resources.ResolvedTask{
+		TaskName: "my-task",
+		TaskSpec: taskSpec,
+	}
+
+	r := &Reconciler{
+		tracerProvider: tp,
+	}
+
+	_, err := applyParamsContextsResultsAndWorkspaces(
+		t.Context(),
+		r,
+		tr,
+		rtr,
+		map[string]corev1.Volume{},
+	)
+	if err != nil {
+		t.Fatalf("applyParamsContextsResultsAndWorkspaces() = %v", err)
+	}
+
+	spans := exporter.GetSpans()
+
+	found := false
+	for _, s := range spans {
+		if s.Name == "applyParamsContextsResultsAndWorkspaces" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatal("applyParamsContextsResultsAndWorkspaces span not exported")
 	}
 }

--- a/pkg/reconciler/taskrun/tracing_test.go
+++ b/pkg/reconciler/taskrun/tracing_test.go
@@ -14,8 +14,10 @@ limitations under the License.
 package taskrun
 
 import (
-	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	"maps"
 	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.opentelemetry.io/otel"
@@ -128,6 +130,9 @@ func TestInitTracing(t *testing.T) {
 func TestReconcilerApplyPathsEmitSpans(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := tracesdk.NewTracerProvider(tracesdk.WithSyncer(exporter))
+	t.Cleanup(func() {
+		_ = tp.Shutdown(t.Context())
+	})
 
 	taskSpec := &v1.TaskSpec{
 		Steps: []v1.Step{{Name: "s", Image: "foo"}},
@@ -148,13 +153,9 @@ func TestReconcilerApplyPathsEmitSpans(t *testing.T) {
 		TaskSpec: taskSpec,
 	}
 
-	r := &Reconciler{
-		tracerProvider: tp,
-	}
-
 	_, err := applyParamsContextsResultsAndWorkspaces(
 		t.Context(),
-		r,
+		tp.Tracer(TracerName),
 		tr,
 		rtr,
 		map[string]corev1.Volume{},
@@ -163,17 +164,20 @@ func TestReconcilerApplyPathsEmitSpans(t *testing.T) {
 		t.Fatalf("applyParamsContextsResultsAndWorkspaces() = %v", err)
 	}
 
-	spans := exporter.GetSpans()
-
-	found := false
-	for _, s := range spans {
-		if s.Name == "applyParamsContextsResultsAndWorkspaces" {
-			found = true
-			break
-		}
+	seen := map[string]struct{}{}
+	for _, s := range exporter.GetSpans() {
+		seen[s.Name] = struct{}{}
 	}
 
-	if !found {
-		t.Fatal("applyParamsContextsResultsAndWorkspaces span not exported")
+	expectedSpanNames := []string{
+		"applyParamsContextsResultsAndWorkspaces",
+		"ApplyParameters",
+		"ApplyWorkspaces",
+	}
+
+	for _, spanName := range expectedSpanNames {
+		if _, ok := seen[spanName]; !ok {
+			t.Fatalf("expected span %q to be exported; got spans: %v", spanName, maps.Keys(seen))
+		}
 	}
 }


### PR DESCRIPTION
# Changes

Add tracing spans to the task parameter and workspace substitution pipeline in the TaskRun reconciler. The orchestrating function applyParamsContextsResultsAndWorkspaces is called on every reconcile but has zero tracing.

# Submitter Checklist

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add tracing spans to the task parameter and workspace substitution pipeline in the TaskRun reconciler to improve observability and performance tracking. No user-facing changes.
```
/kind feature
Fixes tektoncd#9801