### PR TITLE
test: use mirror.gcr.io/busybox in step_when_test to avoid Docker Hub flakes

### DIFF
--- a/test/step_when_test.go
+++ b/test/step_when_test.go
@@ -63,7 +63,7 @@ metadata:
 spec:
   steps:
   - name: foo
-    image: busybox
+    image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
     when:
@@ -92,7 +92,7 @@ metadata:
 spec:
   steps:
   - name: foo
-    image: busybox
+    image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
     when:
@@ -131,7 +131,7 @@ metadata:
 spec:
   steps:
   - name: foo
-    image: busybox
+    image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
     when:
@@ -139,7 +139,7 @@ spec:
       operator: in
       values: [ "bar" ]
   - name: bar
-    image: busybox
+    image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
 `,
@@ -181,13 +181,13 @@ metadata:
 spec:
   steps:
   - name: foo
-    image: busybox
+    image: mirror.gcr.io/busybox
     results:
       - name: result1
     command: ['/bin/sh']
     args: ['-c', 'echo -n bar >> $(step.results.result1.path)']
   - name: bar
-    image: busybox
+    image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
     when:
@@ -275,7 +275,7 @@ metadata:
 spec:
   steps:
   - name: foo
-    image: busybox
+    image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
     when:
@@ -302,7 +302,7 @@ metadata:
 spec:
   steps:
   - name: foo
-    image: busybox
+    image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
     when:
@@ -339,13 +339,13 @@ metadata:
 spec:
   steps:
   - name: foo
-    image: busybox
+    image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
     when:
     - cel: "'foo'=='bar'"
   - name: bar
-    image: busybox
+    image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
 `,
@@ -387,13 +387,13 @@ metadata:
 spec:
   steps:
   - name: foo
-    image: busybox
+    image: mirror.gcr.io/busybox
     results:
       - name: result1
     command: ['/bin/sh']
     args: ['-c', 'echo -n bar >> $(step.results.result1.path)']
   - name: bar
-    image: busybox
+    image: mirror.gcr.io/busybox
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
     when:


### PR DESCRIPTION
# Changes

`test/step_when_test.go` still referenced the bare `busybox` image
(`docker.io/library/busybox`), while the rest of the e2e suite was migrated to
`mirror.gcr.io/busybox`. The un-mirrored references cause intermittent
`TaskRunImagePullFailed` errors when Docker Hub rate-limits or returns errors
(observed as HTTP `520` from `auth.docker.io`), making `TestWhenExpressionsInStep`
and `TestWhenExpressionsCELInStep` flaky in CI.

This replaces the 12 remaining `image: busybox` references with
`image: mirror.gcr.io/busybox`, matching the rest of the test suite.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```