### PR TITLE
feat(tracing): correlate Kubernetes events with distributed traces

### DIFF
--- a/pkg/reconciler/events/event.go
+++ b/pkg/reconciler/events/event.go
@@ -39,3 +39,6 @@ var EmitCloudEvents = cloudevent.EmitCloudEvents
 
 // EmitError is refactored to k8sevent, this is to avoid breaking change
 var EmitError = k8sevent.EmitError
+
+// EmitErrorWithContext emits an error event with trace context annotations when available.
+var EmitErrorWithContext = k8sevent.EmitErrorWithContext

--- a/pkg/reconciler/events/k8sevent/event.go
+++ b/pkg/reconciler/events/k8sevent/event.go
@@ -28,6 +28,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -49,6 +50,9 @@ const (
 // It returns nil when no trace context is present, so callers fall back to
 // un-annotated events.
 func traceAnnotations(ctx context.Context) map[string]string {
+	if !trace.SpanContextFromContext(ctx).IsValid() {
+		return nil
+	}
 	carrier := propagation.MapCarrier{}
 	otel.GetTextMapPropagator().Inject(ctx, carrier)
 	if len(carrier) == 0 {
@@ -101,10 +105,15 @@ func EmitK8sEvents(ctx context.Context, beforeCondition *apis.Condition, afterCo
 	}
 }
 
-// EmitError emits a failure associated to an error, attaching trace context
-// annotations from ctx when available so the error event can be correlated
-// with a distributed trace.
-func EmitError(ctx context.Context, c record.EventRecorder, err error, object runtime.Object) {
+// EmitError emits a failure associated to an error.
+func EmitError(c record.EventRecorder, err error, object runtime.Object) {
+	EmitErrorWithContext(context.Background(), c, err, object)
+}
+
+// EmitErrorWithContext emits a failure associated to an error, attaching trace
+// context annotations from ctx when available so the error event can be
+// correlated with a distributed trace.
+func EmitErrorWithContext(ctx context.Context, c record.EventRecorder, err error, object runtime.Object) {
 	if err != nil {
 		emitEvent(ctx, c, object, corev1.EventTypeWarning, EventReasonError, err.Error())
 	}

--- a/pkg/reconciler/events/k8sevent/event.go
+++ b/pkg/reconciler/events/k8sevent/event.go
@@ -18,7 +18,6 @@ package k8sevent
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -27,7 +26,8 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/controller"
 
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 const (
@@ -41,27 +41,30 @@ const (
 	EventReasonError = "Error"
 )
 
-// traceAnnotations extracts the W3C Trace Context from the context and returns
-// annotations suitable for AnnotatedEventf. If the span context is not valid,
-// it returns nil (falling back to un-annotated events).
+// traceAnnotations extracts the trace context from ctx using the globally
+// configured OpenTelemetry propagator and returns it as event annotations.
+// Using the configured propagator (rather than formatting traceparent by hand)
+// keeps this consistent with the rest of Tekton's tracing setup and preserves
+// additional fields such as tracestate when the propagator emits them.
+// It returns nil when no trace context is present, so callers fall back to
+// un-annotated events.
 func traceAnnotations(ctx context.Context) map[string]string {
-	sc := trace.SpanFromContext(ctx).SpanContext()
-	if !sc.IsValid() {
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
+	if len(carrier) == 0 {
 		return nil
 	}
-	return map[string]string{
-		"traceparent": fmt.Sprintf("00-%s-%s-%s", sc.TraceID(), sc.SpanID(), sc.TraceFlags()),
-	}
+	return carrier
 }
 
-// emitEvent emits a Kubernetes event with trace context annotations when available.
+// emitEvent emits a Kubernetes event, attaching trace context annotations when
+// they are available so the event can be correlated with a distributed trace.
 func emitEvent(ctx context.Context, recorder record.EventRecorder, object runtime.Object, eventType, reason, message string) {
-	annotations := traceAnnotations(ctx)
-	if annotations != nil {
+	if annotations := traceAnnotations(ctx); annotations != nil {
 		recorder.AnnotatedEventf(object, annotations, eventType, reason, "%s", message)
-	} else {
-		recorder.Event(object, eventType, reason, message)
+		return
 	}
+	recorder.Event(object, eventType, reason, message)
 }
 
 // EmitK8sEvents emits kubernetes events for object
@@ -98,9 +101,11 @@ func EmitK8sEvents(ctx context.Context, beforeCondition *apis.Condition, afterCo
 	}
 }
 
-// EmitError emits a failure associated to an error
-func EmitError(c record.EventRecorder, err error, object runtime.Object) {
+// EmitError emits a failure associated to an error, attaching trace context
+// annotations from ctx when available so the error event can be correlated
+// with a distributed trace.
+func EmitError(ctx context.Context, c record.EventRecorder, err error, object runtime.Object) {
 	if err != nil {
-		c.Event(object, corev1.EventTypeWarning, EventReasonError, err.Error())
+		emitEvent(ctx, c, object, corev1.EventTypeWarning, EventReasonError, err.Error())
 	}
 }

--- a/pkg/reconciler/events/k8sevent/event.go
+++ b/pkg/reconciler/events/k8sevent/event.go
@@ -18,6 +18,7 @@ package k8sevent
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -25,6 +26,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/controller"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -37,6 +40,29 @@ const (
 	// EventReasonError is the reason set for events related to TaskRuns / PipelineRuns reconcile errors
 	EventReasonError = "Error"
 )
+
+// traceAnnotations extracts the W3C Trace Context from the context and returns
+// annotations suitable for AnnotatedEventf. If the span context is not valid,
+// it returns nil (falling back to un-annotated events).
+func traceAnnotations(ctx context.Context) map[string]string {
+	sc := trace.SpanFromContext(ctx).SpanContext()
+	if !sc.IsValid() {
+		return nil
+	}
+	return map[string]string{
+		"traceparent": fmt.Sprintf("00-%s-%s-%s", sc.TraceID(), sc.SpanID(), sc.TraceFlags()),
+	}
+}
+
+// emitEvent emits a Kubernetes event with trace context annotations when available.
+func emitEvent(ctx context.Context, recorder record.EventRecorder, object runtime.Object, eventType, reason, message string) {
+	annotations := traceAnnotations(ctx)
+	if annotations != nil {
+		recorder.AnnotatedEventf(object, annotations, eventType, reason, "%s", message)
+	} else {
+		recorder.Event(object, eventType, reason, message)
+	}
+}
 
 // EmitK8sEvents emits kubernetes events for object
 // k8s events are always sent if afterCondition is different from beforeCondition
@@ -54,19 +80,19 @@ func EmitK8sEvents(ctx context.Context, beforeCondition *apis.Condition, afterCo
 		// If the condition changed, and the target condition is not empty, we send an event
 		switch afterCondition.Status {
 		case corev1.ConditionTrue:
-			recorder.Event(object, corev1.EventTypeNormal, EventReasonSucceded, afterCondition.Message)
+			emitEvent(ctx, recorder, object, corev1.EventTypeNormal, EventReasonSucceded, afterCondition.Message)
 		case corev1.ConditionFalse:
-			recorder.Event(object, corev1.EventTypeWarning, EventReasonFailed, afterCondition.Message)
+			emitEvent(ctx, recorder, object, corev1.EventTypeWarning, EventReasonFailed, afterCondition.Message)
 		case corev1.ConditionUnknown:
 			if beforeCondition == nil {
 				// If the condition changed, the status is "unknown", and there was no condition before,
 				// we emit the "Started event". We ignore further updates of the "unknown" status.
-				recorder.Event(object, corev1.EventTypeNormal, EventReasonStarted, "")
+				emitEvent(ctx, recorder, object, corev1.EventTypeNormal, EventReasonStarted, "")
 			} else {
 				// If the condition changed, the status is "unknown", and there was a condition before,
 				// we emit an event that matches the reason and message of the condition.
 				// This is used for instance to signal the transition from "started" to "running"
-				recorder.Event(object, corev1.EventTypeNormal, afterCondition.Reason, afterCondition.Message)
+				emitEvent(ctx, recorder, object, corev1.EventTypeNormal, afterCondition.Reason, afterCondition.Message)
 			}
 		}
 	}

--- a/pkg/reconciler/events/k8sevent/event.go
+++ b/pkg/reconciler/events/k8sevent/event.go
@@ -42,11 +42,11 @@ const (
 	EventReasonError = "Error"
 )
 
-// traceAnnotations extracts the trace context from ctx using the globally
-// configured OpenTelemetry propagator and returns it as event annotations.
-// Using the configured propagator (rather than formatting traceparent by hand)
-// keeps this consistent with the rest of Tekton's tracing setup and preserves
-// additional fields such as tracestate when the propagator emits them.
+// traceAnnotations extracts W3C trace context from ctx using the globally
+// configured OpenTelemetry propagator and returns only the traceparent and
+// tracestate keys as event annotations. Other propagator fields such as
+// baggage are intentionally omitted so Kubernetes Events stay limited to
+// trace correlation metadata.
 // It returns nil when no trace context is present, so callers fall back to
 // un-annotated events.
 func traceAnnotations(ctx context.Context) map[string]string {
@@ -55,10 +55,16 @@ func traceAnnotations(ctx context.Context) map[string]string {
 	}
 	carrier := propagation.MapCarrier{}
 	otel.GetTextMapPropagator().Inject(ctx, carrier)
-	if len(carrier) == 0 {
+	out := make(map[string]string, 2)
+	for _, key := range []string{"traceparent", "tracestate"} {
+		if v, ok := carrier[key]; ok && v != "" {
+			out[key] = v
+		}
+	}
+	if len(out) == 0 {
 		return nil
 	}
-	return carrier
+	return out
 }
 
 // emitEvent emits a Kubernetes event, attaching trace context annotations when

--- a/pkg/reconciler/events/k8sevent/event_internal_test.go
+++ b/pkg/reconciler/events/k8sevent/event_internal_test.go
@@ -29,7 +29,9 @@ import (
 // context from the context using the globally configured propagator, and
 // returns nil when no valid span context is present.
 func TestTraceAnnotations(t *testing.T) {
+	prev := otel.GetTextMapPropagator()
 	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(prev) })
 
 	t.Run("no span context", func(t *testing.T) {
 		if got := traceAnnotations(context.Background()); got != nil {

--- a/pkg/reconciler/events/k8sevent/event_internal_test.go
+++ b/pkg/reconciler/events/k8sevent/event_internal_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sevent
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TestTraceAnnotations verifies that traceAnnotations extracts a W3C trace
+// context from the context using the globally configured propagator, and
+// returns nil when no valid span context is present.
+func TestTraceAnnotations(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	t.Run("no span context", func(t *testing.T) {
+		if got := traceAnnotations(context.Background()); got != nil {
+			t.Errorf("expected nil annotations without a span context, got %v", got)
+		}
+	})
+
+	t.Run("with span context", func(t *testing.T) {
+		traceID, err := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+		if err != nil {
+			t.Fatalf("invalid trace id: %v", err)
+		}
+		spanID, err := trace.SpanIDFromHex("00f067aa0ba902b7")
+		if err != nil {
+			t.Fatalf("invalid span id: %v", err)
+		}
+		sc := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+			Remote:     true,
+		})
+		ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+		got := traceAnnotations(ctx)
+		if got == nil {
+			t.Fatal("expected annotations for a valid span context, got nil")
+		}
+		want := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+		if got["traceparent"] != want {
+			t.Errorf("traceparent = %q, want %q", got["traceparent"], want)
+		}
+	})
+}

--- a/pkg/reconciler/events/k8sevent/event_internal_test.go
+++ b/pkg/reconciler/events/k8sevent/event_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -65,4 +66,55 @@ func TestTraceAnnotations(t *testing.T) {
 			t.Errorf("traceparent = %q, want %q", got["traceparent"], want)
 		}
 	})
+}
+
+func TestTraceAnnotationsOmitsBaggage(t *testing.T) {
+	prev := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	t.Cleanup(func() { otel.SetTextMapPropagator(prev) })
+
+	traceID, err := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	if err != nil {
+		t.Fatalf("invalid trace id: %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("00f067aa0ba902b7")
+	if err != nil {
+		t.Fatalf("invalid span id: %v", err)
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	member, err := baggage.NewMember("userId", "alice")
+	if err != nil {
+		t.Fatalf("baggage member: %v", err)
+	}
+	bag, err := baggage.New(member)
+	if err != nil {
+		t.Fatalf("baggage: %v", err)
+	}
+	ctx = baggage.ContextWithBaggage(ctx, bag)
+
+	got := traceAnnotations(ctx)
+	if got == nil {
+		t.Fatal("expected annotations for a valid span context, got nil")
+	}
+	if _, ok := got["baggage"]; ok {
+		t.Fatalf("baggage must not be copied onto events, got %v", got)
+	}
+	if got["traceparent"] == "" {
+		t.Fatalf("expected traceparent, got %v", got)
+	}
+	for k := range got {
+		if k != "traceparent" && k != "tracestate" {
+			t.Fatalf("unexpected annotation key %q in %v", k, got)
+		}
+	}
 }

--- a/pkg/reconciler/events/k8sevent/event_test.go
+++ b/pkg/reconciler/events/k8sevent/event_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package k8sevent_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -261,7 +260,7 @@ func TestEmitError(t *testing.T) {
 	for _, ts := range testcases {
 		fr := record.NewFakeRecorder(1)
 		tr := &corev1.Pod{}
-		k8sevents.EmitError(context.Background(), fr, ts.err, tr)
+		k8sevents.EmitError(fr, ts.err, tr)
 		err := k8sevents.CheckEventsOrdered(t, fr.Events, ts.name, ts.wantEvents)
 		if err != nil {
 			t.Error(err.Error())

--- a/pkg/reconciler/events/k8sevent/event_test.go
+++ b/pkg/reconciler/events/k8sevent/event_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package k8sevent_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -260,7 +261,7 @@ func TestEmitError(t *testing.T) {
 	for _, ts := range testcases {
 		fr := record.NewFakeRecorder(1)
 		tr := &corev1.Pod{}
-		k8sevents.EmitError(fr, ts.err, tr)
+		k8sevents.EmitError(context.Background(), fr, ts.err, tr)
 		err := k8sevents.CheckEventsOrdered(t, fr.Events, ts.name, ts.wantEvents)
 		if err != nil {
 			t.Error(err.Error())

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -372,7 +372,7 @@ func (c *Reconciler) finishReconcileUpdateEmitEvents(ctx context.Context, pr *v1
 		_, err := c.updateLabelsAndAnnotations(ctx, pr)
 		if err != nil {
 			logger.Warn("Failed to update PipelineRun labels/annotations", zap.Error(err))
-			events.EmitError(ctx, controller.GetEventRecorder(ctx), err, pr)
+			events.EmitErrorWithContext(ctx, controller.GetEventRecorder(ctx), err, pr)
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -372,7 +372,7 @@ func (c *Reconciler) finishReconcileUpdateEmitEvents(ctx context.Context, pr *v1
 		_, err := c.updateLabelsAndAnnotations(ctx, pr)
 		if err != nil {
 			logger.Warn("Failed to update PipelineRun labels/annotations", zap.Error(err))
-			events.EmitError(controller.GetEventRecorder(ctx), err, pr)
+			events.EmitError(ctx, controller.GetEventRecorder(ctx), err, pr)
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -210,7 +210,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) (rec
 	defer func() {
 		if err := c.syncMetadata(ctx, pr); err != nil {
 			logger.Warn("Failed to sync PipelineRun metadata", zap.Error(err))
-			events.EmitError(controller.GetEventRecorder(ctx), err, pr)
+			events.EmitErrorWithContext(ctx, controller.GetEventRecorder(ctx), err, pr)
 			reconcileErr = errors.Join(reconcileErr, err)
 		}
 	}()

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -475,7 +475,7 @@ func (c *Reconciler) finishReconcileUpdateEmitEvents(ctx context.Context, tr *v1
 		_, err := c.updateLabelsAndAnnotations(ctx, tr)
 		if err != nil {
 			logger.Warn("Failed to update TaskRun labels/annotations", zap.Error(err))
-			events.EmitError(controller.GetEventRecorder(ctx), err, tr)
+			events.EmitError(ctx, controller.GetEventRecorder(ctx), err, tr)
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -475,7 +475,7 @@ func (c *Reconciler) finishReconcileUpdateEmitEvents(ctx context.Context, tr *v1
 		_, err := c.updateLabelsAndAnnotations(ctx, tr)
 		if err != nil {
 			logger.Warn("Failed to update TaskRun labels/annotations", zap.Error(err))
-			events.EmitError(ctx, controller.GetEventRecorder(ctx), err, tr)
+			events.EmitErrorWithContext(ctx, controller.GetEventRecorder(ctx), err, tr)
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -164,7 +164,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) (reconci
 	defer func() {
 		if err := c.syncMetadata(ctx, tr); err != nil {
 			logger.Warn("Failed to sync TaskRun metadata", zap.Error(err))
-			events.EmitError(controller.GetEventRecorder(ctx), err, tr)
+			events.EmitErrorWithContext(ctx, controller.GetEventRecorder(ctx), err, tr)
 			reconcileErr = errors.Join(reconcileErr, err)
 		}
 	}()


### PR DESCRIPTION
## Changes

Inject W3C Trace Context (`traceparent`) into Kubernetes events emitted by the TaskRun and PipelineRun reconcilers via `AnnotatedEventf`.

### What it does
When a valid trace span exists in the reconciler context, K8s events now carry a `traceparent` annotation:
```
traceparent: 00-<trace-id>-<span-id>-<flags>
```

This enables one-click navigation from K8s events to the corresponding trace in observability backends (Jaeger, Tempo, etc).

### Implementation
- `traceAnnotations(ctx)` — extracts traceparent from context span
- `emitEvent()` — wrapper that uses `AnnotatedEventf` when trace context is available, falls back to `Event()` otherwise
- All event emissions in `EmitK8sEvents` now go through the wrapper

### Backwards compatible
When no tracing is configured, events are emitted exactly as before (no annotations added).

Fixes #9784
Part of #9701

/kind feature

```release-note
Kubernetes events emitted by the TaskRun and PipelineRun reconcilers now carry W3C trace context annotations, allowing them to be correlated with distributed traces.
```