### PR TITLE
Add container resource requirements customization for affinity-assistant pods

### DIFF
--- a/config/300-crds/300-pipelinerun.yaml
+++ b/config/300-crds/300-pipelinerun.yaml
@@ -406,6 +406,69 @@ spec:
                         If not specified, the pod priority will be default or zero if there is no
                         default.
                       type: string
+                    resources:
+                      description: |-
+                        Resources are the compute resource requirements for the affinity assistant container.
+                        When specified on a PipelineRun's podTemplate, these resources are applied to the
+                        affinity assistant StatefulSet. If not specified, default values of 50m CPU and
+                        100Mi memory (requests and limits) are used.
+                      type: object
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This field depends on the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          type: array
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                          additionalProperties:
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        requests:
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                          additionalProperties:
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
                     runtimeClassName:
                       description: |-
                         RuntimeClassName refers to a RuntimeClass object in the node.k8s.io
@@ -1258,6 +1321,69 @@ spec:
                               If not specified, the pod priority will be default or zero if there is no
                               default.
                             type: string
+                          resources:
+                            description: |-
+                              Resources are the compute resource requirements for the affinity assistant container.
+                              When specified on a PipelineRun's podTemplate, these resources are applied to the
+                              affinity assistant StatefulSet. If not specified, default values of 50m CPU and
+                              100Mi memory (requests and limits) are used.
+                            type: object
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                type: array
+                                items:
+                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                  type: object
+                                  required:
+                                    - name
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                                additionalProperties:
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              requests:
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                                additionalProperties:
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
                           runtimeClassName:
                             description: |-
                               RuntimeClassName refers to a RuntimeClass object in the node.k8s.io
@@ -3681,6 +3807,69 @@ spec:
                               If not specified, the pod priority will be default or zero if there is no
                               default.
                             type: string
+                          resources:
+                            description: |-
+                              Resources are the compute resource requirements for the affinity assistant container.
+                              When specified on a PipelineRun's podTemplate, these resources are applied to the
+                              affinity assistant StatefulSet. If not specified, default values of 50m CPU and
+                              100Mi memory (requests and limits) are used.
+                            type: object
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                type: array
+                                items:
+                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                  type: object
+                                  required:
+                                    - name
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                                additionalProperties:
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              requests:
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                                additionalProperties:
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
                           runtimeClassName:
                             description: |-
                               RuntimeClassName refers to a RuntimeClass object in the node.k8s.io
@@ -4373,6 +4562,69 @@ spec:
                             If not specified, the pod priority will be default or zero if there is no
                             default.
                           type: string
+                        resources:
+                          description: |-
+                            Resources are the compute resource requirements for the affinity assistant container.
+                            When specified on a PipelineRun's podTemplate, these resources are applied to the
+                            affinity assistant StatefulSet. If not specified, default values of 50m CPU and
+                            100Mi memory (requests and limits) are used.
+                          type: object
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This field depends on the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              type: array
+                              items:
+                                description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                type: object
+                                required:
+                                  - name
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                              additionalProperties:
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            requests:
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                              additionalProperties:
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                         runtimeClassName:
                           description: |-
                             RuntimeClassName refers to a RuntimeClass object in the node.k8s.io

--- a/config/300-crds/300-taskrun.yaml
+++ b/config/300-crds/300-taskrun.yaml
@@ -445,6 +445,69 @@ spec:
                         If not specified, the pod priority will be default or zero if there is no
                         default.
                       type: string
+                    resources:
+                      description: |-
+                        Resources are the compute resource requirements for the affinity assistant container.
+                        When specified on a PipelineRun's podTemplate, these resources are applied to the
+                        affinity assistant StatefulSet. If not specified, default values of 50m CPU and
+                        100Mi memory (requests and limits) are used.
+                      type: object
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This field depends on the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          type: array
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                          additionalProperties:
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        requests:
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                          additionalProperties:
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
                     runtimeClassName:
                       description: |-
                         RuntimeClassName refers to a RuntimeClass object in the node.k8s.io
@@ -2743,6 +2806,69 @@ spec:
                         If not specified, the pod priority will be default or zero if there is no
                         default.
                       type: string
+                    resources:
+                      description: |-
+                        Resources are the compute resource requirements for the affinity assistant container.
+                        When specified on a PipelineRun's podTemplate, these resources are applied to the
+                        affinity assistant StatefulSet. If not specified, default values of 50m CPU and
+                        100Mi memory (requests and limits) are used.
+                      type: object
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This field depends on the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          type: array
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                          additionalProperties:
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        requests:
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                          additionalProperties:
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
                     runtimeClassName:
                       description: |-
                         RuntimeClassName refers to a RuntimeClass object in the node.k8s.io

--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -60,7 +60,17 @@ data:
     # to use for affinity assistant pods. If a pod template is specified on the
     # PipelineRun, the default-affinity-assistant-pod-template is merged with
     # that one.
-    # default-affinity-assistant-pod-template:
+    # The "resources" field allows customization of the affinity assistant
+    # container's compute resources. If not specified, defaults of 50m CPU
+    # and 100Mi memory (requests and limits) are used.
+    # default-affinity-assistant-pod-template: |
+    #   resources:
+    #     requests:
+    #       cpu: "50m"
+    #       memory: "100Mi"
+    #     limits:
+    #       cpu: "100m"
+    #       memory: "200Mi"
 
     # default-cloud-events-sink contains the default CloudEvents sink to be
     # used for TaskRun and PipelineRun, when no sink is specified.

--- a/pkg/apis/config/default.go
+++ b/pkg/apis/config/default.go
@@ -181,6 +181,9 @@ func NewDefaultsFromMap(cfgMap map[string]string) (*Defaults, error) {
 		if err := yamlUnmarshal(defaultAAPodTemplate, defaultAAPodTemplateKey, &podTemplate); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal %v", defaultAAPodTemplate)
 		}
+		if errs := podTemplate.ValidateResources(); len(errs) > 0 {
+			return nil, fmt.Errorf("invalid %s: %v", defaultAAPodTemplateKey, errs)
+		}
 		tc.DefaultAAPodTemplate = &podTemplate
 	}
 

--- a/pkg/apis/config/default.go
+++ b/pkg/apis/config/default.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	corev1 "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 )
@@ -180,6 +181,9 @@ func NewDefaultsFromMap(cfgMap map[string]string) (*Defaults, error) {
 		var podTemplate pod.AffinityAssistantTemplate
 		if err := yamlUnmarshal(defaultAAPodTemplate, defaultAAPodTemplateKey, &podTemplate); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal %v", defaultAAPodTemplate)
+		}
+		if errs := podTemplate.ValidateResources(); len(errs) > 0 {
+			return nil, fmt.Errorf("invalid %s: %w", defaultAAPodTemplateKey, utilerrors.NewAggregate(errs))
 		}
 		tc.DefaultAAPodTemplate = &podTemplate
 	}

--- a/pkg/apis/config/default_test.go
+++ b/pkg/apis/config/default_test.go
@@ -115,6 +115,39 @@ func TestNewDefaultsFromConfigMap(t *testing.T) {
 			},
 		},
 		{
+			expectedError: false,
+			fileName:      "config-defaults-aa-pod-template-with-resources",
+			expectedConfig: &config.Defaults{
+				DefaultTimeoutMinutes:      50,
+				DefaultServiceAccount:      "tekton",
+				DefaultManagedByLabelValue: config.DefaultManagedByLabelValue,
+				DefaultAAPodTemplate: &pod.AffinityAssistantTemplate{
+					NodeSelector: map[string]string{
+						"label": "value2",
+					},
+					Resources: &corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("200m"),
+							corev1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+					},
+				},
+				DefaultMaxMatrixCombinationsCount: 256,
+				DefaultImagePullBackOffTimeout:    0,
+				DefaultMaximumResolutionTimeout:   1 * time.Minute,
+				DefaultSidecarLogPollingInterval:  100 * time.Millisecond,
+				DefaultStepRefConcurrencyLimit:    5,
+			},
+		},
+		{
+			expectedError: true,
+			fileName:      "config-defaults-aa-pod-template-invalid-resources",
+		},
+		{
 			expectedError: true,
 			fileName:      "config-defaults-matrix-err",
 		},

--- a/pkg/apis/config/testdata/config-defaults-aa-pod-template-invalid-resources.yaml
+++ b/pkg/apis/config/testdata/config-defaults-aa-pod-template-invalid-resources.yaml
@@ -1,0 +1,30 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: tekton-pipelines
+data:
+  default-timeout-minutes: "50"
+  default-service-account: "tekton"
+  default-affinity-assistant-pod-template: |
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "100m"
+        memory: "256Mi"

--- a/pkg/apis/config/testdata/config-defaults-aa-pod-template-with-resources.yaml
+++ b/pkg/apis/config/testdata/config-defaults-aa-pod-template-with-resources.yaml
@@ -1,0 +1,32 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: tekton-pipelines
+data:
+  default-timeout-minutes: "50"
+  default-service-account: "tekton"
+  default-affinity-assistant-pod-template: |
+    nodeSelector:
+      label: value2
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "256Mi"
+      limits:
+        cpu: "200m"
+        memory: "512Mi"

--- a/pkg/apis/pipeline/pod/affinity_assitant_template.go
+++ b/pkg/apis/pipeline/pod/affinity_assitant_template.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"fmt"
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
@@ -63,6 +64,29 @@ type AffinityAssistantTemplate struct {
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// Resources are the compute resource requirements for the affinity assistant container.
+	// If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used.
+	// This allows customization in environments with ResourceQuota or LimitRange policies.
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+}
+
+// ValidateResources checks that resource requests do not exceed limits.
+func (tpl *AffinityAssistantTemplate) ValidateResources() []error {
+	if tpl == nil || tpl.Resources == nil {
+		return nil
+	}
+	var errs []error
+	for resourceName, request := range tpl.Resources.Requests {
+		if limit, ok := tpl.Resources.Limits[resourceName]; ok {
+			if request.Cmp(limit) > 0 {
+				errs = append(errs, fmt.Errorf("request %s (%s) must be less than or equal to limit (%s)",
+					resourceName, request.String(), limit.String()))
+			}
+		}
+	}
+	return errs
 }
 
 // Equals checks if this Template is identical to the given Template.

--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -149,6 +149,13 @@ type Template struct {
 	// +optional
 	// +listType=atomic
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+
+	// Resources are the compute resource requirements for the affinity assistant container.
+	// When specified on a PipelineRun's podTemplate, these resources are applied to the
+	// affinity assistant StatefulSet. If not specified, default values of 50m CPU and
+	// 100Mi memory (requests and limits) are used.
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // Equals checks if this Template is identical to the given Template.
@@ -176,6 +183,7 @@ func (tpl *Template) ToAffinityAssistantTemplate() *AffinityAssistantTemplate {
 		ImagePullSecrets:  tpl.ImagePullSecrets,
 		SecurityContext:   tpl.SecurityContext,
 		PriorityClassName: tpl.PriorityClassName,
+		Resources:         tpl.Resources,
 	}
 }
 
@@ -247,6 +255,9 @@ func MergePodTemplateWithDefault(tpl, defaultTpl *PodTemplate) *PodTemplate {
 		if tpl.TopologySpreadConstraints == nil {
 			tpl.TopologySpreadConstraints = defaultTpl.TopologySpreadConstraints
 		}
+		if tpl.Resources == nil {
+			tpl.Resources = defaultTpl.Resources
+		}
 		return tpl
 	}
 }
@@ -283,6 +294,9 @@ func MergeAAPodTemplateWithDefault(tpl, defaultTpl *AAPodTemplate) *AAPodTemplat
 		}
 		if tpl.ServiceAccountName == "" {
 			tpl.ServiceAccountName = defaultTpl.ServiceAccountName
+		}
+		if tpl.Resources == nil {
+			tpl.Resources = defaultTpl.Resources
 		}
 
 		return tpl

--- a/pkg/apis/pipeline/pod/template_test.go
+++ b/pkg/apis/pipeline/pod/template_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestMergeByName(t *testing.T) {
@@ -179,6 +180,27 @@ func TestMergeAAPodTemplateWithDefault(t *testing.T) {
 		expected   *AAPodTemplate
 	}
 
+	specResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+	defaultResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+	}
+
 	testCases := []testCase{
 		{
 			name: "defaultTpl is nil",
@@ -212,6 +234,43 @@ func TestMergeAAPodTemplateWithDefault(t *testing.T) {
 				PriorityClassName: &priority2,
 			},
 		},
+		{
+			name: "resources from spec override default",
+			tpl: &AAPodTemplate{
+				Resources: specResources,
+			},
+			defaultTpl: &AAPodTemplate{
+				Resources: defaultResources,
+			},
+			expected: &AAPodTemplate{
+				Resources: specResources,
+			},
+		},
+		{
+			name: "resources from default when spec is nil",
+			tpl: &AAPodTemplate{
+				NodeSelector: map[string]string{"foo": "bar"},
+			},
+			defaultTpl: &AAPodTemplate{
+				Resources: defaultResources,
+			},
+			expected: &AAPodTemplate{
+				NodeSelector: map[string]string{"foo": "bar"},
+				Resources:    defaultResources,
+			},
+		},
+		{
+			name: "no resources when neither set",
+			tpl: &AAPodTemplate{
+				NodeSelector: map[string]string{"foo": "bar"},
+			},
+			defaultTpl: &AAPodTemplate{
+				NodeSelector: map[string]string{"baz": "qux"},
+			},
+			expected: &AAPodTemplate{
+				NodeSelector: map[string]string{"foo": "bar"},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -219,6 +278,145 @@ func TestMergeAAPodTemplateWithDefault(t *testing.T) {
 			result := MergeAAPodTemplateWithDefault(tc.tpl, tc.defaultTpl)
 			if !reflect.DeepEqual(result, tc.expected) {
 				t.Errorf("mergeAAPodTemplateWithDefault(%v, %v) = %v, want %v", tc.tpl, tc.defaultTpl, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestToAffinityAssistantTemplate_PropagatesResources(t *testing.T) {
+	resources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	tpl := &Template{
+		NodeSelector: map[string]string{"foo": "bar"},
+		Resources:    resources,
+	}
+
+	aaTpl := tpl.ToAffinityAssistantTemplate()
+	if aaTpl.Resources == nil {
+		t.Fatal("expected Resources to be propagated, got nil")
+	}
+	if !reflect.DeepEqual(aaTpl.Resources, resources) {
+		t.Errorf("ToAffinityAssistantTemplate() Resources = %v, want %v", aaTpl.Resources, resources)
+	}
+}
+
+func TestToAffinityAssistantTemplate_NilResources(t *testing.T) {
+	tpl := &Template{
+		NodeSelector: map[string]string{"foo": "bar"},
+	}
+
+	aaTpl := tpl.ToAffinityAssistantTemplate()
+	if aaTpl.Resources != nil {
+		t.Errorf("expected Resources to be nil when not set on Template, got %v", aaTpl.Resources)
+	}
+}
+
+func TestValidateResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		tpl       *AffinityAssistantTemplate
+		expectErr bool
+	}{
+		{
+			name:      "nil template",
+			tpl:       nil,
+			expectErr: false,
+		},
+		{
+			name:      "nil resources",
+			tpl:       &AffinityAssistantTemplate{},
+			expectErr: false,
+		},
+		{
+			name: "valid: requests equal limits",
+			tpl: &AffinityAssistantTemplate{
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid: requests less than limits",
+			tpl: &AffinityAssistantTemplate{
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid: CPU request exceeds limit",
+			tpl: &AffinityAssistantTemplate{
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("500m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("100m"),
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid: memory request exceeds limit",
+			tpl: &AffinityAssistantTemplate{
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "valid: requests only, no limits",
+			tpl: &AffinityAssistantTemplate{
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("100m"),
+					},
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := tt.tpl.ValidateResources()
+			if tt.expectErr && len(errs) == 0 {
+				t.Errorf("expected validation errors but got none")
+			}
+			if !tt.expectErr && len(errs) > 0 {
+				t.Errorf("expected no validation errors but got: %v", errs)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/pod/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/pod/zz_generated.deepcopy.go
@@ -57,6 +57,11 @@ func (in *AffinityAssistantTemplate) DeepCopyInto(out *AffinityAssistantTemplate
 		*out = new(string)
 		**out = **in
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -164,6 +169,11 @@ func (in *Template) DeepCopyInto(out *Template) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -180,11 +180,17 @@ func schema_pkg_apis_pipeline_pod_AffinityAssistantTemplate(ref common.Reference
 							Format:      "",
 						},
 					},
+					"resources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Resources are the compute resource requirements for the affinity assistant container. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used. This allows customization in environments with ResourceQuota or LimitRange policies.",
+							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.Toleration"},
+			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration"},
 	}
 }
 
@@ -402,11 +408,17 @@ func schema_pkg_apis_pipeline_pod_Template(ref common.ReferenceCallback) common.
 							},
 						},
 					},
+					"resources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Resources are the compute resource requirements for the affinity assistant container. When specified on a PipelineRun's podTemplate, these resources are applied to the affinity assistant StatefulSet. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used.",
+							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.HostAlias", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodDNSConfig", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.TopologySpreadConstraint", "k8s.io/api/core/v1.Volume"},
+			"k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.HostAlias", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodDNSConfig", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.TopologySpreadConstraint", "k8s.io/api/core/v1.Volume"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -32,6 +32,10 @@
           "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
           "type": "string"
         },
+        "resources": {
+          "description": "Resources are the compute resource requirements for the affinity assistant container. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used. This allows customization in environments with ResourceQuota or LimitRange policies.",
+          "$ref": "#/definitions/v1.ResourceRequirements"
+        },
         "securityContext": {
           "description": "SecurityContext sets the security context for the pod",
           "$ref": "#/definitions/v1.PodSecurityContext"
@@ -123,6 +127,10 @@
         "priorityClassName": {
           "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
           "type": "string"
+        },
+        "resources": {
+          "description": "Resources are the compute resource requirements for the affinity assistant container. When specified on a PipelineRun's podTemplate, these resources are applied to the affinity assistant StatefulSet. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used.",
+          "$ref": "#/definitions/v1.ResourceRequirements"
         },
         "runtimeClassName": {
           "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod. If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.",

--- a/pkg/apis/pipeline/v1alpha1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1alpha1/openapi_generated.go
@@ -127,11 +127,17 @@ func schema_pkg_apis_pipeline_pod_AffinityAssistantTemplate(ref common.Reference
 							Format:      "",
 						},
 					},
+					"resources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Resources are the compute resource requirements for the affinity assistant container. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used. This allows customization in environments with ResourceQuota or LimitRange policies.",
+							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.Toleration"},
+			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration"},
 	}
 }
 
@@ -349,11 +355,17 @@ func schema_pkg_apis_pipeline_pod_Template(ref common.ReferenceCallback) common.
 							},
 						},
 					},
+					"resources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Resources are the compute resource requirements for the affinity assistant container. When specified on a PipelineRun's podTemplate, these resources are applied to the affinity assistant StatefulSet. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used.",
+							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.HostAlias", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodDNSConfig", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.TopologySpreadConstraint", "k8s.io/api/core/v1.Volume"},
+			"k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.HostAlias", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodDNSConfig", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.TopologySpreadConstraint", "k8s.io/api/core/v1.Volume"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1alpha1/swagger.json
+++ b/pkg/apis/pipeline/v1alpha1/swagger.json
@@ -32,6 +32,10 @@
           "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
           "type": "string"
         },
+        "resources": {
+          "description": "Resources are the compute resource requirements for the affinity assistant container. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used. This allows customization in environments with ResourceQuota or LimitRange policies.",
+          "$ref": "#/definitions/v1.ResourceRequirements"
+        },
         "securityContext": {
           "description": "SecurityContext sets the security context for the pod",
           "$ref": "#/definitions/v1.PodSecurityContext"
@@ -123,6 +127,10 @@
         "priorityClassName": {
           "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
           "type": "string"
+        },
+        "resources": {
+          "description": "Resources are the compute resource requirements for the affinity assistant container. When specified on a PipelineRun's podTemplate, these resources are applied to the affinity assistant StatefulSet. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used.",
+          "$ref": "#/definitions/v1.ResourceRequirements"
         },
         "runtimeClassName": {
           "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod. If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.",

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -205,11 +205,17 @@ func schema_pkg_apis_pipeline_pod_AffinityAssistantTemplate(ref common.Reference
 							Format:      "",
 						},
 					},
+					"resources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Resources are the compute resource requirements for the affinity assistant container. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used. This allows customization in environments with ResourceQuota or LimitRange policies.",
+							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.Toleration"},
+			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration"},
 	}
 }
 
@@ -427,11 +433,17 @@ func schema_pkg_apis_pipeline_pod_Template(ref common.ReferenceCallback) common.
 							},
 						},
 					},
+					"resources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Resources are the compute resource requirements for the affinity assistant container. When specified on a PipelineRun's podTemplate, these resources are applied to the affinity assistant StatefulSet. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used.",
+							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.HostAlias", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodDNSConfig", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.TopologySpreadConstraint", "k8s.io/api/core/v1.Volume"},
+			"k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.HostAlias", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodDNSConfig", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.TopologySpreadConstraint", "k8s.io/api/core/v1.Volume"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -32,6 +32,10 @@
           "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
           "type": "string"
         },
+        "resources": {
+          "description": "Resources are the compute resource requirements for the affinity assistant container. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used. This allows customization in environments with ResourceQuota or LimitRange policies.",
+          "$ref": "#/definitions/v1.ResourceRequirements"
+        },
         "securityContext": {
           "description": "SecurityContext sets the security context for the pod",
           "$ref": "#/definitions/v1.PodSecurityContext"
@@ -123,6 +127,10 @@
         "priorityClassName": {
           "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
           "type": "string"
+        },
+        "resources": {
+          "description": "Resources are the compute resource requirements for the affinity assistant container. When specified on a PipelineRun's podTemplate, these resources are applied to the affinity assistant StatefulSet. If not specified, default values of 50m CPU and 100Mi memory (requests and limits) are used.",
+          "$ref": "#/definitions/v1.ResourceRequirements"
         },
         "runtimeClassName": {
           "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod. If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.",

--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -56,6 +56,8 @@ const (
 
 	// volumeNameMaxLength is the maximum length for a Kubernetes volume name.
 	volumeNameMaxLength = 63
+
+	affinityAssistantContainerName = "affinity-assistant"
 )
 
 var (
@@ -372,24 +374,25 @@ func affinityAssistantStatefulSet(aaBehavior aa.AffinityAssistantBehavior, name 
 		serviceAccountName = pr.Spec.TaskRunTemplate.ServiceAccountName
 	}
 
-	containers := []corev1.Container{{
-		Name:  "affinity-assistant",
-		Image: containerConfig.Image,
-		Args:  []string{"tekton_run_indefinitely"},
-
-		// Set requests == limits to get QoS class _Guaranteed_.
-		// See https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed
-		// Affinity Assistant pod is a placeholder; request minimal resources
-		Resources: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				"cpu":    resource.MustParse("50m"),
-				"memory": resource.MustParse("100Mi"),
-			},
-			Requests: corev1.ResourceList{
-				"cpu":    resource.MustParse("50m"),
-				"memory": resource.MustParse("100Mi"),
-			},
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
 		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+	}
+	if tpl.Resources != nil {
+		resources = *tpl.Resources
+	}
+
+	containers := []corev1.Container{{
+		Name:            affinityAssistantContainerName,
+		Image:           containerConfig.Image,
+		Args:            []string{"tekton_run_indefinitely"},
+		Resources:       resources,
 		VolumeMounts:    mounts,
 		SecurityContext: securityContext,
 	}}

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -41,6 +41,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
@@ -967,6 +968,186 @@ func TestThatTheAffinityAssistantIsWithoutNodeSelectorAndTolerations(t *testing.
 
 	if stsWithoutTolerationsAndNodeSelector.Spec.Template.Spec.SecurityContext != nil {
 		t.Errorf("unexpected SecurityContext in the StatefulSet")
+	}
+}
+
+func TestCustomResourcesArePropagatedToAffinityAssistant(t *testing.T) {
+	customResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	defaultTpl := &pod.AffinityAssistantTemplate{
+		Resources: customResources,
+	}
+
+	pr := &v1.PipelineRun{
+		TypeMeta:   metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-with-custom-resources"},
+		Spec:       v1.PipelineRunSpec{},
+	}
+
+	sts := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", pr, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, defaultTpl)
+
+	got := sts.Spec.Template.Spec.Containers[0].Resources
+	if diff := cmp.Diff(*customResources, got); diff != "" {
+		t.Errorf("affinity assistant container resources mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDefaultResourcesAreUsedWhenNoneSpecified(t *testing.T) {
+	pr := &v1.PipelineRun{
+		TypeMeta:   metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-without-custom-resources"},
+		Spec:       v1.PipelineRunSpec{},
+	}
+
+	sts := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", pr, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, nil)
+
+	expectedResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			"cpu":    resource.MustParse("50m"),
+			"memory": resource.MustParse("100Mi"),
+		},
+		Requests: corev1.ResourceList{
+			"cpu":    resource.MustParse("50m"),
+			"memory": resource.MustParse("100Mi"),
+		},
+	}
+
+	got := sts.Spec.Template.Spec.Containers[0].Resources
+	if diff := cmp.Diff(expectedResources, got); diff != "" {
+		t.Errorf("affinity assistant container default resources mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMergedResourcesArePropagatedToAffinityAssistant(t *testing.T) {
+	defaultResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+	}
+
+	defaultTpl := &pod.AffinityAssistantTemplate{
+		Resources: defaultResources,
+		NodeSelector: map[string]string{
+			"disktype": "ssd",
+		},
+	}
+
+	pr := &v1.PipelineRun{
+		TypeMeta:   metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-merged-resources"},
+		Spec: v1.PipelineRunSpec{
+			TaskRunTemplate: v1.PipelineTaskRunTemplate{
+				PodTemplate: &pod.Template{
+					NodeSelector: map[string]string{
+						"zone": "us-east-1a",
+					},
+				},
+			},
+		},
+	}
+
+	sts := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", pr, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, defaultTpl)
+
+	got := sts.Spec.Template.Spec.Containers[0].Resources
+	if diff := cmp.Diff(*defaultResources, got); diff != "" {
+		t.Errorf("expected resources from default template (-want +got):\n%s", diff)
+	}
+
+	if len(sts.Spec.Template.Spec.NodeSelector) != 1 || sts.Spec.Template.Spec.NodeSelector["zone"] != "us-east-1a" {
+		t.Errorf("expected NodeSelector from PipelineRun spec to override default, got %v", sts.Spec.Template.Spec.NodeSelector)
+	}
+}
+
+func TestPipelineRunPodTemplateResourcesArePropagatedToAffinityAssistant(t *testing.T) {
+	customResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("150m"),
+			corev1.ResourceMemory: resource.MustParse("300Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("300m"),
+			corev1.ResourceMemory: resource.MustParse("600Mi"),
+		},
+	}
+
+	pr := &v1.PipelineRun{
+		TypeMeta:   metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-with-resources-on-podtemplate"},
+		Spec: v1.PipelineRunSpec{
+			TaskRunTemplate: v1.PipelineTaskRunTemplate{
+				PodTemplate: &pod.Template{
+					Resources: customResources,
+				},
+			},
+		},
+	}
+
+	sts := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", pr, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, nil)
+
+	got := sts.Spec.Template.Spec.Containers[0].Resources
+	if diff := cmp.Diff(*customResources, got); diff != "" {
+		t.Errorf("per-PipelineRun resources mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPipelineRunResourcesOverrideDefaultResources(t *testing.T) {
+	prResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("400Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("400m"),
+			corev1.ResourceMemory: resource.MustParse("800Mi"),
+		},
+	}
+
+	defaultResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+	}
+
+	defaultTpl := &pod.AffinityAssistantTemplate{
+		Resources: defaultResources,
+	}
+
+	pr := &v1.PipelineRun{
+		TypeMeta:   metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-resources-override"},
+		Spec: v1.PipelineRunSpec{
+			TaskRunTemplate: v1.PipelineTaskRunTemplate{
+				PodTemplate: &pod.Template{
+					Resources: prResources,
+				},
+			},
+		},
+	}
+
+	sts := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", pr, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, defaultTpl)
+
+	got := sts.Spec.Template.Spec.Containers[0].Resources
+	if diff := cmp.Diff(*prResources, got); diff != "" {
+		t.Errorf("per-PipelineRun resources should override default (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -41,6 +41,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	errorutils "k8s.io/apimachinery/pkg/util/errors"
@@ -967,6 +968,186 @@ func TestThatTheAffinityAssistantIsWithoutNodeSelectorAndTolerations(t *testing.
 
 	if stsWithoutTolerationsAndNodeSelector.Spec.Template.Spec.SecurityContext != nil {
 		t.Errorf("unexpected SecurityContext in the StatefulSet")
+	}
+}
+
+func TestCustomResourcesArePropagatedToAffinityAssistant(t *testing.T) {
+	customResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	defaultTpl := &pod.AffinityAssistantTemplate{
+		Resources: customResources,
+	}
+
+	pr := &v1.PipelineRun{
+		TypeMeta:   metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-with-custom-resources"},
+		Spec:       v1.PipelineRunSpec{},
+	}
+
+	sts := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", pr, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, defaultTpl)
+
+	got := sts.Spec.Template.Spec.Containers[0].Resources
+	if diff := cmp.Diff(*customResources, got); diff != "" {
+		t.Errorf("affinity assistant container resources mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDefaultResourcesAreUsedWhenNoneSpecified(t *testing.T) {
+	pr := &v1.PipelineRun{
+		TypeMeta:   metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-without-custom-resources"},
+		Spec:       v1.PipelineRunSpec{},
+	}
+
+	sts := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", pr, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, nil)
+
+	expectedResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+	}
+
+	got := sts.Spec.Template.Spec.Containers[0].Resources
+	if diff := cmp.Diff(expectedResources, got); diff != "" {
+		t.Errorf("affinity assistant container default resources mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMergedResourcesArePropagatedToAffinityAssistant(t *testing.T) {
+	defaultResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+	}
+
+	defaultTpl := &pod.AffinityAssistantTemplate{
+		Resources: defaultResources,
+		NodeSelector: map[string]string{
+			"disktype": "ssd",
+		},
+	}
+
+	pr := &v1.PipelineRun{
+		TypeMeta:   metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-merged-resources"},
+		Spec: v1.PipelineRunSpec{
+			TaskRunTemplate: v1.PipelineTaskRunTemplate{
+				PodTemplate: &pod.Template{
+					NodeSelector: map[string]string{
+						"zone": "us-east-1a",
+					},
+				},
+			},
+		},
+	}
+
+	sts := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", pr, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, defaultTpl)
+
+	got := sts.Spec.Template.Spec.Containers[0].Resources
+	if diff := cmp.Diff(*defaultResources, got); diff != "" {
+		t.Errorf("expected resources from default template (-want +got):\n%s", diff)
+	}
+
+	if len(sts.Spec.Template.Spec.NodeSelector) != 1 || sts.Spec.Template.Spec.NodeSelector["zone"] != "us-east-1a" {
+		t.Errorf("expected NodeSelector from PipelineRun spec to override default, got %v", sts.Spec.Template.Spec.NodeSelector)
+	}
+}
+
+func TestPipelineRunPodTemplateResourcesArePropagatedToAffinityAssistant(t *testing.T) {
+	customResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("150m"),
+			corev1.ResourceMemory: resource.MustParse("300Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("300m"),
+			corev1.ResourceMemory: resource.MustParse("600Mi"),
+		},
+	}
+
+	pr := &v1.PipelineRun{
+		TypeMeta:   metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-with-resources-on-podtemplate"},
+		Spec: v1.PipelineRunSpec{
+			TaskRunTemplate: v1.PipelineTaskRunTemplate{
+				PodTemplate: &pod.Template{
+					Resources: customResources,
+				},
+			},
+		},
+	}
+
+	sts := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", pr, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, nil)
+
+	got := sts.Spec.Template.Spec.Containers[0].Resources
+	if diff := cmp.Diff(*customResources, got); diff != "" {
+		t.Errorf("per-PipelineRun resources mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPipelineRunResourcesOverrideDefaultResources(t *testing.T) {
+	prResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("400Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("400m"),
+			corev1.ResourceMemory: resource.MustParse("800Mi"),
+		},
+	}
+
+	defaultResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+	}
+
+	defaultTpl := &pod.AffinityAssistantTemplate{
+		Resources: defaultResources,
+	}
+
+	pr := &v1.PipelineRun{
+		TypeMeta:   metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-resources-override"},
+		Spec: v1.PipelineRunSpec{
+			TaskRunTemplate: v1.PipelineTaskRunTemplate{
+				PodTemplate: &pod.Template{
+					Resources: prResources,
+				},
+			},
+		},
+	}
+
+	sts := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", pr, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, defaultTpl)
+
+	got := sts.Spec.Template.Spec.Containers[0].Resources
+	if diff := cmp.Diff(*prResources, got); diff != "" {
+		t.Errorf("per-PipelineRun resources should override default (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
# Changes

Allow users to configure CPU and memory requests/limits for affinity assistant containers via the default-affinity-assistant-pod-template ConfigMap or per-PipelineRun podTemplate. Without this, environments with ResourceQuota or LimitRange policies may reject the hardcoded 50m/100Mi defaults.

Priority: per-PipelineRun spec > global config default > hardcoded fallback.

Fixes #9287

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add support for customizing container resource requirements (CPU/memory requests and limits) for affinity-assistant pods via `default-affinity-assistant-pod-template` ConfigMap or per-PipelineRun `podTemplate`. Previously, affinity-assistant pods used hardcoded values of 50m CPU and 100Mi memory, which caused issues in environments with ResourceQuota or LimitRange policies. (#9287)
```
