### PR TITLE
fix: extract correct full Rekor EntryID from API response

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -397,7 +397,7 @@ spec:
                   if [ -n "${TRANSPARENCY}" ]; then
                     # URL format: https://rekor.sigstore.dev/api/v1/log/entries?logIndex=NNNN
                     # Fetch the full entry UUID from the Rekor API (logIndex alone is not the UUID)
-                    REKOR_UUID=$(wget -qO- "${TRANSPARENCY}" | sed -n 's/.*"\([0-9a-f]\{64,\}\)".*/\1/p' | head -1)
+                    REKOR_UUID=$(wget -qO- "${TRANSPARENCY}" | jq -r 'keys[0]')
                     if [ -z "${REKOR_UUID}" ]; then
                       echo "WARNING: Could not fetch Rekor UUID from: ${TRANSPARENCY}"
                       # Fall back to logIndex


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `sed` regex used to extract the Rekor UUID from the API response in the `wait-for-chains` step was matching the **wrong hex string**.

The Rekor API returns a single-line JSON response containing many 64+ char hex strings (EntryID key, logID, inclusion proof hashes, rootHash, etc.). The greedy `.*` in the `sed` pattern caused it to match the **last** quoted hex string on the line instead of the **first** one (the EntryID key).

A full Rekor EntryID is **80 hex chars** (TreeID 16 + UUID 64). The published UUIDs were only 64 chars — they were inclusion proof hashes, not the actual EntryID.

Fix by using `grep -oE` to extract the first quoted 64+ char hex match, which is always the JSON object key (the full EntryID).

Bug was introduced in b7efd599e6dd (June 5, 2026). Affected releases: v1.13.1, v1.12.1, v1.10.3, v1.9.4, v1.6.3, v1.3.5, v1.2.1.

Fixes #10314

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string \"action required\" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix Rekor EntryID extraction in release pipeline to publish correct 80-char EntryIDs instead of truncated 64-char hashes.
```

/kind bug