### PR TITLE
docs: document StepAction support in Hub Resolver

### DIFF
--- a/docs/hub-resolver.md
+++ b/docs/hub-resolver.md
@@ -13,9 +13,9 @@ Use resolver type `hub`.
 
 | Param Name       | Description                                                                   | Example Value                                              |
 |------------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
-| `catalog`        | The catalog from where to pull the resource (Optional)                        | Default:  `tekton-catalog-tasks` (for `task` kind);  `tekton-catalog-pipelines` (for `pipeline` kind)                                        |
+| `catalog`        | The catalog from where to pull the resource (Optional)                        | Default:  `tekton-catalog-tasks` (for `task` kind);  `tekton-catalog-pipelines` (for `pipeline` kind); no default for `stepaction` kind, so `catalog` must be set explicitly |
 | `type`           | The type of Hub from where to pull the resource (Optional). Either `artifact` or `tekton` | Default:  `artifact` (recommended). Note: `tekton` type is deprecated.                                         |
-| `kind`           | Either `task` or `pipeline` (Optional)                                        | Default: `task`                                                     |
+| `kind`           | `task`, `pipeline` or `stepaction` (Optional)                                        | Default: `task`                                                     |
 | `name`           | The name of the task or pipeline to fetch from the hub                        | `golang-build`                                             |
 | `version`        | Version or a Constraint (see [below](#version-constraint) of a task or a pipeline to pull in from. Wrap the number in quotes!   | `"0.5.0"`, `">= 0.5.0"`                                                    |
 | `url`            | Custom hub API endpoint to query instead of the cluster-configured default (Optional). Must be an absolute HTTP or HTTPS URL. Overrides all other URL configuration (ConfigMap URL lists, environment variables, and defaults). | `https://internal-hub.example.com`                        |
@@ -129,6 +129,33 @@ spec:
   # Note: the buildpacks pipeline requires parameters.
   # Resolution of the pipeline will succeed but the PipelineRun
   # overall will not succeed without those parameters.
+```
+
+### StepAction Resolution
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: hub-stepaction-demo
+spec:
+  taskSpec:
+    steps:
+    - name: git-clone
+      ref:
+        resolver: hub
+        params:
+        - name: catalog
+          value: git-clone-stepaction
+        - name: type # optional
+          value: artifact
+        - name: kind
+          value: stepaction
+        - name: name
+          value: git-clone
+        - name: version
+          value: "1.6.0"
+  # Note: Artifact Hub StepAction packages use the tekton-stepaction package type
 ```
 
 ### Task Resolution from a Private Hub


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update docs/hub-resolver.md to:
- list `stepaction` as a supported `kind` value
- note that Artifact Hub StepAction packages use the `tekton-stepaction` package type
- add a StepAction resolution example, matching the existing Task and Pipeline examples

Also note that, unlike `task`/`pipeline`, `stepaction` has no default catalog in resolveCatalogName, so `catalog` must be set explicitly.

Resolves #10202

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
update `hub-resolver.md`: add documentation for StepAction

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
