### PR TITLE
fix-e2e-flaky-namespace-collision

### DIFF
--- a/test/util.go
+++ b/test/util.go
@@ -36,6 +36,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Mysteriously by k8s libs, or they fail to create `KubeClient`s when using oidc authentication. Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/345
@@ -75,8 +76,7 @@ func setup(ctx context.Context, t *testing.T, fn ...func(context.Context, *testi
 
 	cache.Get(ctx).Clear()
 
-	namespace := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")
-
+	namespace := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")	
 	initializeLogsAndMetrics(t)
 
 	// Inline controller logs from SYSTEM_NAMESPACE into the t.Log output.
@@ -149,20 +149,33 @@ func initializeLogsAndMetrics(t *testing.T) {
 	})
 }
 
-func createNamespace(ctx context.Context, t *testing.T, namespace string, kubeClient kubernetes.Interface) {
+func createNamespace(ctx context.Context, t *testing.T, namespace string, kubeClient kubernetes.Interface) string {
 	t.Helper()
 	t.Logf("Create namespace %s to deploy to", namespace)
 	labels := map[string]string{
 		"tekton.dev/test-e2e": "true",
 	}
-	if _, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   namespace,
-			Labels: labels,
-		},
-	}, metav1.CreateOptions{}); err != nil {
+
+	for i := 0; i < 5; i++ {
+		_, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   namespace,
+				Labels: labels,
+			},
+		}, metav1.CreateOptions{})
+
+		if err == nil {
+			return namespace
+		}
+		if errors.IsAlreadyExists(err) {
+			t.Logf("Namespace %s already exists, retrying", namespace)
+			namespace = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")
+			continue
+		}
 		t.Fatalf("Failed to create namespace %s for tests: %s", namespace, err)
 	}
+	t.Fatalf("Failed to create unique namespace after retries")
+	return ""
 }
 
 func getDefaultSA(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface, namespace string) string {

--- a/test/util.go
+++ b/test/util.go
@@ -36,7 +36,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Mysteriously by k8s libs, or they fail to create `KubeClient`s when using oidc authentication. Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/345

--- a/test/util.go
+++ b/test/util.go
@@ -76,7 +76,6 @@ func setup(ctx context.Context, t *testing.T, fn ...func(context.Context, *testi
 	cache.Get(ctx).Clear()
 
 	namespace := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")
-
 	initializeLogsAndMetrics(t)
 
 	// Inline controller logs from SYSTEM_NAMESPACE into the t.Log output.
@@ -84,7 +83,12 @@ func setup(ctx context.Context, t *testing.T, fn ...func(context.Context, *testi
 	t.Cleanup(cancel)
 
 	c := newClients(t, knativetest.Flags.Kubeconfig, knativetest.Flags.Cluster, namespace)
-	createNamespace(ctx, t, namespace, c.KubeClient)
+	// clients will be recreated according to namespace
+	finalNamespace := createNamespace(ctx, t, namespace, c.KubeClient)
+	if finalNamespace != namespace {
+		namespace = finalNamespace
+		c = newClients(t, knativetest.Flags.Kubeconfig, knativetest.Flags.Cluster, namespace)
+	}
 	verifyServiceAccountExistence(ctx, t, namespace, c.KubeClient)
 
 	for _, f := range fn {
@@ -149,20 +153,33 @@ func initializeLogsAndMetrics(t *testing.T) {
 	})
 }
 
-func createNamespace(ctx context.Context, t *testing.T, namespace string, kubeClient kubernetes.Interface) {
+func createNamespace(ctx context.Context, t *testing.T, namespace string, kubeClient kubernetes.Interface) string {
 	t.Helper()
 	t.Logf("Create namespace %s to deploy to", namespace)
 	labels := map[string]string{
 		"tekton.dev/test-e2e": "true",
 	}
-	if _, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   namespace,
-			Labels: labels,
-		},
-	}, metav1.CreateOptions{}); err != nil {
+
+	for range 5 {
+		_, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   namespace,
+				Labels: labels,
+			},
+		}, metav1.CreateOptions{})
+
+		if err == nil {
+			return namespace
+		}
+		if errors.IsAlreadyExists(err) {
+			t.Logf("Namespace %s already exists, retrying", namespace)
+			namespace = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")
+			continue
+		}
 		t.Fatalf("Failed to create namespace %s for tests: %s", namespace, err)
 	}
+	t.Fatalf("Failed to create unique namespace after retries")
+	return ""
 }
 
 func getDefaultSA(ctx context.Context, t *testing.T, kubeClient kubernetes.Interface, namespace string) string {


### PR DESCRIPTION
# Changes

Regenerate client namespaces and allow retries to circumvent namespace collision events.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix flaky E2E tests due to namespace name collisions..
```
Addresses #10141
/kind flake
/area testing


