### PR TITLE
Strip description fields from status spec snapshots

### DIFF
--- a/config/300-crds/300-pipelinerun.yaml
+++ b/config/300-crds/300-pipelinerun.yaml
@@ -2385,6 +2385,8 @@ spec:
                           type: boolean
                         enforceNonfalsifiability:
                           type: string
+                        keepStatusSpecDescriptions:
+                          type: boolean
                         maxResultSize:
                           type: integer
                         requireGitSSHSecretKnownHosts:
@@ -2765,6 +2767,8 @@ spec:
                                     type: boolean
                                   enforceNonfalsifiability:
                                     type: string
+                                  keepStatusSpecDescriptions:
+                                    type: boolean
                                   maxResultSize:
                                     type: integer
                                   requireGitSSHSecretKnownHosts:
@@ -3038,6 +3042,8 @@ spec:
                                           type: boolean
                                         enforceNonfalsifiability:
                                           type: string
+                                        keepStatusSpecDescriptions:
+                                          type: boolean
                                         maxResultSize:
                                           type: integer
                                         requireGitSSHSecretKnownHosts:
@@ -5484,6 +5490,8 @@ spec:
                           type: boolean
                         enforceNonfalsifiability:
                           type: string
+                        keepStatusSpecDescriptions:
+                          type: boolean
                         maxResultSize:
                           type: integer
                         requireGitSSHSecretKnownHosts:

--- a/config/300-crds/300-taskrun.yaml
+++ b/config/300-crds/300-taskrun.yaml
@@ -1900,6 +1900,8 @@ spec:
                           type: boolean
                         enforceNonfalsifiability:
                           type: string
+                        keepStatusSpecDescriptions:
+                          type: boolean
                         maxResultSize:
                           type: integer
                         requireGitSSHSecretKnownHosts:
@@ -2173,6 +2175,8 @@ spec:
                                 type: boolean
                               enforceNonfalsifiability:
                                 type: string
+                              keepStatusSpecDescriptions:
+                                type: boolean
                               maxResultSize:
                                 type: integer
                               requireGitSSHSecretKnownHosts:
@@ -4054,6 +4058,8 @@ spec:
                           type: boolean
                         enforceNonfalsifiability:
                           type: string
+                        keepStatusSpecDescriptions:
+                          type: boolean
                         maxResultSize:
                           type: integer
                         requireGitSSHSecretKnownHosts:
@@ -4319,6 +4325,8 @@ spec:
                                 type: boolean
                               enforceNonfalsifiability:
                                 type: string
+                              keepStatusSpecDescriptions:
+                                type: boolean
                               maxResultSize:
                                 type: integer
                               requireGitSSHSecretKnownHosts:

--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -155,3 +155,7 @@ data:
   #
   # See https://github.com/tektoncd/pipeline/issues/7691 for more info.
   enable-informer-cache-transforms: "true"
+  # Documentation-only description fields are stripped from the
+  # status.taskSpec/status.pipelineSpec snapshots by default to reduce etcd usage.
+  # Set this flag to "true" to keep those descriptions during a migration window.
+  keep-status-spec-descriptions: "false"

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -419,6 +419,8 @@ Set this field to "alpha" to allow [alpha features](#alpha-features) to be used.
 
 - `enable-kubernetes-sidecar`: Set this flag to `"true"` to enable native kubernetes sidecar support. This will allow Tekton sidecars to run as Kubernetes sidecars. Must be using Kubernetes v1.29 or greater.
 
+- `keep-status-spec-descriptions`: documentation-only `description` fields are stripped from the `status.taskSpec` and `status.pipelineSpec` snapshots by default to reduce etcd usage. These fields are never used by the controller during execution; the original Task/Pipeline objects keep their descriptions. Set this flag to `"true"` to retain them in the status snapshot during a migration window. The default is `"false"`. See [#10321](https://github.com/tektoncd/pipeline/issues/10321).
+
 For example:
 
 ```yaml

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -121,6 +121,13 @@ const (
 	EnableTerminationMessageCompression = "enable-termination-message-compression"
 	// DefaultEnableTerminationMessageCompression is the default value for EnableTerminationMessageCompression
 	DefaultEnableTerminationMessageCompression = false
+	// KeepStatusSpecDescriptions is the opt-out flag to retain documentation-only
+	// description fields in the status.taskSpec/status.pipelineSpec snapshots.
+	// They are stripped by default to reduce etcd usage; set this to "true" to
+	// keep them during a migration window. See #10321.
+	KeepStatusSpecDescriptions = "keep-status-spec-descriptions"
+	// DefaultKeepStatusSpecDescriptions is the default value for KeepStatusSpecDescriptions
+	DefaultKeepStatusSpecDescriptions = false
 
 	// EnableStepActions is the flag to enable step actions (no-op since it's stable)
 	EnableStepActions = "enable-step-actions"
@@ -235,6 +242,7 @@ type FeatureFlags struct {
 	EnableKubernetesSidecar             bool   `json:"enableKubernetesSidecar,omitempty"`
 	EnableWaitExponentialBackoff        bool   `json:"enableWaitExponentialBackoff,omitempty"`
 	EnableTerminationMessageCompression bool   `json:"enableTerminationMessageCompression,omitempty"`
+	KeepStatusSpecDescriptions          bool   `json:"keepStatusSpecDescriptions,omitempty"`
 	// DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
 	// to allow deletion of PipelineRuns created before v0.62.x.
 	// This field is not used and can be removed in a future release
@@ -349,6 +357,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setPerFeatureFlag(EnableTerminationMessageCompression, DefaultEnableTerminationMessageCompressionFlag, &tc.EnableTerminationMessageCompression); err != nil {
+		return nil, err
+	}
+	if err := setFeature(KeepStatusSpecDescriptions, DefaultKeepStatusSpecDescriptions, &tc.KeepStatusSpecDescriptions); err != nil {
 		return nil, err
 	}
 

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -81,6 +81,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableConciseResolverSyntax:              true,
 				EnableKubernetesSidecar:                  true,
 				EnableTerminationMessageCompression:      true,
+				KeepStatusSpecDescriptions:               true,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -39,3 +39,4 @@ data:
   enable-concise-resolver-syntax: "true"
   enable-kubernetes-sidecar: "true"
   enable-termination-message-compression: "true"
+  keep-status-spec-descriptions: "true"

--- a/pkg/apis/pipeline/v1/strip_descriptions.go
+++ b/pkg/apis/pipeline/v1/strip_descriptions.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+// StripDescriptions clears documentation-only description fields from the TaskSpec snapshot. See #10321.
+func (ts *TaskSpec) StripDescriptions() {
+	if ts == nil {
+		return
+	}
+	ts.Description = ""
+	for i := range ts.Params {
+		ts.Params[i].Description = ""
+	}
+	for i := range ts.Results {
+		ts.Results[i].Description = ""
+	}
+	for i := range ts.Workspaces {
+		ts.Workspaces[i].Description = ""
+	}
+	for i := range ts.Steps {
+		for j := range ts.Steps[i].Results {
+			ts.Steps[i].Results[j].Description = ""
+		}
+	}
+}
+
+// StripDescriptions clears documentation-only description fields from the PipelineSpec snapshot. See #10321.
+func (ps *PipelineSpec) StripDescriptions() {
+	if ps == nil {
+		return
+	}
+	ps.Description = ""
+	for i := range ps.Params {
+		ps.Params[i].Description = ""
+	}
+	for i := range ps.Results {
+		ps.Results[i].Description = ""
+	}
+	for i := range ps.Workspaces {
+		ps.Workspaces[i].Description = ""
+	}
+	for i := range ps.Tasks {
+		ps.Tasks[i].stripDescriptions()
+	}
+	for i := range ps.Finally {
+		ps.Finally[i].stripDescriptions()
+	}
+}
+
+// stripDescriptions clears the PipelineTask description and any inline embedded TaskSpec descriptions.
+func (pt *PipelineTask) stripDescriptions() {
+	pt.Description = ""
+	if pt.TaskSpec != nil {
+		pt.TaskSpec.TaskSpec.StripDescriptions()
+	}
+}

--- a/pkg/apis/pipeline/v1/strip_descriptions_test.go
+++ b/pkg/apis/pipeline/v1/strip_descriptions_test.go
@@ -17,31 +17,78 @@ limitations under the License.
 package v1_test
 
 import (
-	"strings"
+	"slices"
 	"testing"
 
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
-func TestTaskSpecStripDescriptions(t *testing.T) {
-	ts := &v1.TaskSpec{
-		Description: "task desc",
-		Params:      v1.ParamSpecs{{Name: "p", Description: "param desc"}},
-		Results:     []v1.TaskResult{{Name: "r", Description: "result desc"}},
-		Workspaces:  []v1.WorkspaceDeclaration{{Name: "w", Description: "ws desc"}},
+// fullEmbeddedTask exercises every recursive branch of TaskSpec.StripDescriptions.
+func fullEmbeddedTask() *v1.EmbeddedTask {
+	return &v1.EmbeddedTask{TaskSpec: v1.TaskSpec{
+		Description: "embedded task desc",
+		Params:      v1.ParamSpecs{{Name: "ep", Description: "embedded param desc"}},
+		Results:     []v1.TaskResult{{Name: "er", Description: "embedded result desc"}},
+		Workspaces:  []v1.WorkspaceDeclaration{{Name: "ew", Description: "embedded ws desc"}},
 		Steps: []v1.Step{{
-			Name:    "s",
-			Results: []v1.StepResult{{Name: "sr", Description: "step result desc"}},
+			Name:    "es",
+			Results: []v1.StepResult{{Name: "esr", Description: "embedded step result desc"}},
 		}},
-	}
+	}}
+}
 
-	ts.StripDescriptions()
+func TestTaskSpecStripDescriptions(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *v1.TaskSpec
+	}{{
+		name: "all fields populated",
+		spec: &v1.TaskSpec{
+			Description: "task desc",
+			Params:      v1.ParamSpecs{{Name: "p", Description: "param desc"}},
+			Results:     []v1.TaskResult{{Name: "r", Description: "result desc"}},
+			Workspaces:  []v1.WorkspaceDeclaration{{Name: "w", Description: "ws desc"}},
+			Steps: []v1.Step{{
+				Name:    "s",
+				Results: []v1.StepResult{{Name: "sr", Description: "step result desc"}},
+			}},
+		},
+	}, {
+		name: "multiple items per slice",
+		spec: &v1.TaskSpec{
+			Description: "task desc",
+			Params:      v1.ParamSpecs{{Name: "p1", Description: "d1"}, {Name: "p2", Description: "d2"}},
+			Results:     []v1.TaskResult{{Name: "r1", Description: "d1"}, {Name: "r2", Description: "d2"}},
+			Steps: []v1.Step{
+				{Name: "s1", Results: []v1.StepResult{{Name: "sr1", Description: "d1"}}},
+				{Name: "s2", Results: []v1.StepResult{{Name: "sr2", Description: "d2"}}},
+			},
+		},
+	}, {
+		name: "empty slices",
+		spec: &v1.TaskSpec{Description: "task desc"},
+	}, {
+		name: "descriptions already empty",
+		spec: &v1.TaskSpec{
+			Params:  v1.ParamSpecs{{Name: "p"}},
+			Results: []v1.TaskResult{{Name: "r"}},
+			Steps:   []v1.Step{{Name: "s", Results: []v1.StepResult{{Name: "sr"}}}},
+		},
+	}}
 
-	if d := nonEmptyDescriptions(ts); len(d) > 0 {
-		t.Errorf("expected all TaskSpec descriptions cleared, found: %v", d)
-	}
-	if ts.Params[0].Name != "p" || ts.Results[0].Name != "r" || ts.Steps[0].Results[0].Name != "sr" {
-		t.Error("StripDescriptions must not alter non-description fields")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			names := taskSpecNames(tc.spec)
+
+			tc.spec.StripDescriptions()
+
+			if d := nonEmptyDescriptions(tc.spec); len(d) > 0 {
+				t.Errorf("expected all TaskSpec descriptions cleared, found: %v", d)
+			}
+			if got := taskSpecNames(tc.spec); !slices.Equal(got, names) {
+				t.Errorf("StripDescriptions altered non-description fields: got %v, want %v", got, names)
+			}
+		})
 	}
 }
 
@@ -51,55 +98,130 @@ func TestTaskSpecStripDescriptionsNil(t *testing.T) {
 }
 
 func TestPipelineSpecStripDescriptions(t *testing.T) {
-	embedded := &v1.EmbeddedTask{TaskSpec: v1.TaskSpec{
-		Description: "embedded task desc",
-		Params:      v1.ParamSpecs{{Name: "ep", Description: "embedded param desc"}},
-		Results:     []v1.TaskResult{{Name: "er", Description: "embedded result desc"}},
+	tests := []struct {
+		name string
+		spec *v1.PipelineSpec
+	}{{
+		name: "all fields populated",
+		spec: &v1.PipelineSpec{
+			Description: "pipeline desc",
+			Params:      v1.ParamSpecs{{Name: "p", Description: "param desc"}},
+			Results:     []v1.PipelineResult{{Name: "r", Description: "result desc"}},
+			Workspaces:  []v1.PipelineWorkspaceDeclaration{{Name: "w", Description: "ws desc"}},
+			Tasks:       []v1.PipelineTask{{Name: "t", Description: "task desc", TaskSpec: fullEmbeddedTask()}},
+			Finally:     []v1.PipelineTask{{Name: "f", Description: "finally desc"}},
+		},
+	}, {
+		name: "finally with embedded TaskSpec",
+		spec: &v1.PipelineSpec{
+			Finally: []v1.PipelineTask{{Name: "f", Description: "finally desc", TaskSpec: fullEmbeddedTask()}},
+		},
+	}, {
+		name: "task with TaskRef only",
+		spec: &v1.PipelineSpec{
+			Tasks: []v1.PipelineTask{{Name: "t", Description: "task desc", TaskRef: &v1.TaskRef{Name: "my-task"}}},
+		},
+	}, {
+		name: "empty pipeline spec",
+		spec: &v1.PipelineSpec{Description: "pipeline desc"},
 	}}
-	ps := &v1.PipelineSpec{
-		Description: "pipeline desc",
-		Params:      v1.ParamSpecs{{Name: "p", Description: "param desc"}},
-		Results:     []v1.PipelineResult{{Name: "r", Description: "result desc"}},
-		Workspaces:  []v1.PipelineWorkspaceDeclaration{{Name: "w", Description: "ws desc"}},
-		Tasks:       []v1.PipelineTask{{Name: "t", Description: "task desc", TaskSpec: embedded}},
-		Finally:     []v1.PipelineTask{{Name: "f", Description: "finally desc"}},
-	}
 
-	ps.StripDescriptions()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			names := pipelineSpecNames(tc.spec)
 
-	var leftover []string
-	if ps.Description != "" {
-		leftover = append(leftover, "spec")
-	}
-	if ps.Params[0].Description != "" {
-		leftover = append(leftover, "param")
-	}
-	if ps.Results[0].Description != "" {
-		leftover = append(leftover, "result")
-	}
-	if ps.Workspaces[0].Description != "" {
-		leftover = append(leftover, "workspace")
-	}
-	if ps.Tasks[0].Description != "" {
-		leftover = append(leftover, "task")
-	}
-	if ps.Finally[0].Description != "" {
-		leftover = append(leftover, "finally")
-	}
-	if d := nonEmptyDescriptions(&ps.Tasks[0].TaskSpec.TaskSpec); len(d) > 0 {
-		leftover = append(leftover, "embedded:"+strings.Join(d, ","))
-	}
-	if len(leftover) > 0 {
-		t.Errorf("expected all PipelineSpec descriptions cleared, found: %v", leftover)
-	}
-	if ps.Tasks[0].Name != "t" || ps.Finally[0].Name != "f" {
-		t.Error("StripDescriptions must not alter non-description fields")
+			tc.spec.StripDescriptions()
+
+			if d := nonEmptyPipelineDescriptions(tc.spec); len(d) > 0 {
+				t.Errorf("expected all PipelineSpec descriptions cleared, found: %v", d)
+			}
+			if got := pipelineSpecNames(tc.spec); !slices.Equal(got, names) {
+				t.Errorf("StripDescriptions altered non-description fields: got %v, want %v", got, names)
+			}
+		})
 	}
 }
 
 func TestPipelineSpecStripDescriptionsNil(t *testing.T) {
 	var ps *v1.PipelineSpec
 	ps.StripDescriptions()
+}
+
+// taskSpecNames collects identity fields to prove stripping touches only descriptions.
+func taskSpecNames(ts *v1.TaskSpec) []string {
+	var names []string
+	for _, p := range ts.Params {
+		names = append(names, "param:"+p.Name)
+	}
+	for _, r := range ts.Results {
+		names = append(names, "result:"+r.Name)
+	}
+	for _, w := range ts.Workspaces {
+		names = append(names, "workspace:"+w.Name)
+	}
+	for _, s := range ts.Steps {
+		names = append(names, "step:"+s.Name)
+		for _, r := range s.Results {
+			names = append(names, "stepresult:"+r.Name)
+		}
+	}
+	return names
+}
+
+func pipelineSpecNames(ps *v1.PipelineSpec) []string {
+	var names []string
+	for _, p := range ps.Params {
+		names = append(names, "param:"+p.Name)
+	}
+	for _, r := range ps.Results {
+		names = append(names, "result:"+r.Name)
+	}
+	for _, w := range ps.Workspaces {
+		names = append(names, "workspace:"+w.Name)
+	}
+	for _, pt := range append(slices.Clone(ps.Tasks), ps.Finally...) {
+		names = append(names, "task:"+pt.Name)
+		if pt.TaskRef != nil {
+			names = append(names, "taskref:"+pt.TaskRef.Name)
+		}
+		if pt.TaskSpec != nil {
+			names = append(names, taskSpecNames(&pt.TaskSpec.TaskSpec)...)
+		}
+	}
+	return names
+}
+
+func nonEmptyPipelineDescriptions(ps *v1.PipelineSpec) []string {
+	var found []string
+	if ps.Description != "" {
+		found = append(found, "spec")
+	}
+	for _, p := range ps.Params {
+		if p.Description != "" {
+			found = append(found, "param")
+		}
+	}
+	for _, r := range ps.Results {
+		if r.Description != "" {
+			found = append(found, "result")
+		}
+	}
+	for _, w := range ps.Workspaces {
+		if w.Description != "" {
+			found = append(found, "workspace")
+		}
+	}
+	for _, pt := range append(slices.Clone(ps.Tasks), ps.Finally...) {
+		if pt.Description != "" {
+			found = append(found, "pipelineTask")
+		}
+		if pt.TaskSpec != nil {
+			for _, d := range nonEmptyDescriptions(&pt.TaskSpec.TaskSpec) {
+				found = append(found, "embedded:"+d)
+			}
+		}
+	}
+	return found
 }
 
 func nonEmptyDescriptions(ts *v1.TaskSpec) []string {

--- a/pkg/apis/pipeline/v1/strip_descriptions_test.go
+++ b/pkg/apis/pipeline/v1/strip_descriptions_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"strings"
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+func TestTaskSpecStripDescriptions(t *testing.T) {
+	ts := &v1.TaskSpec{
+		Description: "task desc",
+		Params:      v1.ParamSpecs{{Name: "p", Description: "param desc"}},
+		Results:     []v1.TaskResult{{Name: "r", Description: "result desc"}},
+		Workspaces:  []v1.WorkspaceDeclaration{{Name: "w", Description: "ws desc"}},
+		Steps: []v1.Step{{
+			Name:    "s",
+			Results: []v1.StepResult{{Name: "sr", Description: "step result desc"}},
+		}},
+	}
+
+	ts.StripDescriptions()
+
+	if d := nonEmptyDescriptions(ts); len(d) > 0 {
+		t.Errorf("expected all TaskSpec descriptions cleared, found: %v", d)
+	}
+	if ts.Params[0].Name != "p" || ts.Results[0].Name != "r" || ts.Steps[0].Results[0].Name != "sr" {
+		t.Error("StripDescriptions must not alter non-description fields")
+	}
+}
+
+func TestTaskSpecStripDescriptionsNil(t *testing.T) {
+	var ts *v1.TaskSpec
+	ts.StripDescriptions()
+}
+
+func TestPipelineSpecStripDescriptions(t *testing.T) {
+	embedded := &v1.EmbeddedTask{TaskSpec: v1.TaskSpec{
+		Description: "embedded task desc",
+		Params:      v1.ParamSpecs{{Name: "ep", Description: "embedded param desc"}},
+		Results:     []v1.TaskResult{{Name: "er", Description: "embedded result desc"}},
+	}}
+	ps := &v1.PipelineSpec{
+		Description: "pipeline desc",
+		Params:      v1.ParamSpecs{{Name: "p", Description: "param desc"}},
+		Results:     []v1.PipelineResult{{Name: "r", Description: "result desc"}},
+		Workspaces:  []v1.PipelineWorkspaceDeclaration{{Name: "w", Description: "ws desc"}},
+		Tasks:       []v1.PipelineTask{{Name: "t", Description: "task desc", TaskSpec: embedded}},
+		Finally:     []v1.PipelineTask{{Name: "f", Description: "finally desc"}},
+	}
+
+	ps.StripDescriptions()
+
+	var leftover []string
+	if ps.Description != "" {
+		leftover = append(leftover, "spec")
+	}
+	if ps.Params[0].Description != "" {
+		leftover = append(leftover, "param")
+	}
+	if ps.Results[0].Description != "" {
+		leftover = append(leftover, "result")
+	}
+	if ps.Workspaces[0].Description != "" {
+		leftover = append(leftover, "workspace")
+	}
+	if ps.Tasks[0].Description != "" {
+		leftover = append(leftover, "task")
+	}
+	if ps.Finally[0].Description != "" {
+		leftover = append(leftover, "finally")
+	}
+	if d := nonEmptyDescriptions(&ps.Tasks[0].TaskSpec.TaskSpec); len(d) > 0 {
+		leftover = append(leftover, "embedded:"+strings.Join(d, ","))
+	}
+	if len(leftover) > 0 {
+		t.Errorf("expected all PipelineSpec descriptions cleared, found: %v", leftover)
+	}
+	if ps.Tasks[0].Name != "t" || ps.Finally[0].Name != "f" {
+		t.Error("StripDescriptions must not alter non-description fields")
+	}
+}
+
+func TestPipelineSpecStripDescriptionsNil(t *testing.T) {
+	var ps *v1.PipelineSpec
+	ps.StripDescriptions()
+}
+
+func nonEmptyDescriptions(ts *v1.TaskSpec) []string {
+	var found []string
+	if ts.Description != "" {
+		found = append(found, "spec")
+	}
+	for _, p := range ts.Params {
+		if p.Description != "" {
+			found = append(found, "param")
+		}
+	}
+	for _, r := range ts.Results {
+		if r.Description != "" {
+			found = append(found, "result")
+		}
+	}
+	for _, w := range ts.Workspaces {
+		if w.Description != "" {
+			found = append(found, "workspace")
+		}
+	}
+	for _, s := range ts.Steps {
+		for _, r := range s.Results {
+			if r.Description != "" {
+				found = append(found, "stepresult")
+			}
+		}
+	}
+	return found
+}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -708,6 +708,10 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	pipelineSpec = resources.ApplyWorkspaces(pipelineSpec, pr)
 	// Update pipelinespec of pipelinerun's status field
 	pr.Status.PipelineSpec = pipelineSpec
+	// pipelineSpec is already a deep copy, so strip in place; this assignment overwrites the snapshot stored earlier.
+	if !config.FromContextOrDefaults(ctx).FeatureFlags.KeepStatusSpecDescriptions {
+		pr.Status.PipelineSpec.StripDescriptions()
+	}
 
 	// validate pipelineSpec after apply parameters
 	if err := validatePipelineSpecAfterApplyParameters(ctx, pipelineSpec); err != nil {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -708,9 +708,11 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	pipelineSpec = resources.ApplyWorkspaces(pipelineSpec, pr)
 	// Update pipelinespec of pipelinerun's status field
 	pr.Status.PipelineSpec = pipelineSpec
-	// pipelineSpec is already a deep copy, so strip in place; this assignment overwrites the snapshot stored earlier.
+	// strip a copy: pipelineSpec stays live for the rest of the reconcile, including the embedded specs of child TaskRuns
 	if !config.FromContextOrDefaults(ctx).FeatureFlags.KeepStatusSpecDescriptions {
-		pr.Status.PipelineSpec.StripDescriptions()
+		statusSpec := pipelineSpec.DeepCopy()
+		statusSpec.StripDescriptions()
+		pr.Status.PipelineSpec = statusSpec
 	}
 
 	// validate pipelineSpec after apply parameters

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1955,7 +1955,14 @@ func (c *Reconciler) updateLabelsAndAnnotations(ctx context.Context, pr *v1.Pipe
 func storePipelineSpecAndMergeMeta(ctx context.Context, pr *v1.PipelineRun, ps *v1.PipelineSpec, meta *resolutionutil.ResolvedObjectMeta) error {
 	// Only store the PipelineSpec once, if it has never been set before.
 	if pr.Status.PipelineSpec == nil {
-		pr.Status.PipelineSpec = ps
+		// Strip documentation-only descriptions from the status snapshot to reduce etcd usage, unless opted out. See #10321.
+		if config.FromContextOrDefaults(ctx).FeatureFlags.KeepStatusSpecDescriptions {
+			pr.Status.PipelineSpec = ps
+		} else {
+			stripped := ps.DeepCopy()
+			stripped.StripDescriptions()
+			pr.Status.PipelineSpec = stripped
+		}
 		if meta == nil {
 			return nil
 		}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1955,14 +1955,12 @@ func (c *Reconciler) updateLabelsAndAnnotations(ctx context.Context, pr *v1.Pipe
 func storePipelineSpecAndMergeMeta(ctx context.Context, pr *v1.PipelineRun, ps *v1.PipelineSpec, meta *resolutionutil.ResolvedObjectMeta) error {
 	// Only store the PipelineSpec once, if it has never been set before.
 	if pr.Status.PipelineSpec == nil {
-		// Strip documentation-only descriptions from the status snapshot to reduce etcd usage, unless opted out. See #10321.
-		if config.FromContextOrDefaults(ctx).FeatureFlags.KeepStatusSpecDescriptions {
-			pr.Status.PipelineSpec = ps
-		} else {
-			stripped := ps.DeepCopy()
-			stripped.StripDescriptions()
-			pr.Status.PipelineSpec = stripped
+		// Snapshot the spec, stripping documentation-only descriptions to reduce etcd usage unless opted out. See #10321.
+		snapshot := ps.DeepCopy()
+		if !config.FromContextOrDefaults(ctx).FeatureFlags.KeepStatusSpecDescriptions {
+			snapshot.StripDescriptions()
 		}
+		pr.Status.PipelineSpec = snapshot
 		if meta == nil {
 			return nil
 		}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -7189,11 +7189,9 @@ spec:
 status:
   pipelineSpec:
     results:
-    - description: pipeline result
-      name: result
+    - name: result
       value: $(finally.a-task.results.a-Result)
-    - description: custom task pipeline result
-      name: custom-result
+    - name: custom-result
       value: $(finally.b-task.results.b-Result)
     tasks:
     - name: c-task
@@ -7347,11 +7345,9 @@ spec:
 status:
   pipelineSpec:
     results:
-    - description: pipeline result
-      name: result
+    - name: result
       value: $(tasks.a-task.results.a-Result)
-    - description: custom task pipeline result
-      name: custom-result
+    - name: custom-result
       value: $(tasks.b-task.results.b-Result)
     tasks:
     - name: b-task
@@ -7692,6 +7688,92 @@ func Test_storePipelineSpec_stripsDescriptions(t *testing.T) {
 			}
 			if !tc.wantStripped && (got.Description != "pipeline desc" || embedded != "embedded desc") {
 				t.Errorf("expected descriptions retained, got spec=%q embedded=%q", got.Description, embedded)
+			}
+		})
+	}
+}
+
+// Regression test: the stored snapshot is overwritten later in reconcile, so stripping must survive a full cycle.
+func TestReconcile_StripsStatusPipelineSpecDescriptions(t *testing.T) {
+	tests := []struct {
+		name string
+		keep string
+	}{
+		{name: "default strips descriptions", keep: "false"},
+		{name: "opt-out keeps descriptions", keep: "true"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ps := []*v1.Pipeline{parse.MustParseV1Pipeline(t, `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  description: pipeline desc
+  params:
+  - name: p
+    type: string
+    default: v
+    description: param desc
+  tasks:
+  - name: a-task
+    description: task desc
+    taskRef:
+      name: a-task
+`)}
+			prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: test-pipeline-run-strip-descriptions
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+`)}
+			ts := []*v1.Task{parse.MustParseV1Task(t, `
+metadata:
+  name: a-task
+  namespace: foo
+spec:
+  steps:
+  - name: step1
+    image: foo
+`)}
+
+			d := test.Data{
+				PipelineRuns: prs,
+				Pipelines:    ps,
+				Tasks:        ts,
+				ConfigMaps: []*corev1.ConfigMap{{
+					ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+					Data:       map[string]string{"keep-status-spec-descriptions": tc.keep},
+				}},
+			}
+			prt := newPipelineRunTest(t, d)
+			defer prt.Cancel()
+
+			reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-run-strip-descriptions", nil, false)
+
+			got := reconciledRun.Status.PipelineSpec
+			if got == nil {
+				t.Fatal("expected status.pipelineSpec to be set after reconcile")
+			}
+			// want returns the original description only when the opt-out flag is set.
+			want := func(original string) string {
+				if tc.keep == "true" {
+					return original
+				}
+				return ""
+			}
+			for _, f := range []struct {
+				field, got, original string
+			}{
+				{"description", got.Description, "pipeline desc"},
+				{"params[0].description", got.Params[0].Description, "param desc"},
+				{"tasks[0].description", got.Tasks[0].Description, "task desc"},
+			} {
+				if f.got != want(f.original) {
+					t.Errorf("status.pipelineSpec.%s = %q, want %q", f.field, f.got, want(f.original))
+				}
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -7541,10 +7541,14 @@ metadata:
 	ps := v1.PipelineSpec{Description: "foo-pipeline"}
 	ps1 := v1.PipelineSpec{Description: "bar-pipeline"}
 
+	// descriptions are stripped from the status snapshot by default (#10321)
+	strippedPS := ps.DeepCopy()
+	strippedPS.StripDescriptions()
+
 	want := pr.DeepCopy()
 	want.Status = v1.PipelineRunStatus{
 		PipelineRunStatusFields: v1.PipelineRunStatusFields{
-			PipelineSpec: ps.DeepCopy(),
+			PipelineSpec: strippedPS.DeepCopy(),
 			Provenance: &v1.Provenance{
 				RefSource:    refSource.DeepCopy(),
 				FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
@@ -7562,7 +7566,7 @@ metadata:
 	wantForGeneratedName := prWithGeneratedName.DeepCopy()
 	wantForGeneratedName.Status = v1.PipelineRunStatus{
 		PipelineRunStatusFields: v1.PipelineRunStatusFields{
-			PipelineSpec: ps.DeepCopy(),
+			PipelineSpec: strippedPS.DeepCopy(),
 			Provenance: &v1.Provenance{
 				RefSource:    refSource.DeepCopy(),
 				FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
@@ -7648,6 +7652,46 @@ metadata:
 			}
 			if d := cmp.Diff(tc.wantPipelineRun, tc.pr); d != "" {
 				t.Fatal(diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func Test_storePipelineSpec_stripsDescriptions(t *testing.T) {
+	ps := &v1.PipelineSpec{
+		Description: "pipeline desc",
+		Params:      v1.ParamSpecs{{Name: "p", Description: "param desc"}},
+		Results:     []v1.PipelineResult{{Name: "r", Description: "result desc"}},
+		Tasks: []v1.PipelineTask{{
+			Name:     "t",
+			TaskSpec: &v1.EmbeddedTask{TaskSpec: v1.TaskSpec{Description: "embedded desc"}},
+		}},
+	}
+
+	tests := []struct {
+		name         string
+		keep         bool
+		wantStripped bool
+	}{
+		{name: "default strips descriptions", keep: false, wantStripped: true},
+		{name: "opt-out keeps descriptions", keep: true, wantStripped: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := config.ToContext(t.Context(), &config.Config{
+				FeatureFlags: &config.FeatureFlags{KeepStatusSpecDescriptions: tc.keep},
+			})
+			pr := &v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+			if err := storePipelineSpecAndMergeMeta(ctx, pr, ps.DeepCopy(), nil); err != nil {
+				t.Fatalf("storePipelineSpecAndMergeMeta error = %v", err)
+			}
+			got := pr.Status.PipelineSpec
+			embedded := got.Tasks[0].TaskSpec.TaskSpec.Description
+			if tc.wantStripped && (got.Description != "" || got.Params[0].Description != "" || embedded != "") {
+				t.Errorf("expected descriptions stripped, got spec=%q param=%q embedded=%q", got.Description, got.Params[0].Description, embedded)
+			}
+			if !tc.wantStripped && (got.Description != "pipeline desc" || embedded != "embedded desc") {
+				t.Errorf("expected descriptions retained, got spec=%q embedded=%q", got.Description, embedded)
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -7779,6 +7779,72 @@ spec:
 	}
 }
 
+func TestReconcile_KeepsEmbeddedTaskSpecDescriptionsOnChildTaskRun(t *testing.T) {
+	prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: test-pipeline-run-embedded-spec
+  namespace: foo
+spec:
+  pipelineSpec:
+    description: pipeline desc
+    tasks:
+    - name: a-task
+      description: pipeline task desc
+      taskSpec:
+        description: embedded task description
+        params:
+        - name: p
+          type: string
+          default: v
+          description: embedded param desc
+        steps:
+        - name: step1
+          image: foo
+`)}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		ConfigMaps: []*corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+			Data:       map[string]string{"keep-status-spec-descriptions": "false"},
+		}},
+	}
+	prt := newPipelineRunTest(t, d)
+	defer prt.Cancel()
+
+	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-embedded-spec", nil, false)
+
+	// the child TaskRun spec is a real user-facing object, so descriptions must survive there
+	tr, err := clients.Pipeline.TektonV1().TaskRuns("foo").Get(prt.TestAssets.Ctx, "test-pipeline-run-embedded-spec-a-task", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting created TaskRun: %v", err)
+	}
+	if tr.Spec.TaskSpec == nil {
+		t.Fatal("expected child TaskRun to carry an embedded spec.taskSpec")
+	}
+	if got := tr.Spec.TaskSpec.Description; got != "embedded task description" {
+		t.Errorf("child TaskRun spec.taskSpec.description = %q, want %q", got, "embedded task description")
+	}
+	if got := tr.Spec.TaskSpec.Params[0].Description; got != "embedded param desc" {
+		t.Errorf("child TaskRun spec.taskSpec.params[0].description = %q, want %q", got, "embedded param desc")
+	}
+
+	// status stays stripped
+	got := reconciledRun.Status.PipelineSpec
+	if got == nil {
+		t.Fatal("expected status.pipelineSpec to be set after reconcile")
+	}
+	if got.Description != "" {
+		t.Errorf("status.pipelineSpec.description = %q, want empty", got.Description)
+	}
+	if got.Tasks[0].TaskSpec == nil {
+		t.Fatal("expected status.pipelineSpec.tasks[0].taskSpec to be set")
+	}
+	if d := got.Tasks[0].TaskSpec.Description; d != "" {
+		t.Errorf("status.pipelineSpec.tasks[0].taskSpec.description = %q, want empty", d)
+	}
+}
+
 func Test_storePipelineSpec_metadata(t *testing.T) {
 	pipelinerunlabels := map[string]string{"lbl1": "value1", "lbl2": "value2"}
 	pipelinerunannotations := map[string]string{"io.annotation.1": "value1", "io.annotation.2": "value2"}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -787,6 +787,10 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1.TaskRun, rtr *resourc
 		return err
 	}
 	tr.Status.TaskSpec = ts
+	// ts is already a deep copy, so strip in place; this assignment overwrites the snapshot stored in prepare.
+	if !config.FromContextOrDefaults(ctx).FeatureFlags.KeepStatusSpecDescriptions {
+		tr.Status.TaskSpec.StripDescriptions()
+	}
 
 	if len(tr.Status.TaskSpec.Steps) > 0 {
 		logger.Debugf("set taskspec for %s/%s - script: %s", tr.Namespace, tr.Name, tr.Status.TaskSpec.Steps[0].Script)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -1300,14 +1300,12 @@ func applyVolumeClaimTemplates(workspaceBindings []v1.WorkspaceBinding, owner me
 func storeTaskSpecAndMergeMeta(ctx context.Context, tr *v1.TaskRun, ts *v1.TaskSpec, meta *resolutionutil.ResolvedObjectMeta) error {
 	// Only store the TaskSpec once, if it has never been set before.
 	if tr.Status.TaskSpec == nil {
-		// Strip documentation-only descriptions from the status snapshot to reduce etcd usage, unless opted out. See #10321.
-		if config.FromContextOrDefaults(ctx).FeatureFlags.KeepStatusSpecDescriptions {
-			tr.Status.TaskSpec = ts
-		} else {
-			stripped := ts.DeepCopy()
-			stripped.StripDescriptions()
-			tr.Status.TaskSpec = stripped
+		// Snapshot the spec, stripping documentation-only descriptions to reduce etcd usage unless opted out. See #10321.
+		snapshot := ts.DeepCopy()
+		if !config.FromContextOrDefaults(ctx).FeatureFlags.KeepStatusSpecDescriptions {
+			snapshot.StripDescriptions()
 		}
+		tr.Status.TaskSpec = snapshot
 		if meta == nil {
 			return nil
 		}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -787,9 +787,11 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1.TaskRun, rtr *resourc
 		return err
 	}
 	tr.Status.TaskSpec = ts
-	// ts is already a deep copy, so strip in place; this assignment overwrites the snapshot stored in prepare.
+	// strip a copy: ts stays live for the rest of the reconcile and is handed to createPod
 	if !config.FromContextOrDefaults(ctx).FeatureFlags.KeepStatusSpecDescriptions {
-		tr.Status.TaskSpec.StripDescriptions()
+		statusSpec := ts.DeepCopy()
+		statusSpec.StripDescriptions()
+		tr.Status.TaskSpec = statusSpec
 	}
 
 	if len(tr.Status.TaskSpec.Steps) > 0 {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -1300,7 +1300,14 @@ func applyVolumeClaimTemplates(workspaceBindings []v1.WorkspaceBinding, owner me
 func storeTaskSpecAndMergeMeta(ctx context.Context, tr *v1.TaskRun, ts *v1.TaskSpec, meta *resolutionutil.ResolvedObjectMeta) error {
 	// Only store the TaskSpec once, if it has never been set before.
 	if tr.Status.TaskSpec == nil {
-		tr.Status.TaskSpec = ts
+		// Strip documentation-only descriptions from the status snapshot to reduce etcd usage, unless opted out. See #10321.
+		if config.FromContextOrDefaults(ctx).FeatureFlags.KeepStatusSpecDescriptions {
+			tr.Status.TaskSpec = ts
+		} else {
+			stripped := ts.DeepCopy()
+			stripped.StripDescriptions()
+			tr.Status.TaskSpec = stripped
+		}
 		if meta == nil {
 			return nil
 		}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -6009,10 +6009,13 @@ spec:
 		Description: "bar-task",
 	}
 
+	// descriptions are stripped from the status snapshot by default (#10321)
+	strippedTS := ts.DeepCopy()
+	strippedTS.StripDescriptions()
 	want := tr.DeepCopy()
 	want.Status = v1.TaskRunStatus{
 		TaskRunStatusFields: v1.TaskRunStatusFields{
-			TaskSpec: ts.DeepCopy(),
+			TaskSpec: strippedTS,
 			Provenance: &v1.Provenance{
 				RefSource:    refSource.DeepCopy(),
 				FeatureFlags: config.DefaultFeatureFlags.DeepCopy(),
@@ -6081,6 +6084,42 @@ spec:
 			}
 			if d := cmp.Diff(tc.wantTaskRun, tr); d != "" {
 				t.Fatal(diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func Test_storeTaskSpec_stripsDescriptions(t *testing.T) {
+	ts := &v1.TaskSpec{
+		Description: "task desc",
+		Params:      v1.ParamSpecs{{Name: "p", Description: "param desc"}},
+		Results:     []v1.TaskResult{{Name: "r", Description: "result desc"}},
+		Workspaces:  []v1.WorkspaceDeclaration{{Name: "w", Description: "ws desc"}},
+	}
+
+	tests := []struct {
+		name         string
+		keep         bool
+		wantStripped bool
+	}{
+		{name: "default strips descriptions", keep: false, wantStripped: true},
+		{name: "opt-out keeps descriptions", keep: true, wantStripped: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := config.ToContext(t.Context(), &config.Config{
+				FeatureFlags: &config.FeatureFlags{KeepStatusSpecDescriptions: tc.keep},
+			})
+			tr := &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+			if err := storeTaskSpecAndMergeMeta(ctx, tr, ts.DeepCopy(), nil); err != nil {
+				t.Fatalf("storeTaskSpecAndMergeMeta error = %v", err)
+			}
+			got := tr.Status.TaskSpec.Description
+			if tc.wantStripped && got != "" {
+				t.Errorf("expected description stripped, got %q", got)
+			}
+			if !tc.wantStripped && got != "task desc" {
+				t.Errorf("expected description retained, got %q", got)
 			}
 		})
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -6125,6 +6125,106 @@ func Test_storeTaskSpec_stripsDescriptions(t *testing.T) {
 	}
 }
 
+// Regression test: the stored snapshot is overwritten later in reconcile, so stripping must survive a full cycle.
+func TestReconcile_StripsStatusTaskSpecDescriptions(t *testing.T) {
+	stepAction := parse.MustParseV1beta1StepAction(t, `
+metadata:
+  name: stepAction
+  namespace: foo
+spec:
+  image: myImage
+  command: ["ls"]
+`)
+	stepActionBytes, err := yaml.Marshal(stepAction)
+	if err != nil {
+		t.Fatal("failed to marshal StepAction", err)
+	}
+
+	tests := []struct {
+		name string
+		keep string
+	}{
+		{name: "default strips descriptions", keep: "false"},
+		{name: "opt-out keeps descriptions", keep: "true"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := parse.MustParseV1TaskRun(t, `
+metadata:
+  name: test-task-run-strip-descriptions
+  namespace: foo
+spec:
+  taskSpec:
+    description: task desc
+    params:
+    - name: p
+      type: string
+      default: v
+      description: param desc
+    results:
+    - name: r
+      description: result desc
+    workspaces:
+    - name: w
+      optional: true
+      description: ws desc
+    steps:
+    - name: remote
+      ref:
+        resolver: bar
+`)
+			stepActionReq := getResolvedResolutionRequest(t, "bar", stepActionBytes, tr.Namespace, tr.Name)
+			d := test.Data{
+				TaskRuns: []*v1.TaskRun{tr},
+				ConfigMaps: []*corev1.ConfigMap{{
+					ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+					Data:       map[string]string{"keep-status-spec-descriptions": tc.keep},
+				}},
+				ResolutionRequests: []*resolutionv1beta1.ResolutionRequest{&stepActionReq},
+			}
+
+			testAssets, cancel := getTaskRunController(t, d)
+			defer cancel()
+			createServiceAccount(t, testAssets, "default", tr.Namespace)
+			if err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, fmt.Sprintf("%s/%s", tr.Namespace, tr.Name)); controller.IsPermanentError(err) {
+				t.Fatalf("Not expected permanent error but got %v", err)
+			}
+			reconciledRun, err := testAssets.Clients.Pipeline.TektonV1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("getting reconciled run: %v", err)
+			}
+
+			ts := reconciledRun.Status.TaskSpec
+			if ts == nil {
+				t.Fatal("expected status.taskSpec to be set after reconcile")
+			}
+			// want returns the original description only when the opt-out flag is set.
+			want := func(original string) string {
+				if tc.keep == "true" {
+					return original
+				}
+				return ""
+			}
+			for _, f := range []struct {
+				field, got, original string
+			}{
+				{"description", ts.Description, "task desc"},
+				{"params[0].description", ts.Params[0].Description, "param desc"},
+				{"results[0].description", ts.Results[0].Description, "result desc"},
+				{"workspaces[0].description", ts.Workspaces[0].Description, "ws desc"},
+			} {
+				if f.got != want(f.original) {
+					t.Errorf("status.taskSpec.%s = %q, want %q", f.field, f.got, want(f.original))
+				}
+			}
+			// The overwrite at the end of reconcile must still carry the resolved StepAction.
+			if len(ts.Steps) != 1 || ts.Steps[0].Image != "myImage" {
+				t.Errorf("expected resolved StepAction image in status.taskSpec.steps, got %+v", ts.Steps)
+			}
+		})
+	}
+}
+
 func Test_storeTaskSpec_metadata(t *testing.T) {
 	taskrunlabels := map[string]string{"lbl1": "value1", "lbl2": "value2"}
 	taskrunannotations := map[string]string{"io.annotation.1": "value1", "io.annotation.2": "value2"}


### PR DESCRIPTION
# Changes

Strip documentation-only `description` fields from the resolved spec snapshots stored in `status.taskSpec` and `status.pipelineSpec`.

When Tekton resolves a Task or Pipeline it snapshots the full spec into the object's status. That snapshot includes `description` fields on params, results, workspaces, step results, pipeline tasks, inline embedded task specs
and the spec itself. The controller never reads these during execution, yet etcd stores a full copy of the object per revision, so the bytes are amplified 10-20x over a run's lifecycle (see #10321 for measured impact on tektoncd/catalog and konflux-ci/build-definitions).

This PR:

- Adds `StripDescriptions()` helpers on `v1.TaskSpec` and `v1.PipelineSpec` (recursing into `PipelineTask` and inline `EmbeddedTask` specs) that clear the documentation-only `description` fields.
- Applies them when populating the status snapshot in `storeTaskSpecAndMergeMeta` and `storePipelineSpecAndMergeMeta`. The resolved spec is deep-copied before stripping, so the in-memory spec the rest of the reconcile uses (e.g. pod creation) is unaffected, and the original Task/Pipeline objects keep their descriptions.
- Adds a `keep-status-spec-descriptions` feature flag. Stripping is **on by  default**; setting the flag to `"true"` retains the descriptions in status for a migration window. This follows the maintainer guidance on #10321 (unconditional by default, opt-out flag).

## Why this is safe

The `description` fields are purely informational and are never used by the controller for any runtime decision. I verified the first-party clients do not read them off the status snapshot either:

- **tektoncd/cli**: reads only `status.PipelineSpec.Tasks` (for tracking/logs); never reads `status.TaskSpec`; `describe` templates render descriptions from the live `Spec`/`Status.Results`, not the status spec snapshot.
- **tektoncd/dashboard**: no references to `taskSpec`/`pipelineSpec` descriptions in source; the only `description` usages are i18n message catalogs.

## /kind feature

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if necessary.
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) included if necessary.
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages).
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code).
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`.
- [x] Release notes block below has been updated with any user-facing changes.
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release.

# Release Notes

```release-note
TaskRun and PipelineRun status snapshots (`status.taskSpec`/`status.pipelineSpec`) now strip documentation-only `description` fields by default to reduce etcd usage. Set the new `keep-status-spec-descriptions` feature flag to `"true"` to retain them.
```