### PR TITLE
fix(taskrun): prevent concurrent map writes when resolving StepAction refs

### DIFF
--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -414,7 +415,12 @@ func replacementsFromDefaultParams(defaults v1.ParamSpecs) (map[string]string, m
 				}
 			case v1.ParamTypeObject:
 				for _, pattern := range paramPatterns {
-					objectReplacements[fmt.Sprintf(pattern, p.Name)] = p.Default.ObjectVal
+					// Clone, never alias: callers (extendObjectReplacements, getTaskParameters)
+					// merge TaskRun values into these object replacements. Handing out the param's
+					// shared ObjectVal let that merge mutate the default in place; with concurrent
+					// StepAction ref resolution that shared-map write crashed the controller with
+					// "fatal error: concurrent map writes".
+					objectReplacements[fmt.Sprintf(pattern, p.Name)] = maps.Clone(p.Default.ObjectVal)
 				}
 				for k, v := range p.Default.ObjectVal {
 					stringReplacements[fmt.Sprintf(objectIndividualVariablePattern, p.Name, k)] = v
@@ -475,7 +481,9 @@ func replacementsFromParams(params v1.Params) (map[string]string, map[string][]s
 			}
 		case v1.ParamTypeObject:
 			for _, pattern := range paramPatterns {
-				objectReplacements[fmt.Sprintf(pattern, p.Name)] = p.Value.ObjectVal
+				// Clone for the same reason as replacementsFromDefaultParams: never hand out an
+				// alias of the param's shared ObjectVal, so downstream merges stay private.
+				objectReplacements[fmt.Sprintf(pattern, p.Name)] = maps.Clone(p.Value.ObjectVal)
 			}
 			for k, v := range p.Value.ObjectVal {
 				stringReplacements[fmt.Sprintf(objectIndividualVariablePattern, p.Name, k)] = v

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -775,6 +775,46 @@ func TestApplyArrayParameters(t *testing.T) {
 	}
 }
 
+// TestApplyParametersDoesNotMutateObjectParamDefault is a deterministic regression test for
+// the same shared-map aliasing fixed in extendObjectReplacements, on the ApplyParameters
+// path: getTaskParameters merged the TaskRun object value into the param's shared default
+// map in place. This path is not concurrent (so it never panicked), but it still corrupted
+// the Task's object-param default; substitution must leave the default untouched.
+func TestApplyParametersDoesNotMutateObjectParamDefault(t *testing.T) {
+	spec := &v1.TaskSpec{
+		Params: v1.ParamSpecs{{
+			Name:       "obj",
+			Type:       v1.ParamTypeObject,
+			Properties: map[string]v1.PropertySpec{"key": {Type: v1.ParamTypeString}},
+			Default:    v1.NewObject(map[string]string{"key": "from-default"}),
+		}},
+		Steps: []v1.Step{{
+			Name:  "s",
+			Image: "img",
+			Args:  []string{"$(params.obj.key)"},
+		}},
+	}
+	tr := &v1.TaskRun{
+		Spec: v1.TaskRunSpec{
+			Params: v1.Params{{
+				Name:  "obj",
+				Value: *v1.NewObject(map[string]string{"key": "from-taskrun"}),
+			}},
+		},
+	}
+
+	applied := resources.ApplyParameters(spec, tr, spec.Params...)
+
+	// The TaskRun value is applied to the step args in the returned spec...
+	if got := applied.Steps[0].Args[0]; got != "from-taskrun" {
+		t.Errorf("step arg = %q, want %q", got, "from-taskrun")
+	}
+	// ...but the object-param default on the input spec must not be mutated in place.
+	if got := spec.Params[0].Default.ObjectVal["key"]; got != "from-default" {
+		t.Errorf("object param default was mutated: key = %q, want %q", got, "from-default")
+	}
+}
+
 func TestApplyParameters(t *testing.T) {
 	tr := &v1.TaskRun{
 		Spec: v1.TaskRunSpec{

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -570,6 +571,119 @@ func TestStepActionResolverParamReplacements(t *testing.T) {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})
+	}
+}
+
+// TestApplyParameterSubstitutionInResolverParamsConcurrent is a regression test for a
+// data race. GetStepActionsData resolves StepAction refs concurrently (one goroutine per
+// step), and every goroutine calls ApplyParameterSubstitutionInResolverParams on the same
+// TaskRun/TaskSpec. extendObjectReplacements used to alias and then write into the param's
+// shared ObjectVal map, so concurrent resolution crashed the controller with
+// "fatal error: concurrent map writes". This must stay race-free; run under -race to guard.
+func TestApplyParameterSubstitutionInResolverParamsConcurrent(t *testing.T) {
+	const numSteps = 16
+	steps := make([]v1.Step, numSteps)
+	for i := range steps {
+		steps[i] = v1.Step{
+			Ref: &v1.Ref{
+				ResolverRef: v1.ResolverRef{
+					Resolver: "git",
+					Params: []v1.Param{{
+						Name:  "pathInRepo",
+						Value: *v1.NewStructuredValues("$(params.obj.path)"),
+					}},
+				},
+			},
+		}
+	}
+	// Object param that has BOTH a default and a TaskRun-provided value: that is what
+	// drives extendObjectReplacements into the (previously shared-map mutating) write path.
+	taskSpec := v1.TaskSpec{
+		Params: v1.ParamSpecs{{
+			Name:       "obj",
+			Type:       v1.ParamTypeObject,
+			Properties: map[string]v1.PropertySpec{"path": {Type: v1.ParamTypeString}},
+			Default: &v1.ParamValue{
+				Type:      v1.ParamTypeObject,
+				ObjectVal: map[string]string{"path": "from-default"},
+			},
+		}},
+		Steps: steps,
+	}
+	tr := &v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "some-tr"},
+		Spec: v1.TaskRunSpec{
+			Params: v1.Params{{
+				Name:  "obj",
+				Value: *v1.NewObject(map[string]string{"path": "from-taskrun"}),
+			}},
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := range taskSpec.Steps {
+		wg.Add(1)
+		go func(step *v1.Step) {
+			defer wg.Done()
+			resources.ApplyParameterSubstitutionInResolverParams(tr, taskSpec, step)
+		}(&taskSpec.Steps[i])
+	}
+	wg.Wait()
+
+	// Each step's resolver param must resolve to the TaskRun-provided value.
+	for i := range taskSpec.Steps {
+		if got := taskSpec.Steps[i].Ref.Params[0].Value.StringVal; got != "from-taskrun" {
+			t.Errorf("step %d resolver param = %q, want %q", i, got, "from-taskrun")
+		}
+	}
+}
+
+// TestApplyParameterSubstitutionInResolverParamsDoesNotMutateDefault is a deterministic
+// (non -race) regression test: substituting resolver params must not mutate the TaskSpec's
+// object-param default in place. Before the fix, merging the TaskRun value aliased and then
+// wrote into the shared Default.ObjectVal map, corrupting the Task's default.
+func TestApplyParameterSubstitutionInResolverParamsDoesNotMutateDefault(t *testing.T) {
+	taskSpec := v1.TaskSpec{
+		Params: v1.ParamSpecs{{
+			Name:       "obj",
+			Type:       v1.ParamTypeObject,
+			Properties: map[string]v1.PropertySpec{"path": {Type: v1.ParamTypeString}},
+			Default: &v1.ParamValue{
+				Type:      v1.ParamTypeObject,
+				ObjectVal: map[string]string{"path": "from-default"},
+			},
+		}},
+		Steps: []v1.Step{{
+			Ref: &v1.Ref{
+				ResolverRef: v1.ResolverRef{
+					Resolver: "git",
+					Params: []v1.Param{{
+						Name:  "pathInRepo",
+						Value: *v1.NewStructuredValues("$(params.obj.path)"),
+					}},
+				},
+			},
+		}},
+	}
+	tr := &v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "some-tr"},
+		Spec: v1.TaskRunSpec{
+			Params: v1.Params{{
+				Name:  "obj",
+				Value: *v1.NewObject(map[string]string{"path": "from-taskrun"}),
+			}},
+		},
+	}
+
+	resources.ApplyParameterSubstitutionInResolverParams(tr, taskSpec, &taskSpec.Steps[0])
+
+	// The resolver param resolves to the TaskRun-provided value...
+	if got := taskSpec.Steps[0].Ref.Params[0].Value.StringVal; got != "from-taskrun" {
+		t.Errorf("resolver param = %q, want %q", got, "from-taskrun")
+	}
+	// ...but the Task's object-param default must be left untouched.
+	if got := taskSpec.Params[0].Default.ObjectVal["path"]; got != "from-default" {
+		t.Errorf("taskSpec param default was mutated: path = %q, want %q", got, "from-default")
 	}
 }
 

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -2291,3 +2291,59 @@ func TestGetStepActionsData_InvalidStepResultReference(t *testing.T) {
 		t.Errorf("Expected error message %s but got %s", expectedError, err.Error())
 	}
 }
+
+// TestGetStepActionsDataConcurrentObjectParamDefault exercises the real concurrent resolution
+// path end to end. GetStepActionsData resolves the StepAction refs of all steps concurrently
+// (errgroup, default-step-ref-concurrency-limit defaults to 5), and each goroutine runs
+// applyStepActionParameters against the same shared TaskSpec. The object param "cfg" has both a
+// default and a TaskRun value, so resolving a step merged the TaskRun value onto the param's
+// shared default ObjectVal map. Doing that from many goroutines crashed the controller with
+// "fatal error: concurrent map writes". Run under -race to guard the whole real path; the
+// assertion also catches the single-threaded in-place mutation of the Task's default.
+func TestGetStepActionsDataConcurrentObjectParamDefault(t *testing.T) {
+	const numSteps = 16
+	stepAction := &v1beta1.StepAction{
+		ObjectMeta: metav1.ObjectMeta{Name: "echo", Namespace: "default"},
+		Spec: v1beta1.StepActionSpec{
+			Image:  "bash:latest",
+			Params: v1.ParamSpecs{{Name: "msg", Type: v1.ParamTypeString}},
+			Args:   []string{"$(params.msg)"},
+		},
+	}
+	steps := make([]v1.Step, numSteps)
+	for i := range steps {
+		steps[i] = v1.Step{
+			Ref:    &v1.Ref{Name: "echo"},
+			Params: v1.Params{{Name: "msg", Value: *v1.NewStructuredValues("hi")}},
+		}
+	}
+	taskSpec := v1.TaskSpec{
+		Params: v1.ParamSpecs{{
+			Name:       "cfg",
+			Type:       v1.ParamTypeObject,
+			Properties: map[string]v1.PropertySpec{"key": {Type: v1.ParamTypeString}},
+			Default:    &v1.ParamValue{Type: v1.ParamTypeObject, ObjectVal: map[string]string{"key": "from-default"}},
+		}},
+		Steps: steps,
+	}
+	tr := &v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "mytaskrun", Namespace: "default"},
+		Spec: v1.TaskRunSpec{
+			TaskSpec: &taskSpec,
+			Params:   v1.Params{{Name: "cfg", Value: *v1.NewObject(map[string]string{"key": "from-taskrun"})}},
+		},
+	}
+
+	tektonclient := fake.NewSimpleClientset()
+	if err := tektonclient.Tracker().Add(stepAction); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := GetStepActionsData(t.Context(), taskSpec, tr, tektonclient, nil, nil); err != nil {
+		t.Fatalf("GetStepActionsData returned error: %v", err)
+	}
+	// Concurrent resolution must not have mutated the Task's shared object-param default.
+	if got := taskSpec.Params[0].Default.ObjectVal["key"]; got != "from-default" {
+		t.Errorf("object param default mutated by concurrent resolution: key = %q, want %q", got, "from-default")
+	}
+}


### PR DESCRIPTION
Fixes #10323

# Changes

StepActions are resolved concurrently in `GetStepActionsData`
(`default-step-ref-concurrency-limit`, default `5`). Each goroutine runs the
parameter-substitution helpers against the same `TaskSpec`. The replacement
builders `replacementsFromDefaultParams` / `replacementsFromParams` returned the
object parameter's shared `ObjectVal` map **by reference**, so when a caller merged
the TaskRun value onto a default it mutated that shared map in place. With
concurrent resolution this crashed the controller with `fatal error: concurrent map
writes`; even single-threaded it corrupted the Task's object-param default.

This clones the object map at the source with `maps.Clone`, so the builders never
hand out an alias and every downstream merge (StepAction resolver params,
`applyStepActionParameters`, `getTaskParameters`) stays private. Affects `v1.4.0+`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed a controller crash ("concurrent map writes") that could occur while resolving multiple StepAction references when the Task uses an object parameter with both a default and a TaskRun-provided value.
```

/kind bug

---

> This PR was developed with assistance from Claude (Opus 4.8). All changes were reviewed, tested, and are owned by me. Per the [AI contribution policy](https://github.com/tektoncd/community/blob/main/ai-contribution-policy.md), the commit also carries an `Assisted-by` trailer.
