### PR TITLE
chore: move patch release cron from Thursday to Tuesday

### DIFF
--- a/.github/workflows/patch-release.yaml
+++ b/.github/workflows/patch-release.yaml
@@ -17,8 +17,8 @@ name: Patch Release
         type: boolean
         default: true
   schedule:
-    # Weekly on Thursday at 10:00 UTC
-    - cron: "0 10 * * 4"
+    # Weekly on Tuesday at 10:00 UTC
+    - cron: "0 10 * * 2"
 
 permissions: {}
 


### PR DESCRIPTION
# Changes

Move the automated patch release cron from Thursday to Tuesday so that the operator automated release (Thursday) can pick up the latest pipeline patch releases.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. `/kind cleanup`
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string \"action required\" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```