### PR TITLE
chore: group Dependabot updates by dependency family

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -39,6 +39,35 @@ ecosystems:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+    groups:
+      kubernetes:
+        patterns:
+          - k8s.io/*
+      opentelemetry:
+        patterns:
+          - go.opentelemetry.io/*
+          - go.opentelemetry.io/contrib/*
+          - knative.dev/pkg
+      golang-x:
+        patterns:
+          - golang.org/x/*
+      grpc-protobuf:
+        patterns:
+          - google.golang.org/grpc
+          - google.golang.org/protobuf
+          - google.golang.org/genproto*
+      container-registry:
+        patterns:
+          - github.com/google/go-containerregistry*
+      scm:
+        patterns:
+          - github.com/jenkins-x/go-scm
+          - code.gitea.io/sdk/gitea
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: gomod
     directory: /tools
     schedule:
@@ -53,6 +82,35 @@ ecosystems:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+    groups:
+      kubernetes:
+        patterns:
+          - k8s.io/*
+      opentelemetry:
+        patterns:
+          - go.opentelemetry.io/*
+          - go.opentelemetry.io/contrib/*
+          - knative.dev/pkg
+      golang-x:
+        patterns:
+          - golang.org/x/*
+      grpc-protobuf:
+        patterns:
+          - google.golang.org/grpc
+          - google.golang.org/protobuf
+          - google.golang.org/genproto*
+      container-registry:
+        patterns:
+          - github.com/google/go-containerregistry*
+      scm:
+        patterns:
+          - github.com/jenkins-x/go-scm
+          - code.gitea.io/sdk/gitea
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: gomod
     directory: /test/custom-task-ctrls/wait-task-beta
     schedule:
@@ -67,6 +125,35 @@ ecosystems:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+    groups:
+      kubernetes:
+        patterns:
+          - k8s.io/*
+      opentelemetry:
+        patterns:
+          - go.opentelemetry.io/*
+          - go.opentelemetry.io/contrib/*
+          - knative.dev/pkg
+      golang-x:
+        patterns:
+          - golang.org/x/*
+      grpc-protobuf:
+        patterns:
+          - google.golang.org/grpc
+          - google.golang.org/protobuf
+          - google.golang.org/genproto*
+      container-registry:
+        patterns:
+          - github.com/google/go-containerregistry*
+      scm:
+        patterns:
+          - github.com/jenkins-x/go-scm
+          - code.gitea.io/sdk/gitea
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -76,6 +163,8 @@ ecosystems:
       - dependencies
       - release-note-none
       - kind/misc
+    cooldown:
+      default-days: 7
   - package-ecosystem: docker
     directory: /tekton
     schedule:
@@ -89,6 +178,8 @@ ecosystems:
       all:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: docker
     directory: /
     schedule:
@@ -102,3 +193,5 @@ ecosystems:
       all:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -48,21 +48,6 @@ ecosystems:
           - go.opentelemetry.io/*
           - go.opentelemetry.io/contrib/*
           - knative.dev/pkg
-      golang-x:
-        patterns:
-          - golang.org/x/*
-      grpc-protobuf:
-        patterns:
-          - google.golang.org/grpc
-          - google.golang.org/protobuf
-          - google.golang.org/genproto*
-      container-registry:
-        patterns:
-          - github.com/google/go-containerregistry*
-      scm:
-        patterns:
-          - github.com/jenkins-x/go-scm
-          - code.gitea.io/sdk/gitea
     cooldown:
       default-days: 7
       semver-major-days: 30
@@ -91,21 +76,6 @@ ecosystems:
           - go.opentelemetry.io/*
           - go.opentelemetry.io/contrib/*
           - knative.dev/pkg
-      golang-x:
-        patterns:
-          - golang.org/x/*
-      grpc-protobuf:
-        patterns:
-          - google.golang.org/grpc
-          - google.golang.org/protobuf
-          - google.golang.org/genproto*
-      container-registry:
-        patterns:
-          - github.com/google/go-containerregistry*
-      scm:
-        patterns:
-          - github.com/jenkins-x/go-scm
-          - code.gitea.io/sdk/gitea
     cooldown:
       default-days: 7
       semver-major-days: 30
@@ -134,21 +104,6 @@ ecosystems:
           - go.opentelemetry.io/*
           - go.opentelemetry.io/contrib/*
           - knative.dev/pkg
-      golang-x:
-        patterns:
-          - golang.org/x/*
-      grpc-protobuf:
-        patterns:
-          - google.golang.org/grpc
-          - google.golang.org/protobuf
-          - google.golang.org/genproto*
-      container-registry:
-        patterns:
-          - github.com/google/go-containerregistry*
-      scm:
-        patterns:
-          - github.com/jenkins-x/go-scm
-          - code.gitea.io/sdk/gitea
     cooldown:
       default-days: 7
       semver-major-days: 30

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /tools
       schedule:
@@ -35,6 +64,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /test/custom-task-ctrls/wait-task-beta
       schedule:
@@ -49,6 +107,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: github-actions
       directory: /
       schedule:
@@ -58,6 +145,8 @@ updates:
         - dependencies
         - release-note-none
         - kind/misc
+      cooldown:
+        default-days: 7
     - package-ecosystem: docker
       directory: /tekton
       schedule:
@@ -71,6 +160,8 @@ updates:
         all:
             patterns:
                 - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: docker
       directory: /
       schedule:
@@ -84,6 +175,8 @@ updates:
         all:
             patterns:
                 - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v1.12.x
@@ -103,6 +196,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /tools
       target-branch: release-v1.12.x
@@ -122,6 +244,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /test/custom-task-ctrls/wait-task-beta
       target-branch: release-v1.12.x
@@ -141,6 +292,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: github-actions
       directory: /
       target-branch: release-v1.12.x
@@ -156,6 +336,8 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      cooldown:
+        default-days: 7
     - package-ecosystem: docker
       directory: /tekton
       target-branch: release-v1.12.x
@@ -175,6 +357,8 @@ updates:
         all:
             patterns:
                 - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: docker
       directory: /
       target-branch: release-v1.12.x
@@ -194,6 +378,8 @@ updates:
         all:
             patterns:
                 - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v1.9.x
@@ -213,6 +399,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /tools
       target-branch: release-v1.9.x
@@ -232,6 +447,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /test/custom-task-ctrls/wait-task-beta
       target-branch: release-v1.9.x
@@ -251,6 +495,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: github-actions
       directory: /
       target-branch: release-v1.9.x
@@ -266,6 +539,8 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      cooldown:
+        default-days: 7
     - package-ecosystem: docker
       directory: /tekton
       target-branch: release-v1.9.x
@@ -285,6 +560,8 @@ updates:
         all:
             patterns:
                 - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: docker
       directory: /
       target-branch: release-v1.9.x
@@ -304,6 +581,8 @@ updates:
         all:
             patterns:
                 - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v1.6.x
@@ -323,6 +602,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /tools
       target-branch: release-v1.6.x
@@ -342,6 +650,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /test/custom-task-ctrls/wait-task-beta
       target-branch: release-v1.6.x
@@ -361,6 +698,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: github-actions
       directory: /
       target-branch: release-v1.6.x
@@ -376,6 +742,8 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      cooldown:
+        default-days: 7
     - package-ecosystem: docker
       directory: /tekton
       target-branch: release-v1.6.x
@@ -395,6 +763,8 @@ updates:
         all:
             patterns:
                 - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: docker
       directory: /
       target-branch: release-v1.6.x
@@ -414,6 +784,8 @@ updates:
         all:
             patterns:
                 - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v1.3.x
@@ -433,6 +805,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /tools
       target-branch: release-v1.3.x
@@ -452,6 +853,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /test/custom-task-ctrls/wait-task-beta
       target-branch: release-v1.3.x
@@ -471,6 +901,35 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        container-registry:
+            patterns:
+                - github.com/google/go-containerregistry*
+        golang-x:
+            patterns:
+                - golang.org/x/*
+        grpc-protobuf:
+            patterns:
+                - google.golang.org/grpc
+                - google.golang.org/protobuf
+                - google.golang.org/genproto*
+        kubernetes:
+            patterns:
+                - k8s.io/*
+        opentelemetry:
+            patterns:
+                - go.opentelemetry.io/*
+                - go.opentelemetry.io/contrib/*
+                - knative.dev/pkg
+        scm:
+            patterns:
+                - github.com/jenkins-x/go-scm
+                - code.gitea.io/sdk/gitea
+      cooldown:
+        default-days: 7
+        semver-major-days: 30
+        semver-minor-days: 7
+        semver-patch-days: 3
     - package-ecosystem: github-actions
       directory: /
       target-branch: release-v1.3.x
@@ -486,6 +945,8 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      cooldown:
+        default-days: 7
     - package-ecosystem: docker
       directory: /tekton
       target-branch: release-v1.3.x
@@ -505,6 +966,8 @@ updates:
         all:
             patterns:
                 - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: docker
       directory: /
       target-branch: release-v1.3.x
@@ -524,3 +987,5 @@ updates:
         all:
             patterns:
                 - '*'
+      cooldown:
+        default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,17 +22,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -41,10 +30,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -65,17 +50,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -84,10 +58,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -108,17 +78,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -127,10 +86,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -197,17 +152,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -216,10 +160,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -245,17 +185,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -264,10 +193,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -293,17 +218,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -312,10 +226,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -400,17 +310,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -419,10 +318,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -448,17 +343,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -467,10 +351,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -496,17 +376,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -515,10 +384,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -603,17 +468,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -622,10 +476,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -651,17 +501,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -670,10 +509,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -699,17 +534,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -718,10 +542,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -806,17 +626,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -825,10 +634,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -854,17 +659,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -873,10 +667,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30
@@ -902,17 +692,6 @@ updates:
             - version-update:semver-major
             - version-update:semver-minor
       groups:
-        container-registry:
-            patterns:
-                - github.com/google/go-containerregistry*
-        golang-x:
-            patterns:
-                - golang.org/x/*
-        grpc-protobuf:
-            patterns:
-                - google.golang.org/grpc
-                - google.golang.org/protobuf
-                - google.golang.org/genproto*
         kubernetes:
             patterns:
                 - k8s.io/*
@@ -921,10 +700,6 @@ updates:
                 - go.opentelemetry.io/*
                 - go.opentelemetry.io/contrib/*
                 - knative.dev/pkg
-        scm:
-            patterns:
-                - github.com/jenkins-x/go-scm
-                - code.gitea.io/sdk/gitea
       cooldown:
         default-days: 7
         semver-major-days: 30

--- a/hack/generate-dependabot.go
+++ b/hack/generate-dependabot.go
@@ -38,6 +38,7 @@ type Ecosystem struct {
 	Labels           []string                 `yaml:"labels"`
 	Ignore           []map[string]interface{} `yaml:"ignore,omitempty"`
 	Groups           map[string]interface{}   `yaml:"groups,omitempty"`
+	Cooldown         map[string]interface{}   `yaml:"cooldown,omitempty"`
 }
 
 // DependabotConfig represents the generated dependabot.yml structure
@@ -55,6 +56,7 @@ type Update struct {
 	Labels           []string                 `yaml:"labels"`
 	Ignore           []map[string]interface{} `yaml:"ignore,omitempty"`
 	Groups           map[string]interface{}   `yaml:"groups,omitempty"`
+	Cooldown         map[string]interface{}   `yaml:"cooldown,omitempty"`
 }
 
 func main() {
@@ -132,6 +134,7 @@ func generateDependabotConfig(config Config) DependabotConfig {
 			Labels:           ecosystem.Labels,
 			Ignore:           ecosystem.Ignore,
 			Groups:           ecosystem.Groups,
+			Cooldown:         ecosystem.Cooldown,
 		}
 		dependabotConfig.Updates = append(dependabotConfig.Updates, update)
 	}
@@ -160,6 +163,7 @@ func generateDependabotConfig(config Config) DependabotConfig {
 				Labels:           ecosystem.Labels,
 				Ignore:           ignore,
 				Groups:           ecosystem.Groups,
+				Cooldown:         ecosystem.Cooldown,
 			}
 			dependabotConfig.Updates = append(dependabotConfig.Updates, update)
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Groups the two Dependabot Go module families that need to move together:

- `k8s.io/*`
- OpenTelemetry + `knative.dev/pkg`

Adds Dependabot cooldown settings:

- Go modules: 7 day default, 30 day major, 7 day minor, 3 day patch
- Docker/GitHub Actions: 7 day default

Security updates are not delayed by cooldown.

## Why this diff is larger than the source change

The source-of-truth change is in `.github/dependabot.config.yml`; `.github/dependabot.yml` is generated by `./hack/generate-dependabot.sh` and must be committed too.

The generated file repeats each option under every existing Dependabot update entry. This repo currently generates entries for each monitored ecosystem across `main` and active release branches, so one small Go module rule gets repeated across 15 generated Go module entries.

This PR intentionally keeps the existing per-directory/per-branch structure instead of switching to newer cross-directory `directories:` behavior. That keeps the behavioral change narrow: related dependencies are grouped within the update entries Tekton already has.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
  - No user-facing docs needed; this only changes Dependabot automation.
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
  - Regenerated Dependabot config and validated generated YAML shape.
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release
  - No action required.

# Release Notes

```release-note
NONE
```
