### PR TITLE
docs: add etcd revision profiling guide and helper tool

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -20,6 +20,7 @@ channel for training and tutorials on Tekton!
   - [Resources Labeling](./resources-labelling.md): Labels applied to Tekton resources.
   - [Multi-Tenant Support](./multi-tenant-support.md): Running Tekton in multi-tenant configurations.
   - [Informer Cache Transform](../tekton-controller-performance-configuration.md#informer-cache-transform-memory-optimization): Memory optimization that strips fields from cached objects.
+  - [Profiling etcd Usage](./etcd-revision-profiling.md): Measuring the etcd revision/storage footprint of PipelineRuns.
 - [API Versioning](./api-versioning.md): How Tekton supports multiple API versions and feature gates.
 - How specific features are implemented:
   - [Results](./results-lifecycle.md)

--- a/docs/developers/etcd-revision-profiling.md
+++ b/docs/developers/etcd-revision-profiling.md
@@ -1,0 +1,330 @@
+<!--
+---
+linkTitle: "Profiling etcd Usage"
+weight: 1000
+---
+-->
+# Understanding and profiling etcd usage
+
+This guide explains how a Tekton workload consumes etcd storage, and how to
+measure that consumption for your own pipelines. It is aimed at operators and
+platform builders doing capacity planning or chasing etcd pressure.
+
+- [Why etcd cost is more than the object size](#why-etcd-cost-is-more-than-the-object-size)
+- [The key primitive: per-object revision count](#the-key-primitive-per-object-revision-count)
+- [How Tekton objects are laid out in etcd](#how-tekton-objects-are-laid-out-in-etcd)
+- [Profiling a single object](#profiling-a-single-object)
+- [Attributing revisions to controllers](#attributing-revisions-to-controllers)
+- [Profiling a whole PipelineRun](#profiling-a-whole-pipelinerun)
+- [Estimating total etcd cost](#estimating-total-etcd-cost)
+- [Caveats](#caveats)
+
+## Why etcd cost is more than the object size
+
+etcd is an MVCC store: every write to a key creates a new revision that holds a
+full copy of the value. Between [compaction](https://etcd.io/docs/latest/op-guide/maintenance/#history-compaction)
+cycles, all of those revisions occupy storage. A single TaskRun may be written
+10-20 times over its lifecycle as multiple controllers update it (the Pipelines
+controller, plus Chains, Results, and platform controllers), so its real etcd
+footprint is many times the size of its "live" snapshot.
+
+The dominant factor is usually revision count, not object size. A small object
+that is rewritten thousands of times can cost far more than a large object
+written once. For example, on a quiet single-node cluster the `Node` object is
+only ~20 KB but has accumulated 2028 revisions from status heartbeats, while a
+13 KB ConfigMap written once sits at a single revision.
+
+## The key primitive: per-object revision count
+
+Every key in etcd carries a `version` field: it starts at 1 when the key is
+created and increments on every write. So `version` is the number of revisions
+the object has accumulated since creation, which is the quantity you want when
+reasoning about etcd cost.
+
+You can read it with `etcdctl`. From a kubeadm control-plane node:
+
+```bash
+ETCDCTL_API=3 etcdctl \
+  --endpoints=https://127.0.0.1:2379 \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt \
+  --key=/etc/kubernetes/pki/etcd/healthcheck-client.key \
+  get /registry/minions/<node-name> -w fields | grep -E '^"(CreateRevision|ModRevision|Version)"'
+```
+
+```
+"CreateRevision" : 6
+"ModRevision" : 1761674
+"Version" : 2028
+```
+
+`CreateRevision`/`ModRevision` are global logical clocks (the same counter for
+the whole store); `Version` is per-key and is the one to track.
+
+## How Tekton objects are laid out in etcd
+
+The apiserver stores each object under a `/registry/...` key:
+
+| Object | Group | etcd key |
+| --- | --- | --- |
+| PipelineRun | `tekton.dev` | `/registry/tekton.dev/pipelineruns/<ns>/<name>` |
+| TaskRun | `tekton.dev` | `/registry/tekton.dev/taskruns/<ns>/<name>` |
+| Pod | core | `/registry/pods/<ns>/<name>` |
+| Event | core | `/registry/events/<ns>/<name>` |
+
+The group segment is not simply the API group. Resources served by
+CustomResourceDefinitions, Tekton's included, are stored under their group
+(`/registry/<group>/<resource>/<ns>/<name>`). Most groups compiled into the
+apiserver instead register a bare per-resource prefix, so Deployments live at
+`/registry/deployments/<ns>/<name>` and not under `/registry/apps/`, and the
+same goes for `leases`, `clusterroles` and the rest. The exceptions run both
+ways: `apiextensions.k8s.io` and `apiregistration.k8s.io` are compiled in and
+still keep their group, `Node` is stored at `/registry/minions/<name>`, and
+Services are split across `/registry/services/specs/` and
+`/registry/services/endpoints/`.
+
+So derive keys only for Tekton's own resources, Pods and Events. For anything
+else, ask etcd rather than guessing.
+
+List the keys for a namespace to see the layout directly:
+
+```bash
+etcdctl ... get /registry/tekton.dev/ --prefix --keys-only
+```
+
+## Profiling a single object
+
+`version` plus the current value size already tells you most of the story:
+
+```bash
+# revision count: writes to the key since it was created
+etcdctl ... get /registry/tekton.dev/taskruns/<ns>/<name> -w json | jq '.kvs[0].version'
+# current value size: decode the value out of the JSON, since --print-value-only
+# adds a trailing newline that wc would count
+etcdctl ... get /registry/tekton.dev/taskruns/<ns>/<name> -w json \
+  | jq -r '.kvs[0].value' | base64 -d | wc -c
+```
+
+The helper in [`hack/etcd-revision-profile`](../../hack/etcd-revision-profile)
+wraps this:
+
+```bash
+go run ./hack/etcd-revision-profile -etcd-key /registry/minions/<node-name>
+```
+
+```
+/registry/minions/<node-name>
+  revisions (version): 2028
+  current value bytes: 20243
+```
+
+## Attributing revisions to controllers
+
+To find *which* controller is driving the writes, look at `managedFields`. It
+records who currently manages each field and when they last did so. It is not a
+write history: entries change as field ownership moves between managers, and a
+manager that has stopped owning a field disappears from it. `kubectl` hides the
+section unless asked for it.
+
+```bash
+kubectl get taskrun <name> -n <ns> -o json --show-managed-fields \
+  | jq '[.metadata.managedFields[] | {manager, operation, subresource, time}]'
+```
+
+For per-write attribution (who issued each write), enable the apiserver
+[audit log](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/) at
+`Metadata` level for `taskruns`/`pipelineruns` and count `create`, `update` and
+`patch` events grouped by `user.username`. `Metadata` records the user, verb,
+resource and timestamp without the request and response bodies, which is enough
+for attribution and avoids logging object contents. `managedFields` shows the
+set of writers and their last write; the audit log shows the full history.
+
+Count the create as well as the updates: a key's `version` is 1 the moment it is
+created and rises by one per write after that, so the number an audit log has to
+account for is `version`, not `version - 1`.
+
+Audit entries are API requests, not confirmed etcd writes: a request can be
+rejected by admission, fail on conflict, be a dry run, or be short-circuited by
+the reconciler before it reaches storage. Filter to `ResponseComplete` with a
+success status, and treat the count as a close upper bound on writes.
+
+## Profiling a whole PipelineRun
+
+To see the aggregate footprint of a PipelineRun, its TaskRuns, their Pods and
+the Events for all of those, use the helper with `-pipelinerun`:
+
+```bash
+go run ./hack/etcd-revision-profile -n <ns> -pipelinerun <name>
+```
+
+```
+etcd revision profile for PipelineRun default/etcd-demo-wl52g (discovered keys read at revision 11677152)
+
+KIND           NAME                                          REVISIONS     CURRENT(B) EST-WRITE-BYTES(B)
+Event          etcd-demo-wl52g-build-pod.18c7aeb5ac278b09            1            614                614
+Event          etcd-demo-wl52g-build-pod.18c7aeb5fa5c96c3            1            580                580
+Event          etcd-demo-wl52g-build-pod.18c7aeb60c8f433d            1            835                835
+        ... 62 more Event rows omitted from this excerpt ...
+PipelineRun    etcd-demo-wl52g                                       6           3029              18174
+Pod            etcd-demo-wl52g-build-pod                            13          10725             139425
+Pod            etcd-demo-wl52g-package-pod                          13          10729             139477
+Pod            etcd-demo-wl52g-test-pod                             13          10721             139373
+TaskRun        etcd-demo-wl52g-build                                 9           3326              29934
+TaskRun        etcd-demo-wl52g-package                               9           3334              30006
+TaskRun        etcd-demo-wl52g-test                                  9           3321              29889
+
+KIND            COUNT  REVISIONS     CURRENT(B) EST-WRITE-BYTES(B)
+Event              65         70          41081              44031
+PipelineRun         1          6           3029              18174
+Pod                 3         39          32175             418275
+TaskRun             3         27           9981              89829
+------------------------------------------------------------------
+TOTAL              72        142          86266             570309
+
+estimated rewrite multiple (est-write-bytes / current-bytes): 6.6x
+```
+
+The per-object rows are the point: they say *which* TaskRun or Pod is driving
+the writes, which a per-Kind total hides. Only three of the 65 Event rows are
+shown above; the tool prints them all.
+
+The figures are from a real three-task sequential pipeline, profiled right after
+it finished so its Events were still alive. Each TaskRun was written nine times
+and each Pod thirteen, so the bytes written over their lives run to several
+times the live snapshot; a production pipeline with tens of TaskRuns multiplies
+that further. Events dominate the object count and barely register in bytes:
+they are written about once each, which is what pulls the overall multiple down
+to 6.6x. Profile the same run an hour later, after the Events expire, and the
+remaining objects alone come out around twice that.
+
+The helper does not use labels at all. They are mutable, can be copied onto an
+unrelated object, and the UID one only exists from Tekton v0.63, so a child
+whose labels were stripped would be missing from a report that still called
+itself complete. It lists the namespace's TaskRuns and Pods and keeps those whose
+controller owner reference points at this PipelineRun, or at one of its
+accepted TaskRuns for Pods. Tekton's own reconciler settles membership the same
+way when it rebuilds a run's child references, which is how it leaves out
+TaskRuns a custom task created for itself. Owning is also what rejects objects
+orphaned by an earlier run that used this name.
+An object this run does not own is not one of its children rather than
+something withheld from the count, so nothing is reported about it. Events are
+found by `involvedObject.uid` on the accepted objects.
+
+The PipelineRun is read first and the store-wide revision that read was served
+at is reused for every other key, so every value in the table comes from the same
+revision rather than from a rolling read that other controllers can write into
+halfway through. That revision is printed in the header. The set of rows is
+still whatever the API returned during discovery, which happens first, so an
+object created in between exists at that revision without appearing in the row
+set. The listing taken after the reads catches those: anything this run owns
+that was not read is looked up at the pinned revision, and reported as not
+counted if it was already there. One created after that revision is correctly
+absent and is not reported. If the PipelineRun's own key is gone, or now holds a
+different UID, the helper stops instead of reporting the leftovers.
+
+Once every key has been read, the identity of each object the profile actually
+counted is confirmed again through the API. An object whose identity cannot be
+confirmed is left out of the rows and the totals rather than reported under the
+identity it was discovered as, and if that object is the PipelineRun itself the
+run stops, since nothing else in the report could then be attributed to it. Objects already reported as missing
+are left out of that check: they are expected to look replaced, and rechecking
+them would turn a result `-allow-partial` exists to accept into a hard failure. That listing carries no label
+selector, for the same reason discovery does not: labels are mutable and prove
+nothing about identity. Both the UID and the
+controller owner are compared, so an object that kept its UID but was
+re-parented is caught as well. A name that has simply disappeared is fine: it
+was measured at the pinned revision and those figures still describe it. This
+check does not read stored values, so it is the one that still works where
+encryption at rest leaves no readable UID to compare. That also decides what a
+vanished name means: with `-verify-uid` on, the stored value already confirmed
+the generation and the figures stand, but with it off nothing did, so the run
+stops rather than attribute unconfirmed figures.
+
+Objects are read under the apiserver's `--etcd-prefix`, which defaults to
+`/registry`. Pass `-etcd-prefix` if the cluster sets a different one.
+
+What the helper does not cover: CustomRuns, child PipelineRuns from
+Pipelines-in-Pipelines, PVCs, and Affinity Assistant StatefulSets. It does
+report the CustomRuns and child PipelineRuns a run owns, so a pipeline built out
+of them is not mistaken for one with no children; they are owned the same way as
+TaskRuns and could be profiled the same way if that is worth doing. Whatever a
+custom task's own controller creates downstream stays opaque, since nothing ties
+it back to the PipelineRun.
+
+## Estimating total etcd cost
+
+Adding up the sizes of *every* revision means replaying the writes themselves,
+which is what etcd's watch stream from an uncompacted revision gives you: one
+event per PUT, each carrying that write's own value. Point-in-time reads cannot
+do it, because `etcdctl get --rev=<n>` returns whatever the key held at global
+revision `n`, so stepping `n` forward returns the same value again and again
+whenever some other key was what changed. Even a perfect sum of those payloads
+is not the backend cost, which also carries MVCC metadata, keys, index and page
+overhead. As a cheap estimate,
+the helper reports `EST-WRITE-BYTES = Σ (version × current_size)`, i.e. it assumes
+each revision was about the size of the current one. This over-counts objects
+that grew over time and under-counts objects that shrank, but it is a good
+first-order signal for "where is my etcd budget going".
+
+The `estimated rewrite multiple` (estimated write bytes ÷ current bytes) summarizes how many times over each object has been rewritten. Read it
+as write volume, not as bytes etcd is holding now: compaction keeps the
+current revision of every live key indefinitely and discards the superseded
+ones, so with the default 5 minute interval most of the history counted here is
+already gone.
+
+## Caveats
+
+- Compaction resets the picture. Revisions older than the last compaction are
+  gone; `version` keeps counting but the storage they used has been reclaimed.
+  The apiserver compacts every 5 minutes by default
+  (`--etcd-compaction-interval`), so for anything but a very short run most of
+  the history counted here is no longer stored. Compaction also does not return
+  space to the filesystem on its own, which needs a defragmentation. Size the
+  cluster from `etcd_mvcc_db_total_size_in_bytes`, the physical backend size
+  the space quota and the `NOSPACE` alarm act on;
+  `etcd_mvcc_db_total_size_in_use_in_bytes` excludes free pages, so the gap
+  between the two is what a defragmentation would give back.
+- The profile is a live-key snapshot. Discovery lists what the API server can
+  still see, so objects already deleted or garbage collected are absent even
+  when their revisions have not been compacted yet. Events matter most here:
+  they default to a one hour TTL, so run the helper soon after the PipelineRun
+  finishes. Objects that disappear between discovery and the etcd read are
+  reported on stderr as skipped, and the profile says how many were lost.
+- Values may be encrypted at rest. With an
+  [EncryptionConfiguration](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
+  the etcd value is ciphertext, so the size is meaningful but it is not the
+  decoded object.
+- Some built-in resources use a legacy key. `Node` lives at
+  `/registry/minions/`; if a lookup returns "not found", list the prefix with
+  `--prefix --keys-only` to find the real key.
+- Reading etcd needs root, since the client keys under
+  `/etc/kubernetes/pki/etcd/` are root-only. Run `etcdctl` and the helper with
+  `sudo`. The helper wraps its own `etcdctl` calls in `sudo` by default;
+  disable that with `-sudo=false` if `etcdctl` can already read the keys.
+- One endpoint reaches one etcd cluster. `kube-apiserver` can route individual
+  resources elsewhere with `--etcd-servers-overrides`, most often to keep
+  Events off the main cluster (`/events#https://etcd-events:2379`). Aggregate
+  mode does not support that: it takes a single `-endpoints`, and every object
+  of an overridden resource is reported as missing. Running it a second time
+  against the other endpoint does not help either, because the PipelineRun it
+  anchors on does not live there, and revisions are local to a cluster so the
+  two runs could not be combined anyway. Check the apiserver flags first; for an
+  overridden resource, inspect individual keys with `-etcd-key` against its own
+  endpoint. The override applies only to resources compiled into the apiserver,
+  so it never moves Tekton's own objects, only Pods and Events.
+- Storage keys hold names, not UIDs, so a name deleted and recreated between
+  discovery and the read would otherwise be counted as the object that was
+  discovered. The helper compares the UID it discovered against the stored
+  value and skips the object when they differ. Encrypted values carry no
+  plaintext UID and would all fail that check, so pass `-verify-uid=false`
+  on a cluster using encryption at rest.
+- Ownership, not labels, decides what belongs to a run, so objects orphaned by
+  `kubectl delete pipelinerun <name> --cascade=orphan` are not attributed to a
+  later run that reuses the name, and a child whose labels were stripped is
+  still counted. It also means a run whose objects straddle a Tekton upgrade is
+  found whole, without depending on the `tekton.dev/pipelineRunUID` label that
+  only exists from v0.63.
+- The pinned revision has to survive the run. The apiserver compacts every 5
+  minutes by default, so on a very large PipelineRun the reads can outlast it;
+  etcd then rejects the remaining gets and the helper stops rather than
+  silently mixing revisions.

--- a/hack/etcd-revision-profile/README.md
+++ b/hack/etcd-revision-profile/README.md
@@ -1,0 +1,62 @@
+# etcd-revision-profile
+
+A profiling helper that reports how often each of a PipelineRun's keys has been written and how large it is: how
+many revisions and bytes its PipelineRun, TaskRuns, their Pods, and the Events
+for all of those have accumulated in etcd, per object and summarised by kind.
+
+Membership is decided by the controller owner reference rather than by labels,
+which are mutable: a child whose labels were stripped is still found, an object
+carrying this run's labels but owned by something else is not counted, and a
+PipelineRun reusing a deleted run's name does not inherit its objects.
+Every key is read at the revision the PipelineRun's own read was served at, so
+every value comes from the same revision. Afterwards each measured object's UID
+and controller owner are confirmed again through the API, listing without a
+label selector so a same-name replacement cannot hide by dropping its labels.
+
+CustomRuns, child PipelineRuns, PVCs and Affinity Assistant StatefulSets are
+not included. Only objects the API server can still list are profiled, so run
+it soon after the PipelineRun finishes: Events expire after an hour by default.
+
+It is an operator tool, not part of the Tekton control plane. See
+[docs/developers/etcd-revision-profiling.md](../../docs/developers/etcd-revision-profiling.md)
+for the concepts and methodology.
+
+## Usage
+
+Run from a control-plane node (etcd client keys are root-only, so `etcdctl`
+runs via `sudo` by default):
+
+```bash
+# Whole PipelineRun (PipelineRun + TaskRuns + Pods + Events)
+go run ./hack/etcd-revision-profile -n <namespace> -pipelinerun <name>
+
+# A single raw etcd key
+go run ./hack/etcd-revision-profile -etcd-key /registry/minions/<node-name>
+```
+
+Flags: `-kubectl`, `-etcdctl` (binary paths), `-endpoints`, `-cacert`, `-cert`,
+`-key` (etcd client TLS), `-sudo` (default true), `-etcd-prefix` (the
+apiserver's `--etcd-prefix`, default `/registry`), `-verify-uid` (default true;
+turn off when values are encrypted at rest), `-allow-partial`.
+
+Output on stderr is split by what it means. `note:` lines are things worth
+knowing that do not affect the numbers, such as CustomRuns or child PipelineRuns
+this run owns but the helper does not profile. `missing:` lines are objects that
+could not be measured, and the run exits non-zero unless `-allow-partial` is
+passed.
+
+## Design
+
+The pure analysis lives in `profile.go`: etcd key layout (`etcdKeyFor`),
+`etcdctl ... -w json` parsing (`parseEtcdGetJSON`), and aggregation
+(`aggregate`). It is unit-tested in `profile_test.go` and `wiring_test.go` with
+no cluster required.
+
+`main.go` is the thin `kubectl`/`etcdctl` shell. It runs the same commands an
+operator would run by hand, which keeps the helper free of client libraries.
+The exec calls go through a `commandRunner` seam, so the discovery and
+argument-building logic is covered by `main_test.go` with a fake runner.
+
+```bash
+go test ./hack/etcd-revision-profile/
+```

--- a/hack/etcd-revision-profile/main.go
+++ b/hack/etcd-revision-profile/main.go
@@ -1,0 +1,736 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command etcd-revision-profile reports, for a single PipelineRun and the
+// TaskRuns, Pods and Events belonging to it, how many times each key has been
+// written, how large its current stored value is, and an estimate of the
+// serialized bytes written over its life.
+//
+// It is a profiling helper for operators, not part of the Tekton control plane.
+// The pure analysis (key layout, etcdctl JSON parsing, aggregation) lives in
+// profile.go and is unit-tested; this file is the thin kubectl/etcdctl shell.
+//
+// Usage:
+//
+//	etcd-revision-profile -n <namespace> -pipelinerun <name> [etcd flags]
+//
+// etcd flags default to a kubeadm control-plane node's local endpoint and
+// client certificates; -sudo runs etcdctl via sudo because those keys are
+// root-only.
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var errNotFound = errors.New("key not found in etcd")
+
+// listJSONPath prints one tab-separated name, UID, and controller owner kind
+// and UID per listed object. The owner is what establishes membership.
+const listJSONPath = "jsonpath={range .items[*]}{.metadata.name}{\"\\t\"}{.metadata.uid}" +
+	"{\"\\t\"}{.metadata.ownerReferences[?(@.controller==true)].kind}" +
+	"{\"\\t\"}{.metadata.ownerReferences[?(@.controller==true)].uid}" +
+	"{\"\\t\"}{.involvedObject.uid}{\"\\n\"}{end}"
+
+// profiledRef is one object to profile, tagged with the Kind to group it under
+// and the UID its Events refer back to.
+type profiledRef struct {
+	Kind        string
+	UID         string
+	OwnerKind   string
+	OwnerUID    string
+	InvolvedUID string
+	Ref         objectRef
+}
+
+// objectLister discovers the object set belonging to a PipelineRun, along with
+// notes on how it decided what belongs. The PipelineRun itself must come first:
+// it anchors the report and its read fixes the revision the rest are read at.
+type objectLister interface {
+	list(ctx context.Context, namespace, pipelineRun string) ([]profiledRef, []string, error)
+	// recheck confirms the API still serves the same generation of every
+	// profiled object, so a name reused mid-run cannot be counted as the
+	// object discovery found.
+	recheck(ctx context.Context, namespace, pipelineRun string, discovered, measured []profiledRef, storedUIDVerified bool) (recheckResult, error)
+}
+
+// diagnostics separates what is worth knowing from what is missing. Only the
+// latter should make a caller distrust the numbers.
+type diagnostics struct {
+	Info       []string
+	Incomplete []string
+}
+
+func (d diagnostics) complete() bool { return len(d.Incomplete) == 0 }
+
+// etcdGetter returns the etcd footprint of a single storage key. A rev of 0
+// reads the current value; anything else reads the key as of that store-wide
+// revision.
+type etcdGetter interface {
+	get(ctx context.Context, key string, rev int64) (etcdObject, error)
+}
+
+// buildProfile resolves every discovered object to its etcd key, fetches its
+// revision footprint, and aggregates the result. It returns a warning for each
+// thing that left the profile incomplete: an object deleted before it could be
+// read, and a key that no longer holds the object discovery found. Discovery's
+// own notes come back separately in Info and do not make the profile
+// incomplete. Any other getter error aborts so we never report a misleading
+// partial result.
+//
+// etcd keys are built from names, not UIDs, so an object deleted and recreated
+// under the same name between discovery and the read would otherwise be counted
+// as the object we set out to profile. verifyUID rejects those by checking the
+// stored value still carries the UID discovery saw.
+func buildProfile(ctx context.Context, l objectLister, g etcdGetter, prefix, namespace, pipelineRun string, verifyUID bool) (profile, diagnostics, error) {
+	refs, info, err := l.list(ctx, namespace, pipelineRun)
+	d := diagnostics{Info: info}
+	if err != nil {
+		return profile{}, d, fmt.Errorf("discovering objects: %w", err)
+	}
+	if len(refs) == 0 {
+		return profile{}, d, errors.New("discovery returned no objects")
+	}
+
+	// The PipelineRun anchors the whole report, so read it first and insist on
+	// it. If its key is gone or now holds another generation there is nothing
+	// left to attribute the children to. Its read also fixes the revision every
+	// other key is read at, so the rows all describe one point in time rather
+	// than whatever each key happened to hold when it was reached.
+	root := refs[0]
+	if root.Kind != kindPipelineRun || root.Ref.Name != pipelineRun {
+		return profile{}, d, fmt.Errorf("discovery did not put %s %s/%s first; the anchor and the pinned revision would come from %s %s",
+			kindPipelineRun, namespace, pipelineRun, root.Kind, root.Ref.Name)
+	}
+	rootKey := etcdKeyFor(prefix, root.Ref)
+	rootObj, err := g.get(ctx, rootKey, 0)
+	if err != nil {
+		return profile{}, d, fmt.Errorf("reading %s %s (%s): %w", root.Kind, root.Ref.Name, rootKey, err)
+	}
+	if verifyUID && root.UID != "" && !rootObj.holdsUID(root.UID) {
+		return profile{}, d, fmt.Errorf("%s %s no longer holds UID %s, so it was replaced during profiling; if values are encrypted at rest, pass -verify-uid=false",
+			root.Kind, rootKey, root.UID)
+	}
+	rev := rootObj.headerRevision
+
+	objs := []etcdObject{annotate(rootObj, root)}
+	// Recheck only what the profile actually counted. A child skipped as
+	// incomplete is expected to look replaced, and rechecking it would turn a
+	// result -allow-partial exists to accept back into a fatal error.
+	measured := []profiledRef{root}
+	for _, r := range refs[1:] {
+		key := etcdKeyFor(prefix, r.Ref)
+		o, err := g.get(ctx, key, rev)
+		switch {
+		case errors.Is(err, errNotFound):
+			d.Incomplete = append(d.Incomplete, fmt.Sprintf("skipped %s %s/%s: no key %s at revision %d; it was deleted, or this resource lives in another etcd cluster",
+				r.Kind, r.Ref.Namespace, r.Ref.Name, key, rev))
+			continue
+		case err != nil:
+			return profile{}, d, fmt.Errorf("reading %s %s (%s): %w", r.Kind, r.Ref.Name, key, err)
+		}
+		if verifyUID && r.UID != "" && !o.holdsUID(r.UID) {
+			d.Incomplete = append(d.Incomplete, fmt.Sprintf("skipped %s %s/%s: %s no longer holds UID %s, so it was replaced after discovery; if values are encrypted at rest, pass -verify-uid=false",
+				r.Kind, r.Ref.Namespace, r.Ref.Name, key, r.UID))
+			continue
+		}
+		objs = append(objs, annotate(o, r))
+		measured = append(measured, r)
+	}
+
+	// The stored-value check cannot see through encryption at rest, so confirm
+	// through the API that every name still resolves to the generation it was
+	// profiled as. Without this, -verify-uid=false would leave the whole report
+	// open to objects being replaced while they were being read.
+	res, err := l.recheck(ctx, namespace, pipelineRun, refs, measured, verifyUID)
+	if err != nil {
+		return profile{}, d, err
+	}
+
+	// An object whose identity could not be confirmed must not contribute
+	// figures that were just declared unattributable. Losing the anchor is
+	// worse than losing a row: nothing else in the report can be trusted to
+	// belong to this run.
+	drop := map[string]bool{}
+	for _, u := range res.Unverified {
+		if u.Kind == kindPipelineRun && u.Ref.Name == pipelineRun {
+			return profile{}, d, fmt.Errorf("%s %s/%s could not be confirmed as the object that was measured, so nothing in the report can be attributed to it",
+				u.Kind, namespace, u.Ref.Name)
+		}
+		drop[u.Kind+"/"+u.Ref.Name] = true
+		d.Incomplete = append(d.Incomplete, fmt.Sprintf("not counted: %s %s/%s was read, but its identity could not be confirmed afterwards, so its figures are left out",
+			u.Kind, namespace, u.Ref.Name))
+	}
+	if len(drop) > 0 {
+		kept := objs[:0]
+		for _, o := range objs {
+			if !drop[o.Kind+"/"+o.Name] {
+				kept = append(kept, o)
+			}
+		}
+		objs = kept
+	}
+
+	// Candidates that turned up only after the reads may or may not have
+	// existed at the pinned revision. Asking etcd at that revision is the only
+	// way to tell a genuine omission from an object created later.
+	for _, a := range res.Appeared {
+		key := etcdKeyFor(prefix, a.Ref)
+		switch _, err := g.get(ctx, key, rev); {
+		case errors.Is(err, errNotFound):
+			// Created after the revision, so rightly absent from this profile.
+		case err != nil:
+			return profile{}, d, fmt.Errorf("checking whether %s %s existed at revision %d: %w", a.Kind, a.Ref.Name, rev, err)
+		default:
+			d.Incomplete = append(d.Incomplete, fmt.Sprintf("not counted: %s %s/%s belongs to this PipelineRun and existed at revision %d, but discovery listed its children before that revision was pinned",
+				a.Kind, namespace, a.Ref.Name, rev))
+		}
+	}
+	p := aggregate(objs)
+	p.Revision = rev
+	return p, d, nil
+}
+
+// annotate copies the identity discovery established onto the read object and
+// drops the raw value, which is only needed for the UID check.
+func annotate(o etcdObject, r profiledRef) etcdObject {
+	o.Kind = r.Kind
+	o.Namespace = r.Ref.Namespace
+	o.Name = r.Ref.Name
+	o.UID = r.UID
+	o.value = nil
+	return o
+}
+
+// commandRunner runs an external command and returns its stdout (a test seam).
+type commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// execRunner runs the command, returning stdout. On failure it folds the
+// command's stderr into the error so kubectl/etcdctl problems are debuggable.
+func execRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return out, fmt.Errorf("%w: %s", err, msg)
+		}
+		return out, err
+	}
+	return out, nil
+}
+
+// splitLines turns newline-separated command output into trimmed, non-empty lines.
+func splitLines(out []byte) []string {
+	var names []string
+	for _, n := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if n = strings.TrimSpace(n); n != "" {
+			names = append(names, n)
+		}
+	}
+	return names
+}
+
+// kubectlLister discovers the object set with `kubectl`.
+type kubectlLister struct {
+	bin string
+	run commandRunner
+}
+
+// objectID is a discovered object's identity and its controller owner. Names
+// can be reused by a later object, so the UID pins it to one generation, and
+// the owner is what proves which parent it belongs to.
+type objectID struct {
+	Name      string
+	UID       string
+	OwnerKind string
+	OwnerUID  string
+	// InvolvedUID is set for Events: the object the Event is about, which is
+	// what ties it to this PipelineRun rather than an owner reference.
+	InvolvedUID string
+}
+
+// ownedBy reports whether this object is controlled by the given parent.
+func (o objectID) ownedBy(kind, uid string) bool {
+	return o.OwnerKind == kind && o.OwnerUID == uid
+}
+
+func (k kubectlLister) objects(ctx context.Context, namespace, resource string) ([]objectID, error) {
+	out, err := k.run(ctx, k.bin, "get", resource, "-n", namespace, "-o", listJSONPath)
+	if err != nil {
+		return nil, fmt.Errorf("kubectl get %s: %w", resource, err)
+	}
+	return parseListLines(out), nil
+}
+
+// parseListLines reads the tab-separated rows printed by listJSONPath.
+func parseListLines(out []byte) []objectID {
+	var ids []objectID
+	for _, line := range splitLines(out) {
+		f := strings.Split(line, "\t")
+		name := strings.TrimSpace(f[0])
+		if name == "" {
+			continue
+		}
+		id := objectID{Name: name}
+		if len(f) > 1 {
+			id.UID = strings.TrimSpace(f[1])
+		}
+		if len(f) > 2 {
+			id.OwnerKind = strings.TrimSpace(f[2])
+		}
+		if len(f) > 3 {
+			id.OwnerUID = strings.TrimSpace(f[3])
+		}
+		if len(f) > 4 {
+			id.InvolvedUID = strings.TrimSpace(f[4])
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// recheck re-reads the identities the profile was built from and fails if any
+// name now resolves to a different UID. It is the only generation check that
+// survives encryption at rest, where the stored bytes carry no readable UID.
+//
+// A name that has disappeared is not an error: the object was read at the
+// pinned revision, so those figures still describe it.
+// recheckResult is what confirming the measured objects turned up. Neither
+// field is fatal on its own: they say the numbers are short, which is what
+// -allow-partial exists to accept.
+type recheckResult struct {
+	// Appeared are objects this run owns that the profile never read. They are
+	// candidates only: discovery ran before the revision was pinned, so some
+	// existed at it and were missed, while others were created after it and are
+	// rightly absent. Reading each one at the pinned revision tells them apart.
+	Appeared []profiledRef
+	// Unverified are measured objects that vanished before their identity could
+	// be confirmed, with nothing else having established it. Their figures
+	// cannot be attributed and must not be counted.
+	Unverified []profiledRef
+}
+
+func (k kubectlLister) recheck(ctx context.Context, namespace, pipelineRun string, discovered, measured []profiledRef, storedUIDVerified bool) (recheckResult, error) {
+	// Listed the same way discovery lists, and for the same reason: labels are
+	// mutable and prove nothing about identity, so membership is settled again
+	// from the UID and the controller owner.
+	byKind := map[string]map[string]objectID{}
+	// Sorted so a failure always surfaces for the same resource first and the
+	// output can be diffed between runs.
+	resources := map[string]string{
+		kindPipelineRun: resPipelineRuns + "." + groupTektonDev,
+		kindTaskRun:     resTaskRuns + "." + groupTektonDev,
+		kindPod:         resPods,
+		kindEvent:       resEvents,
+	}
+	for _, kind := range sortedKeys(resources) {
+		resource := resources[kind]
+		found, err := k.objects(ctx, namespace, resource)
+		if err != nil {
+			return recheckResult{}, err
+		}
+		byName := make(map[string]objectID, len(found))
+		for _, o := range found {
+			byName[o.Name] = o
+		}
+		byKind[kind] = byName
+	}
+
+	res := recheckResult{}
+	var prUID string
+	for _, r := range discovered {
+		if r.Kind == kindPipelineRun && r.Ref.Name == pipelineRun {
+			prUID = r.UID
+		}
+	}
+	for _, r := range measured {
+		if r.UID == "" {
+			continue
+		}
+		now, ok := byKind[r.Kind][r.Ref.Name]
+		if !ok {
+			if !storedUIDVerified {
+				// Nothing proved which generation was measured: the stored
+				// value check is off, and the name is gone before it could be
+				// confirmed here. Objects expire routinely, Events most of all,
+				// so this makes the profile short rather than unusable.
+				res.Unverified = append(res.Unverified, r)
+			}
+			// Deleted after it was read, but the stored value confirmed the
+			// generation at the pinned revision, so those figures stand.
+			continue
+		}
+		if now.UID != r.UID {
+			return recheckResult{}, fmt.Errorf("%s %s/%s now has UID %s, not the %s it was profiled as: it was replaced while being read",
+				r.Kind, namespace, r.Ref.Name, now.UID, r.UID)
+		}
+		if r.OwnerUID != "" && (now.OwnerKind != r.OwnerKind || now.OwnerUID != r.OwnerUID) {
+			return recheckResult{}, fmt.Errorf("%s %s/%s is now controlled by %s %s, not the %s it was attributed to",
+				r.Kind, namespace, r.Ref.Name, now.OwnerKind, now.OwnerUID, r.OwnerUID)
+		}
+	}
+
+	// Discovery ran before the revision was pinned, so a child created in
+	// between exists at that revision without having been read. These listings
+	// are taken after the reads, so they can say which ones those were without
+	// costing another call.
+	res.Appeared = k.unmeasured(namespace, byKind, discovered, prUID)
+	return res, nil
+}
+
+// sortedKeys returns a map's keys in order, so iteration does not reorder
+// output or decide which of several errors is reported.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// unmeasured names the objects this PipelineRun owns that the profile did not
+// read, so a child created between discovery and the pinned read stops being a
+// silent omission. Discovered refs are excluded as well as measured ones: an
+// object that was found and then skipped is already accounted for, and would
+// otherwise be reported twice under two different explanations.
+//
+// Pod and Event ownership is resolved against every TaskRun this run owns
+// now, not only the measured ones, so a TaskRun that appeared late does not
+// hide the Pods and Events that came with it.
+func (k kubectlLister) unmeasured(namespace string, byKind map[string]map[string]objectID, discovered []profiledRef, prUID string) []profiledRef {
+	known := map[string]bool{}
+	for _, r := range discovered {
+		known[r.Kind+"/"+r.Ref.Name] = true
+	}
+
+	trUIDs := map[string]bool{}
+	for _, o := range byKind[kindTaskRun] {
+		if o.ownedBy(kindPipelineRun, prUID) {
+			trUIDs[o.UID] = true
+		}
+	}
+	mine := map[string]bool{prUID: true}
+	for uid := range trUIDs {
+		mine[uid] = true
+	}
+	for _, o := range byKind[kindPod] {
+		if o.OwnerKind == kindTaskRun && trUIDs[o.OwnerUID] {
+			mine[o.UID] = true
+		}
+	}
+
+	var missed []profiledRef
+	for name, o := range byKind[kindTaskRun] {
+		if !known[kindTaskRun+"/"+name] && o.ownedBy(kindPipelineRun, prUID) {
+			missed = append(missed, profiledRef{Kind: kindTaskRun, UID: o.UID,
+				Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: namespace, Name: name}})
+		}
+	}
+	for name, o := range byKind[kindPod] {
+		if !known[kindPod+"/"+name] && o.OwnerKind == kindTaskRun && trUIDs[o.OwnerUID] {
+			missed = append(missed, profiledRef{Kind: kindPod, UID: o.UID,
+				Ref: objectRef{Resource: resPods, Namespace: namespace, Name: name}})
+		}
+	}
+	for name, o := range byKind[kindEvent] {
+		if !known[kindEvent+"/"+name] && o.InvolvedUID != "" && mine[o.InvolvedUID] {
+			missed = append(missed, profiledRef{Kind: kindEvent, UID: o.UID, InvolvedUID: o.InvolvedUID,
+				Ref: objectRef{Resource: resEvents, Namespace: namespace, Name: name}})
+		}
+	}
+	sort.Slice(missed, func(i, j int) bool {
+		if missed[i].Kind != missed[j].Kind {
+			return missed[i].Kind < missed[j].Kind
+		}
+		return missed[i].Ref.Name < missed[j].Ref.Name
+	})
+	return missed
+}
+
+// uid reads one object's UID, which anchors the whole profile to the requested
+// generation of a name that may have been deleted and recreated.
+func (k kubectlLister) uid(ctx context.Context, namespace, resource, name string) (string, error) {
+	out, err := k.run(ctx, k.bin, "get", resource, name, "-n", namespace, "-o", "jsonpath={.metadata.uid}")
+	if err != nil {
+		return "", fmt.Errorf("kubectl get %s %s: %w", resource, name, err)
+	}
+	uid := strings.TrimSpace(string(out))
+	if uid == "" {
+		return "", fmt.Errorf("%s %s/%s returned no UID", resource, namespace, name)
+	}
+	return uid, nil
+}
+
+func (k kubectlLister) events(ctx context.Context, namespace, involvedUID string) ([]objectID, error) {
+	// An empty UID would select every Event whose involvedObject has none,
+	// which on a real cluster means unrelated Node and kubelet Events.
+	if involvedUID == "" {
+		return nil, errors.New("refusing to list events for an object with no UID")
+	}
+	out, err := k.run(ctx, k.bin, "get", resEvents, "-n", namespace,
+		"--field-selector", "involvedObject.uid="+involvedUID,
+		"-o", listJSONPath)
+	if err != nil {
+		return nil, fmt.Errorf("kubectl get events for uid %s: %w", involvedUID, err)
+	}
+	return parseListLines(out), nil
+}
+
+func (k kubectlLister) list(ctx context.Context, namespace, pipelineRun string) ([]profiledRef, []string, error) {
+	prUID, err := k.uid(ctx, namespace, resPipelineRuns+"."+groupTektonDev, pipelineRun)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pr := profiledRef{Kind: kindPipelineRun, UID: prUID, Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: namespace, Name: pipelineRun}}
+	refs := []profiledRef{pr}
+	involved := []profiledRef{pr}
+
+	taskRuns, pods, err := k.children(ctx, namespace, prUID)
+	if err != nil {
+		return nil, nil, err
+	}
+	notes := k.unsupported(ctx, namespace, pipelineRun, prUID)
+	for _, tr := range taskRuns {
+		r := profiledRef{Kind: kindTaskRun, UID: tr.UID, OwnerKind: tr.OwnerKind, OwnerUID: tr.OwnerUID, Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: namespace, Name: tr.Name}}
+		refs = append(refs, r)
+		involved = append(involved, r)
+	}
+	for _, p := range pods {
+		r := profiledRef{Kind: kindPod, UID: p.UID, OwnerKind: p.OwnerKind, OwnerUID: p.OwnerUID, Ref: objectRef{Resource: resPods, Namespace: namespace, Name: p.Name}}
+		refs = append(refs, r)
+		involved = append(involved, r)
+	}
+
+	for _, obj := range involved {
+		events, err := k.events(ctx, namespace, obj.UID)
+		if err != nil {
+			return nil, notes, err
+		}
+		for _, e := range events {
+			refs = append(refs, profiledRef{Kind: kindEvent, UID: e.UID, InvolvedUID: obj.UID, Ref: objectRef{Resource: resEvents, Namespace: namespace, Name: e.Name}})
+		}
+	}
+	return refs, notes, nil
+}
+
+// children finds the PipelineRun's TaskRuns and their Pods by controller owner
+// reference, which carries the parent's UID. Tekton's own reconciler settles
+// membership the same way when it rebuilds a run's child references, which is
+// how it leaves out TaskRuns a custom task created for itself; it compares the
+// first owner reference, while this compares the one marked as the controller
+// and its kind.
+//
+// Labels are deliberately not used to narrow the listing. They are mutable and
+// can be copied onto an unrelated object, the UID one only exists from Tekton
+// v0.63, and a child whose labels were stripped would be missing from a report
+// that still called itself complete. Listing the namespace and keeping what
+// this PipelineRun owns costs one call per resource and cannot be fooled that
+// way. It also leaves nothing to explain away: an object this run does not own,
+// the Affinity Assistant's Pod included, is simply not one of its children.
+func (k kubectlLister) children(ctx context.Context, namespace, prUID string) ([]objectID, []objectID, error) {
+	allTaskRuns, err := k.objects(ctx, namespace, resTaskRuns+"."+groupTektonDev)
+	if err != nil {
+		return nil, nil, err
+	}
+	var taskRuns []objectID
+	trUIDs := map[string]bool{}
+	for _, tr := range allTaskRuns {
+		if tr.ownedBy(kindPipelineRun, prUID) {
+			taskRuns = append(taskRuns, tr)
+			trUIDs[tr.UID] = true
+		}
+	}
+
+	allPods, err := k.objects(ctx, namespace, resPods)
+	if err != nil {
+		return nil, nil, err
+	}
+	var pods []objectID
+	for _, p := range allPods {
+		if p.OwnerKind == kindTaskRun && trUIDs[p.OwnerUID] {
+			pods = append(pods, p)
+		}
+	}
+	return taskRuns, pods, nil
+}
+
+// unsupported names the CustomRuns and child PipelineRuns this run owns, so a
+// pipeline built out of them is not reported as a tidy single row. Other owned
+// kinds, the Affinity Assistant StatefulSet and workspace PVCs among them, are
+// out of scope and not checked for. It is a note rather than a gap in the
+// numbers, so nothing here can fail the run.
+func (k kubectlLister) unsupported(ctx context.Context, namespace, pipelineRun, prUID string) []string {
+	var notes []string
+	resources := map[string]string{
+		kindCustomRun:   resCustomRuns + "." + groupTektonDev,
+		kindPipelineRun: resPipelineRuns + "." + groupTektonDev,
+	}
+	for _, kind := range sortedKeys(resources) {
+		found, err := k.objects(ctx, namespace, resources[kind])
+		if err != nil {
+			// This only feeds a note. A cluster that does not serve CustomRuns,
+			// or a caller without list rights on them, must still get its
+			// profile.
+			notes = append(notes, fmt.Sprintf("could not check for %ss this PipelineRun owns: %v", kind, err))
+			continue
+		}
+		var owned []string
+		for _, o := range found {
+			// The PipelineRun being profiled is not one of its own children,
+			// and a self-referencing owner reference is accepted by the API.
+			if o.Name == pipelineRun && kind == kindPipelineRun {
+				continue
+			}
+			if o.ownedBy(kindPipelineRun, prUID) {
+				owned = append(owned, o.Name)
+			}
+		}
+		if len(owned) > 0 {
+			sort.Strings(owned)
+			notes = append(notes, fmt.Sprintf("this PipelineRun owns %d %s(s) that the helper does not profile: %s",
+				len(owned), kind, strings.Join(owned, ", ")))
+		}
+	}
+	return notes
+}
+
+// etcdctlGetter fetches keys with `etcdctl ... get <key> -w json`.
+type etcdctlGetter struct {
+	bin       string
+	run       commandRunner
+	sudo      bool
+	endpoints string
+	cacert    string
+	cert      string
+	key       string
+}
+
+func (e etcdctlGetter) get(ctx context.Context, key string, rev int64) (etcdObject, error) {
+	name, args := e.bin, []string{
+		"--endpoints=" + e.endpoints,
+		"--cacert=" + e.cacert,
+		"--cert=" + e.cert,
+		"--key=" + e.key,
+		"get", key, "-w", "json",
+	}
+	if rev > 0 {
+		args = append(args, "--rev="+strconv.FormatInt(rev, 10))
+	}
+	if e.sudo {
+		args = append([]string{name}, args...)
+		name = "sudo"
+	}
+	out, err := e.run(ctx, name, args...)
+	if err != nil {
+		return etcdObject{}, fmt.Errorf("etcdctl get %s: %w", key, err)
+	}
+	return parseEtcdGetJSON(out, key)
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		namespace        = flag.String("n", "default", "namespace of the PipelineRun")
+		pipelineRun      = flag.String("pipelinerun", "", "name of the PipelineRun to profile (required unless -etcd-key is set)")
+		probeKey         = flag.String("etcd-key", "", "profile a single raw etcd key (e.g. /registry/minions/<node>) and exit; bypasses kubectl discovery")
+		etcdPrefix       = flag.String("etcd-prefix", defaultEtcdPrefix, "apiserver --etcd-prefix, the root under which Kubernetes objects are stored")
+		allowPartialFlag = flag.Bool("allow-partial", false, "exit successfully even when some objects could not be measured")
+		verifyUID        = flag.Bool("verify-uid", true, "skip objects whose stored value no longer carries the UID found during discovery; turn off when values are encrypted at rest")
+		kubectlBin       = flag.String("kubectl", "kubectl", "path to the kubectl binary")
+		etcdctlBin       = flag.String("etcdctl", "etcdctl", "path to the etcdctl binary")
+		sudo             = flag.Bool("sudo", true, "run etcdctl via sudo (etcd client keys are root-only)")
+		endpoints        = flag.String("endpoints", "https://127.0.0.1:2379", "etcd client endpoint")
+		cacert           = flag.String("cacert", "/etc/kubernetes/pki/etcd/ca.crt", "etcd CA certificate")
+		cert             = flag.String("cert", "/etc/kubernetes/pki/etcd/healthcheck-client.crt", "etcd client certificate")
+		keyFile          = flag.String("key", "/etc/kubernetes/pki/etcd/healthcheck-client.key", "etcd client key")
+	)
+	flag.Parse()
+
+	// Cancel in-flight kubectl/etcdctl calls on Ctrl-C.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	getter := etcdctlGetter{bin: *etcdctlBin, run: execRunner, sudo: *sudo, endpoints: *endpoints, cacert: *cacert, cert: *cert, key: *keyFile}
+
+	if *probeKey != "" {
+		o, err := getter.get(ctx, *probeKey, 0)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s\n  revisions (version): %d\n  current value bytes: %d\n", o.Key, o.Version, o.ValueBytes)
+		return nil
+	}
+
+	if *pipelineRun == "" {
+		flag.Usage()
+		return errors.New("-pipelinerun is required (or use -etcd-key)")
+	}
+
+	lister := kubectlLister{bin: *kubectlBin, run: execRunner}
+
+	p, diag, err := buildProfile(ctx, lister, getter, *etcdPrefix, *namespace, *pipelineRun, *verifyUID)
+	if err != nil {
+		// Discovery notes explain how the failed run was correlated, so print
+		// them rather than letting the error swallow them.
+		printLines("note", diag.Info)
+		printLines("missing", diag.Incomplete)
+		return err
+	}
+
+	fmt.Printf("etcd revision profile for PipelineRun %s/%s (discovered keys read at revision %d)\n\n", *namespace, *pipelineRun, p.Revision)
+	fmt.Print(renderObjects(p))
+	fmt.Printf("\n%s", renderTable(p))
+	if p.Total.CurrentBytes > 0 {
+		fmt.Printf("\nestimated rewrite multiple (est-write-bytes / current-bytes): %.1fx\n",
+			float64(p.Total.EstRevisionBytes)/float64(p.Total.CurrentBytes))
+	}
+	printLines("note", diag.Info)
+	if !diag.complete() {
+		// Say it on stdout too: a redirected report would otherwise look clean.
+		fmt.Printf("\nINCOMPLETE: %d object(s) could not be measured, listed on stderr\n", len(diag.Incomplete))
+		printLines("missing", diag.Incomplete)
+		if !*allowPartialFlag {
+			return fmt.Errorf("profile is incomplete (%d object(s) unmeasured); pass -allow-partial to accept it", len(diag.Incomplete))
+		}
+	}
+	return nil
+}
+
+func printLines(label string, lines []string) {
+	for _, l := range lines {
+		fmt.Fprintf(os.Stderr, "%s: %s\n", label, l)
+	}
+}

--- a/hack/etcd-revision-profile/main_test.go
+++ b/hack/etcd-revision-profile/main_test.go
@@ -1,0 +1,402 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const prUID = "9f0c1d2e-0000-4000-8000-00000000pr01"
+
+// fake kubectl: answers each `get` by the resource it asks for. Listing calls
+// return the tab-separated columns of listJSONPath.
+func fakeKubectl(_ context.Context, _ string, args ...string) ([]byte, error) {
+	joined := strings.Join(args, " ")
+	switch {
+	case strings.Contains(joined, "jsonpath={.metadata.uid}"):
+		return []byte(prUID + "\n"), nil
+	case strings.Contains(joined, "taskruns.tekton.dev"):
+		return []byte("demo-build\ttr-uid-1\tPipelineRun\t" + prUID + "\ndemo-test\ttr-uid-2\tPipelineRun\t" + prUID + "\n"), nil
+	case strings.Contains(joined, "get pods"):
+		return []byte("demo-build-pod\tpod-uid-1\tTaskRun\ttr-uid-1\n"), nil
+	case strings.Contains(joined, "get events"):
+		return []byte("ev-1\tev-uid-1\n"), nil
+	default:
+		return nil, nil
+	}
+}
+
+func TestKubectlListerList(t *testing.T) {
+	lister := kubectlLister{bin: "kubectl", run: fakeKubectl}
+	refs, _, err := lister.list(context.Background(), "ci", "demo")
+	if err != nil {
+		t.Fatalf("list() error: %v", err)
+	}
+
+	// 1 PipelineRun + 2 TaskRuns + 1 Pod, and one Event per involved object
+	// (the PipelineRun, both TaskRuns and the Pod) = 4 events.
+	counts := map[string]int{}
+	for _, r := range refs {
+		counts[r.Kind]++
+	}
+	want := map[string]int{kindPipelineRun: 1, kindTaskRun: 2, kindPod: 1, kindEvent: 4}
+	for kind, n := range want {
+		if counts[kind] != n {
+			t.Errorf("Kind %s: got %d refs, want %d (all: %v)", kind, counts[kind], n, refs)
+		}
+	}
+
+	if key := etcdKeyFor(defaultEtcdPrefix, refs[0].Ref); key != "/registry/tekton.dev/pipelineruns/ci/demo" {
+		t.Errorf("PipelineRun resolves to key %q", key)
+	}
+	if refs[0].UID != prUID {
+		t.Errorf("PipelineRun UID = %q, want %q", refs[0].UID, prUID)
+	}
+}
+
+func TestEtcdctlGetterGet(t *testing.T) {
+	key := "/registry/tekton.dev/pipelineruns/ci/demo"
+	value := []byte("some-protobuf")
+
+	var gotName string
+	var gotArgs []string
+	run := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotName, gotArgs = name, args
+		raw := fmt.Sprintf(`{"header":{"revision":99},"kvs":[{"key":%q,"version":7,"value":%q}],"count":1}`,
+			base64.StdEncoding.EncodeToString([]byte(key)),
+			base64.StdEncoding.EncodeToString(value))
+		return []byte(raw), nil
+	}
+
+	getter := etcdctlGetter{bin: "etcdctl", run: run, sudo: true, endpoints: "https://127.0.0.1:2379", cacert: "ca", cert: "crt", key: "k"}
+	obj, err := getter.get(context.Background(), key, 0)
+	if err != nil {
+		t.Fatalf("get() error: %v", err)
+	}
+	if obj.Version != 7 {
+		t.Errorf("Version = %d, want 7", obj.Version)
+	}
+	if obj.ValueBytes != len(value) {
+		t.Errorf("ValueBytes = %d, want %d", obj.ValueBytes, len(value))
+	}
+
+	// with -sudo the etcdctl binary is shifted to be sudo's first argument
+	if gotName != "sudo" || len(gotArgs) == 0 || gotArgs[0] != "etcdctl" {
+		t.Errorf("got command %q %v, want sudo etcdctl ...", gotName, gotArgs)
+	}
+	if !strings.Contains(strings.Join(gotArgs, " "), key) {
+		t.Errorf("get args do not mention key %q: %v", key, gotArgs)
+	}
+}
+
+// A PipelineRun that has not created anything yet is a clean result, not a
+// discovery problem, so it must not produce notes.
+func TestKubectlListerNoChildren(t *testing.T) {
+	run := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if strings.Contains(strings.Join(args, " "), "jsonpath={.metadata.uid}") {
+			return []byte(prUID + "\n"), nil
+		}
+		return nil, nil
+	}
+
+	lister := kubectlLister{bin: "kubectl", run: run}
+	refs, notes, err := lister.list(context.Background(), "ci", "demo")
+	if err != nil {
+		t.Fatalf("list() error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Errorf("got %d refs, want just the PipelineRun", len(refs))
+	}
+	if len(notes) != 0 {
+		t.Errorf("notes = %v, want none when the run simply has no children", notes)
+	}
+}
+
+func TestEventsRejectsEmptyUID(t *testing.T) {
+	called := false
+	run := func(context.Context, string, ...string) ([]byte, error) {
+		called = true
+		return nil, nil
+	}
+	if _, err := (kubectlLister{bin: "kubectl", run: run}).events(context.Background(), "ci", ""); err == nil {
+		t.Error("events() with an empty UID = nil error, want a refusal")
+	}
+	if called {
+		t.Error("events() ran kubectl with an empty involvedObject.uid selector")
+	}
+}
+
+// A pinned read has to reach etcdctl as --rev, and a zero must not.
+func TestEtcdctlGetterPinsRevision(t *testing.T) {
+	var gotArgs []string
+	run := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		raw := fmt.Sprintf(`{"header":{"revision":9},"kvs":[{"key":%q,"version":1,"value":""}],"count":1}`,
+			base64.StdEncoding.EncodeToString([]byte("/k")))
+		return []byte(raw), nil
+	}
+	getter := etcdctlGetter{bin: "etcdctl", run: run}
+
+	if _, err := getter.get(context.Background(), "/k", 4242); err != nil {
+		t.Fatalf("get() error: %v", err)
+	}
+	if !strings.Contains(strings.Join(gotArgs, " "), "--rev=4242") {
+		t.Errorf("pinned get did not pass --rev=4242: %v", gotArgs)
+	}
+
+	if _, err := getter.get(context.Background(), "/k", 0); err != nil {
+		t.Fatalf("get() error: %v", err)
+	}
+	if strings.Contains(strings.Join(gotArgs, " "), "--rev") {
+		t.Errorf("unpinned get passed a --rev flag: %v", gotArgs)
+	}
+}
+
+// A TaskRun deleted and recreated under the same name need not carry the labels
+// discovery selected on. Rechecking through those same selectors would find
+// nothing, read that as "it is gone", and accept the replacement's figures as
+// the original's, so the recheck lists without a selector.
+func TestKubectlListerRechecksWithoutLabelSelector(t *testing.T) {
+	run := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "jsonpath={.metadata.uid}"):
+			return []byte(prUID + "\n"), nil
+		// The replacement carries no PipelineRun label, so it is only visible
+		// to a listing that does not filter on one.
+		case strings.Contains(joined, "taskruns.tekton.dev") && !strings.Contains(joined, "-l "):
+			return []byte("build\ttr-uid-new\t\t\n"), nil
+		default:
+			return nil, nil
+		}
+	}
+
+	refs := []profiledRef{
+		{Kind: kindTaskRun, UID: "tr-uid-old", Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "build"}},
+	}
+	lister := kubectlLister{bin: "kubectl", run: run}
+	_, err := lister.recheck(context.Background(), "ci", "demo", refs, refs, true)
+	if err == nil {
+		t.Fatal("recheck() = nil error for a same-name replacement with no labels, want an error")
+	}
+	if !strings.Contains(err.Error(), "tr-uid-new") {
+		t.Errorf("error = %v, want it to name the UID now serving that name", err)
+	}
+}
+
+// Keeping its UID but being re-parented means the figures no longer belong to
+// this PipelineRun, so the owner is rechecked too.
+func TestKubectlListerRechecksOwnership(t *testing.T) {
+	run := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "jsonpath={.metadata.uid}"):
+			return []byte(prUID + "\n"), nil
+		case strings.Contains(joined, "taskruns.tekton.dev") && !strings.Contains(joined, "-l "):
+			return []byte("build\ttr-uid-1\tPipelineRun\tsome-other-pr\n"), nil
+		default:
+			return nil, nil
+		}
+	}
+
+	refs := []profiledRef{
+		{Kind: kindTaskRun, UID: "tr-uid-1", OwnerKind: kindPipelineRun, OwnerUID: prUID,
+			Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "build"}},
+	}
+	lister := kubectlLister{bin: "kubectl", run: run}
+	if _, err := lister.recheck(context.Background(), "ci", "demo", refs, refs, true); err == nil {
+		t.Fatal("recheck() = nil error for a re-parented TaskRun, want an error")
+	}
+}
+
+// Membership is decided by the controller owner reference, not by labels. A
+// TaskRun another PipelineRun owns, a Pod belonging to it, and the Affinity
+// Assistant's StatefulSet-owned Pod are all simply not this run's children,
+// however they are labelled.
+func TestKubectlListerSelectsByOwnership(t *testing.T) {
+	run := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "jsonpath={.metadata.uid}"):
+			return []byte(prUID + "\n"), nil
+		case strings.Contains(joined, "taskruns.tekton.dev"):
+			return []byte("mine\ttr-uid-1\tPipelineRun\t" + prUID + "\n" +
+				"theirs\ttr-uid-9\tPipelineRun\tsome-other-pr\n" +
+				"standalone\ttr-uid-8\t\t\n"), nil
+		case strings.Contains(joined, "get pods"):
+			return []byte("mine-pod\tpod-uid-1\tTaskRun\ttr-uid-1\n" +
+				"theirs-pod\tpod-uid-9\tTaskRun\ttr-uid-9\n" +
+				"affinity-assistant-abc-0\taa-uid\tStatefulSet\tss-uid\n"), nil
+		default:
+			return nil, nil
+		}
+	}
+
+	lister := kubectlLister{bin: "kubectl", run: run}
+	refs, notes, err := lister.list(context.Background(), "ci", "demo")
+	if err != nil {
+		t.Fatalf("list() error: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, r := range refs {
+		got[r.Ref.Name] = true
+	}
+	if !got["mine"] || !got["mine-pod"] {
+		t.Errorf("this PipelineRun's own children are missing: %v", got)
+	}
+	for _, unwanted := range []string{"theirs", "theirs-pod", "standalone", "affinity-assistant-abc-0"} {
+		if got[unwanted] {
+			t.Errorf("%q was profiled but this PipelineRun does not own it", unwanted)
+		}
+	}
+	// Objects the run does not own are not anomalies worth reporting.
+	if len(notes) != 0 {
+		t.Errorf("notes = %v, want none", notes)
+	}
+}
+
+// Discovery must not filter on labels: a child whose labels were stripped is
+// still owned by this PipelineRun and still costs etcd revisions.
+func TestKubectlListerFindsChildWithoutLabels(t *testing.T) {
+	var selectorUsed bool
+	run := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "-l ") {
+			selectorUsed = true
+		}
+		switch {
+		case strings.Contains(joined, "jsonpath={.metadata.uid}"):
+			return []byte(prUID + "\n"), nil
+		case strings.Contains(joined, "taskruns.tekton.dev"):
+			return []byte("unlabelled\ttr-uid-1\tPipelineRun\t" + prUID + "\n"), nil
+		default:
+			return nil, nil
+		}
+	}
+
+	lister := kubectlLister{bin: "kubectl", run: run}
+	refs, _, err := lister.list(context.Background(), "ci", "demo")
+	if err != nil {
+		t.Fatalf("list() error: %v", err)
+	}
+	if selectorUsed {
+		t.Error("discovery filtered on a label selector, which a stripped child would escape")
+	}
+	found := false
+	for _, r := range refs {
+		if r.Ref.Name == "unlabelled" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the unlabelled but owned TaskRun was not discovered: %v", refs)
+	}
+}
+
+// A run made of CustomRuns or child PipelineRuns would otherwise profile as a
+// tidy single row. Those objects are out of scope rather than unmeasured, so
+// they are reported as a note and leave the profile complete.
+func TestKubectlListerNotesUnsupportedChildren(t *testing.T) {
+	run := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "jsonpath={.metadata.uid}"):
+			return []byte(prUID + "\n"), nil
+		case strings.Contains(joined, "customruns"):
+			return []byte("custom-a\tcr-uid\tPipelineRun\t" + prUID + "\n"), nil
+		case strings.Contains(joined, "pipelineruns.tekton.dev"):
+			return []byte("child-pr\tcpr-uid\tPipelineRun\t" + prUID + "\n"), nil
+		default:
+			return nil, nil
+		}
+	}
+
+	lister := kubectlLister{bin: "kubectl", run: run}
+	_, notes, err := lister.list(context.Background(), "ci", "demo")
+	if err != nil {
+		t.Fatalf("list() error: %v", err)
+	}
+	joined := strings.Join(notes, " | ")
+	for _, want := range []string{"custom-a", "child-pr"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("notes do not mention %q: %v", want, notes)
+		}
+	}
+}
+
+// The rule that an unconfirmable disappearance is only reportable when the
+// stored value was never checked lives in the real lister, so it is tested
+// there rather than in a fake that would just restate it.
+func TestKubectlListerRecheckReportsUnconfirmableDisappearance(t *testing.T) {
+	// The namespace no longer holds the object under any kind.
+	run := func(context.Context, string, ...string) ([]byte, error) { return nil, nil }
+	refs := []profiledRef{
+		{Kind: kindTaskRun, UID: "tr-uid", Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "build"}},
+	}
+	lister := kubectlLister{bin: "kubectl", run: run}
+
+	res, err := lister.recheck(context.Background(), "ci", "demo", refs, refs, false)
+	if err != nil {
+		t.Fatalf("recheck() error: %v", err)
+	}
+	if len(res.Unverified) != 1 {
+		t.Errorf("Unverified = %v, want the vanished object reported when its stored value was never checked", res.Unverified)
+	}
+
+	// With the stored value verified, the same disappearance is accounted for.
+	res, err = lister.recheck(context.Background(), "ci", "demo", refs, refs, true)
+	if err != nil {
+		t.Fatalf("recheck() error: %v", err)
+	}
+	if len(res.Unverified) != 0 {
+		t.Errorf("Unverified = %v, want none once the stored value confirmed the generation", res.Unverified)
+	}
+}
+
+// The CustomRun lookup only feeds a note, so a cluster that does not serve the
+// kind, or a caller without list rights on it, must still get its profile.
+func TestKubectlListerSurvivesUnsupportedLookupFailure(t *testing.T) {
+	run := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "jsonpath={.metadata.uid}"):
+			return []byte(prUID + "\n"), nil
+		case strings.Contains(joined, "customruns"):
+			return nil, errors.New(`the server doesn't have a resource type "customruns"`)
+		default:
+			return nil, nil
+		}
+	}
+
+	lister := kubectlLister{bin: "kubectl", run: run}
+	refs, notes, err := lister.list(context.Background(), "ci", "demo")
+	if err != nil {
+		t.Fatalf("list() failed because an informational lookup did: %v", err)
+	}
+	if len(refs) == 0 {
+		t.Error("no refs returned; the PipelineRun itself should still be profiled")
+	}
+	if len(notes) != 1 || !strings.Contains(notes[0], "could not check") {
+		t.Errorf("notes = %v, want one recording that the check could not run", notes)
+	}
+}

--- a/hack/etcd-revision-profile/profile.go
+++ b/hack/etcd-revision-profile/profile.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// etcdObject is one stored Kubernetes object's write count and current size.
+//
+// Version is etcd's per-key write counter: it starts at 1 when the key is
+// created and increments on every write, so it equals the number of revisions
+// the object has accumulated since creation. ValueBytes is the size of the
+// object's current serialized value (the live snapshot), not the sum across
+// revisions.
+type etcdObject struct {
+	Key        string
+	Kind       string
+	Namespace  string
+	Name       string
+	UID        string
+	Version    int64
+	ValueBytes int
+
+	// value is the raw stored bytes, kept only long enough to confirm the key
+	// still holds the object that discovery found. etcd keys carry no UID, so
+	// this is the only way to notice a delete and recreate under the same name.
+	value []byte
+	// headerRevision is the store-wide revision the read was served at.
+	headerRevision int64
+}
+
+// objectRef identifies a Kubernetes object well enough to construct its
+// apiserver storage key. Group is "" for the core API group.
+type objectRef struct {
+	Group     string
+	Resource  string
+	Namespace string
+	Name      string
+}
+
+// Object coordinates shared by discovery and key construction.
+const (
+	kindPipelineRun = "PipelineRun"
+	kindTaskRun     = "TaskRun"
+	kindPod         = "Pod"
+	kindEvent       = "Event"
+	kindCustomRun   = "CustomRun"
+
+	groupTektonDev = "tekton.dev"
+
+	resPipelineRuns = "pipelineruns"
+	resTaskRuns     = "taskruns"
+	resPods         = "pods"
+	resEvents       = "events"
+	resCustomRuns   = "customruns"
+
+	totalRow = "TOTAL"
+)
+
+// defaultEtcdPrefix is the kube-apiserver default for --etcd-prefix.
+const defaultEtcdPrefix = "/registry"
+
+// etcdKeyFor builds an object's storage key:
+//
+//	<prefix>/<group>/<resource>/<namespace>/<name>, group omitted when empty
+//
+// prefix is the apiserver's --etcd-prefix. The flag supplies its /registry
+// default, so an explicitly empty or root prefix is honoured as the store root
+// rather than quietly turned back into /registry, which is how the apiserver
+// itself resolves it. Cluster-scoped objects (empty Namespace) drop the
+// namespace segment.
+//
+// Group is not simply the API group. Resources served by CRDs, Tekton's
+// included, are stored under their group, while most compiled-in groups
+// register a bare per-resource prefix, so Deployments live at
+// /registry/deployments rather than under /registry/apps. The exceptions go
+// both ways: apiextensions.k8s.io and apiregistration.k8s.io keep their group,
+// Node is stored at /registry/minions, and Services split across
+// /registry/services/specs and /registry/services/endpoints. For anything
+// beyond Tekton's own resources, Pods and Events, confirm the layout with
+// `etcdctl get <prefix> --prefix --keys-only` rather than deriving it.
+func etcdKeyFor(prefix string, ref objectRef) string {
+	parts := []string{"/", prefix}
+	if ref.Group != "" {
+		parts = append(parts, ref.Group)
+	}
+	parts = append(parts, ref.Resource)
+	if ref.Namespace != "" {
+		parts = append(parts, ref.Namespace)
+	}
+	parts = append(parts, ref.Name)
+	return path.Join(parts...)
+}
+
+// etcdGetResponse is the subset of `etcdctl get <key> -w json` we consume.
+type etcdGetResponse struct {
+	Header struct {
+		Revision int64 `json:"revision"`
+	} `json:"header"`
+	Count int `json:"count"`
+	Kvs   []struct {
+		Key     string `json:"key"`
+		Version int64  `json:"version"`
+		Value   string `json:"value"`
+	} `json:"kvs"`
+}
+
+// parseEtcdGetJSON parses the JSON emitted by `etcdctl get <key> -w json` for
+// the single key that was asked for, returning its decoded key, version, and
+// current value size. A response with no kvs (count 0) is reported as
+// errNotFound rather than a zero-valued success, since that means the key does
+// not exist.
+//
+// The other invariants are checked because the caller pins every later read to
+// the revision this response reports. A response without one would leave that
+// zero, which etcd reads as "latest", quietly turning the pinned reads back
+// into a rolling one.
+func parseEtcdGetJSON(raw []byte, wantKey string) (etcdObject, error) {
+	var resp etcdGetResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return etcdObject{}, fmt.Errorf("decoding etcdctl json: %w", err)
+	}
+	// The header comes first: etcd answers a missing key with a valid header and
+	// no kvs, so a response without one is not a missing key but an answer that
+	// cannot be trusted, and must not be skippable as merely absent.
+	if resp.Header.Revision <= 0 {
+		return etcdObject{}, fmt.Errorf("etcdctl response for %s carries no header revision", wantKey)
+	}
+	if resp.Count == 0 && len(resp.Kvs) == 0 {
+		return etcdObject{}, fmt.Errorf("%w", errNotFound)
+	}
+	if len(resp.Kvs) != 1 || resp.Count != 1 {
+		return etcdObject{}, fmt.Errorf("etcdctl returned %d key(s) (count=%d) for the single key %s", len(resp.Kvs), resp.Count, wantKey)
+	}
+	kv := resp.Kvs[0]
+	if kv.Version < 1 {
+		return etcdObject{}, fmt.Errorf("etcdctl reports version %d for the live key %s", kv.Version, wantKey)
+	}
+	key, err := base64.StdEncoding.DecodeString(kv.Key)
+	if err != nil {
+		return etcdObject{}, fmt.Errorf("decoding key: %w", err)
+	}
+	if string(key) != wantKey {
+		return etcdObject{}, fmt.Errorf("etcdctl answered for %s, not the requested %s", key, wantKey)
+	}
+	value, err := base64.StdEncoding.DecodeString(kv.Value)
+	if err != nil {
+		return etcdObject{}, fmt.Errorf("decoding value: %w", err)
+	}
+	return etcdObject{
+		Key:            string(key),
+		Version:        kv.Version,
+		ValueBytes:     len(value),
+		value:          value,
+		headerRevision: resp.Header.Revision,
+	}, nil
+}
+
+// holdsUID reports whether the stored value still belongs to the object with
+// this UID. Every Kubernetes object serializes metadata.uid as a plain string,
+// in both the JSON used for CRDs and the protobuf used for core resources, so
+// a substring check works without decoding either encoding. It cannot see
+// through encryption at rest, where no plaintext UID is present.
+func (o etcdObject) holdsUID(uid string) bool {
+	return bytes.Contains(o.value, []byte(uid))
+}
+
+// kindProfile aggregates the etcd footprint of every object of one Kind.
+type kindProfile struct {
+	Kind             string
+	Count            int
+	TotalRevisions   int64 // sum of per-object Version
+	CurrentBytes     int64 // sum of current value sizes (live snapshot)
+	EstRevisionBytes int64 // sum of Version*ValueBytes: the serialized volume
+	// written over each key's life, assuming every revision was about the size
+	// of the current one. It over-counts objects that grew and under-counts
+	// ones that shrank, and compaction reclaims history without resetting
+	// Version, so it is not the currently retained etcd footprint.
+}
+
+// profile is every profiled object, the per-Kind breakdown, and a grand total.
+// The per-object rows are what answers "which TaskRun is driving the writes",
+// so they are kept rather than only their sums.
+type profile struct {
+	// Revision is the store-wide revision every key was read at. It cannot be
+	// taken from a row: only the PipelineRun is read at latest, and a read
+	// pinned with --rev still reports the current store revision in its header.
+	Revision int64
+	Objects  []etcdObject
+	Kinds    []kindProfile
+	Total    kindProfile
+}
+
+// aggregate buckets objects by Kind (rows sorted by Kind name) and computes the
+// per-Kind and overall revision/size totals.
+func aggregate(objs []etcdObject) profile {
+	byKind := map[string]*kindProfile{}
+	for _, o := range objs {
+		kp := byKind[o.Kind]
+		if kp == nil {
+			kp = &kindProfile{Kind: o.Kind}
+			byKind[o.Kind] = kp
+		}
+		kp.Count++
+		kp.TotalRevisions += o.Version
+		kp.CurrentBytes += int64(o.ValueBytes)
+		kp.EstRevisionBytes += o.Version * int64(o.ValueBytes)
+	}
+
+	kinds := make([]string, 0, len(byKind))
+	for k := range byKind {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+
+	rows := append([]etcdObject(nil), objs...)
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Kind != rows[j].Kind {
+			return rows[i].Kind < rows[j].Kind
+		}
+		return rows[i].Name < rows[j].Name
+	})
+
+	p := profile{Objects: rows, Total: kindProfile{Kind: totalRow}}
+	for _, k := range kinds {
+		kp := byKind[k]
+		p.Kinds = append(p.Kinds, *kp)
+		p.Total.Count += kp.Count
+		p.Total.TotalRevisions += kp.TotalRevisions
+		p.Total.CurrentBytes += kp.CurrentBytes
+		p.Total.EstRevisionBytes += kp.EstRevisionBytes
+	}
+	return p
+}
+
+// renderObjects lists every profiled object, which is where a single hot
+// TaskRun or oversized Pod shows up; the per-Kind summary alone hides it.
+func renderObjects(p profile) string {
+	// Size the name column from the data. Pod and Event names carry the
+	// PipelineRun's own name plus a suffix, so any fixed width wide enough for
+	// them is mostly padding, and any narrower one bends the table.
+	width := len("NAME")
+	for _, o := range p.Objects {
+		if len(o.Name) > width {
+			width = len(o.Name)
+		}
+	}
+
+	name := "%-" + strconv.Itoa(width) + "s"
+	header := "%-14s " + name + " %10s %14s %18s\n"
+	row := "%-14s " + name + " %10d %14d %18d\n"
+
+	var b strings.Builder
+	fmt.Fprintf(&b, header, "KIND", "NAME", "REVISIONS", "CURRENT(B)", "EST-WRITE-BYTES(B)")
+	for _, o := range p.Objects {
+		fmt.Fprintf(&b, row, o.Kind, o.Name, o.Version, o.ValueBytes, o.Version*int64(o.ValueBytes))
+	}
+	return b.String()
+}
+
+// renderTable formats a profile as a fixed-width text table.
+func renderTable(p profile) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%-14s %6s %10s %14s %18s\n", "KIND", "COUNT", "REVISIONS", "CURRENT(B)", "EST-WRITE-BYTES(B)")
+	row := func(kp kindProfile) {
+		fmt.Fprintf(&b, "%-14s %6d %10d %14d %18d\n",
+			kp.Kind, kp.Count, kp.TotalRevisions, kp.CurrentBytes, kp.EstRevisionBytes)
+	}
+	for _, kp := range p.Kinds {
+		row(kp)
+	}
+	fmt.Fprintf(&b, "%s\n", strings.Repeat("-", 66))
+	row(p.Total)
+	return b.String()
+}

--- a/hack/etcd-revision-profile/profile_test.go
+++ b/hack/etcd-revision-profile/profile_test.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// parseEtcdGetJSON must understand the real shape emitted by
+// `etcdctl get <key> -w json`: a header plus a kvs array whose key/value are
+// base64-encoded and whose `version` is etcd's per-key write count.
+func TestParseEtcdGetJSON(t *testing.T) {
+	key := "/registry/tekton.dev/taskruns/default/demo-run-build"
+	value := []byte("0123456789") // 10 bytes once base64-decoded
+
+	raw := fmt.Sprintf(
+		`{"header":{"revision":42},"kvs":[{"key":%q,"create_revision":6,"mod_revision":40,"version":17,"value":%q}],"count":1}`,
+		base64.StdEncoding.EncodeToString([]byte(key)),
+		base64.StdEncoding.EncodeToString(value),
+	)
+
+	got, err := parseEtcdGetJSON([]byte(raw), key)
+	if err != nil {
+		t.Fatalf("parseEtcdGetJSON() unexpected error: %v", err)
+	}
+	if got.Key != key {
+		t.Errorf("Key = %q, want %q", got.Key, key)
+	}
+	if got.Version != 17 {
+		t.Errorf("Version = %d, want 17", got.Version)
+	}
+	if got.ValueBytes != len(value) {
+		t.Errorf("ValueBytes = %d, want %d", got.ValueBytes, len(value))
+	}
+}
+
+// A get against a non-existent key returns count:0 and an empty kvs array;
+// that must be surfaced as an error, not a zero-valued success.
+func TestParseEtcdGetJSON_NotFound(t *testing.T) {
+	raw := []byte(`{"header":{"revision":42},"count":0}`)
+	_, err := parseEtcdGetJSON(raw, "/registry/pods/ci/gone")
+	if err == nil {
+		t.Fatal("parseEtcdGetJSON() on count:0 = nil error, want an error")
+	}
+	if !errors.Is(err, errNotFound) {
+		t.Errorf("error %v cannot be detected as not-found via errors.Is(errNotFound)", err)
+	}
+}
+
+// etcdKeyFor must reproduce the apiserver storage key layout: core resources
+// have no group segment, CRDs and other API groups do.
+func TestEtcdKeyFor(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		ref    objectRef
+		want   string
+	}{{
+		name:   "tekton CRD (namespaced)",
+		prefix: defaultEtcdPrefix,
+		ref:    objectRef{Group: "tekton.dev", Resource: "pipelineruns", Namespace: "default", Name: "r1"},
+		want:   "/registry/tekton.dev/pipelineruns/default/r1",
+	}, {
+		name:   "core pod",
+		prefix: defaultEtcdPrefix,
+		ref:    objectRef{Group: "", Resource: "pods", Namespace: "default", Name: "r1-build-pod"},
+		want:   "/registry/pods/default/r1-build-pod",
+	}, {
+		name:   "core event",
+		prefix: defaultEtcdPrefix,
+		ref:    objectRef{Group: "", Resource: "events", Namespace: "ci", Name: "r1.17abc"},
+		want:   "/registry/events/ci/r1.17abc",
+	}, {
+		name:   "cluster-scoped (no namespace)",
+		prefix: defaultEtcdPrefix,
+		ref:    objectRef{Group: "", Resource: "nodes", Namespace: "", Name: "node-1"},
+		want:   "/registry/nodes/node-1",
+	}, {
+		// --etcd-prefix is configurable; a cluster that changed it stores every
+		// object somewhere other than /registry.
+		name:   "custom apiserver prefix",
+		prefix: "/tekton-registry",
+		ref:    objectRef{Group: "tekton.dev", Resource: "taskruns", Namespace: "ci", Name: "t1"},
+		want:   "/tekton-registry/tekton.dev/taskruns/ci/t1",
+	}, {
+		name:   "prefix with surrounding slashes is normalized",
+		prefix: "/nested/registry/",
+		ref:    objectRef{Group: "", Resource: "pods", Namespace: "ci", Name: "p1"},
+		want:   "/nested/registry/pods/ci/p1",
+	}, {
+		// The flag supplies the /registry default, so an explicit root or
+		// empty prefix means the store root, as the apiserver resolves it.
+		name:   "explicit root prefix is honoured",
+		prefix: "/",
+		ref:    objectRef{Group: "", Resource: "pods", Namespace: "ci", Name: "p1"},
+		want:   "/pods/ci/p1",
+	}, {
+		name:   "empty prefix is the store root",
+		prefix: "",
+		ref:    objectRef{Group: "tekton.dev", Resource: "taskruns", Namespace: "ci", Name: "t1"},
+		want:   "/tekton.dev/taskruns/ci/t1",
+	}, {
+		name:   "prefix without a leading slash still resolves",
+		prefix: "registry",
+		ref:    objectRef{Group: "", Resource: "pods", Namespace: "ci", Name: "p1"},
+		want:   "/registry/pods/ci/p1",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := etcdKeyFor(tc.prefix, tc.ref); got != tc.want {
+				t.Errorf("etcdKeyFor(%q, %+v) = %q, want %q", tc.prefix, tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+// aggregate groups objects by Kind (sorted), summing the revision count, the
+// current value size, and the lifetime revision-bytes estimate
+// (sum of version*size), and produces a grand total.
+func TestAggregate(t *testing.T) {
+	objs := []etcdObject{
+		{Kind: "PipelineRun", Version: 9, ValueBytes: 4000},
+		{Kind: "TaskRun", Version: 14, ValueBytes: 68000},
+		{Kind: "TaskRun", Version: 11, ValueBytes: 64000},
+		{Kind: "Pod", Version: 8, ValueBytes: 12000},
+		{Kind: "Pod", Version: 6, ValueBytes: 11000},
+		{Kind: "Event", Version: 1, ValueBytes: 600},
+		{Kind: "Event", Version: 1, ValueBytes: 600},
+		{Kind: "Event", Version: 1, ValueBytes: 600},
+	}
+
+	got := aggregate(objs)
+
+	// Rows are sorted by Kind name: "PipelineRun" sorts before "Pod"
+	// (they differ first at the 2nd character, 'i' < 'o').
+	wantKinds := []kindProfile{
+		{Kind: "Event", Count: 3, TotalRevisions: 3, CurrentBytes: 1800, EstRevisionBytes: 1800},
+		{Kind: "PipelineRun", Count: 1, TotalRevisions: 9, CurrentBytes: 4000, EstRevisionBytes: 36000},
+		{Kind: "Pod", Count: 2, TotalRevisions: 14, CurrentBytes: 23000, EstRevisionBytes: 162000},
+		{Kind: "TaskRun", Count: 2, TotalRevisions: 25, CurrentBytes: 132000, EstRevisionBytes: 1656000},
+	}
+	if len(got.Kinds) != len(wantKinds) {
+		t.Fatalf("got %d kind rows, want %d (%+v)", len(got.Kinds), len(wantKinds), got.Kinds)
+	}
+	for i, w := range wantKinds {
+		if got.Kinds[i] != w {
+			t.Errorf("Kinds[%d] = %+v, want %+v", i, got.Kinds[i], w)
+		}
+	}
+
+	wantTotal := kindProfile{Kind: "TOTAL", Count: 8, TotalRevisions: 51, CurrentBytes: 160800, EstRevisionBytes: 1855800}
+	if got.Total != wantTotal {
+		t.Errorf("Total = %+v, want %+v", got.Total, wantTotal)
+	}
+}
+
+func TestRenderTableContainsTotals(t *testing.T) {
+	p := aggregate([]etcdObject{
+		{Kind: "PipelineRun", Version: 9, ValueBytes: 4000},
+		{Kind: "TaskRun", Version: 14, ValueBytes: 68000},
+	})
+	out := renderTable(p)
+	for _, want := range []string{"PipelineRun", "TaskRun", "TOTAL", "REVISIONS"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("renderTable() output missing %q\n%s", want, out)
+		}
+	}
+}
+
+// The name column has to size itself: real Pod and Event names carry the
+// PipelineRun's name plus a suffix and overflow any fixed width, which bends
+// every column to their right.
+func TestRenderObjectsColumnsLineUp(t *testing.T) {
+	out := renderObjects(aggregate([]etcdObject{
+		{Kind: "PipelineRun", Name: "etcd-demo-fm98n", Version: 6, ValueBytes: 3887},
+		{Kind: "Pod", Name: "etcd-demo-fm98n-package-pod", Version: 14, ValueBytes: 10798},
+		{Kind: "Event", Name: "etcd-demo-fm98n-build.1870f3a4c1b2d3e4", Version: 1, ValueBytes: 600},
+	}))
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("got %d lines, want a header and 3 rows:\n%s", len(lines), out)
+	}
+	// Every column is fixed width and the numbers are right aligned, so an
+	// aligned table has rows exactly as wide as its header.
+	for i, l := range lines[1:] {
+		if len(l) != len(lines[0]) {
+			t.Errorf("row %d is %d columns wide, header is %d\n%s", i, len(l), len(lines[0]), out)
+		}
+	}
+}
+
+// The header revision is what every child read is pinned to, so losing it
+// would silently turn the profile back into a rolling read.
+func TestParseEtcdGetJSONKeepsHeaderRevision(t *testing.T) {
+	raw := fmt.Sprintf(`{"header":{"revision":4242},"kvs":[{"key":%q,"version":3,"value":%q}],"count":1}`,
+		base64.StdEncoding.EncodeToString([]byte("/registry/pods/ci/p")),
+		base64.StdEncoding.EncodeToString([]byte("v")))
+	got, err := parseEtcdGetJSON([]byte(raw), "/registry/pods/ci/p")
+	if err != nil {
+		t.Fatalf("parseEtcdGetJSON() error: %v", err)
+	}
+	if got.headerRevision != 4242 {
+		t.Errorf("headerRevision = %d, want 4242", got.headerRevision)
+	}
+}
+
+// Every later read is pinned to the revision this response reports, and etcd
+// reads a revision of zero as "latest". A response that cannot supply one, or
+// that answers about some other key, has to be an error rather than something
+// the caller silently builds a rolling profile from.
+func TestParseEtcdGetJSONRejectsUnusableResponses(t *testing.T) {
+	const key = "/registry/pods/ci/p"
+	enc := base64.StdEncoding.EncodeToString
+	kv := func(k string, version int) string {
+		return fmt.Sprintf(`{"key":%q,"version":%d,"value":%q}`, enc([]byte(k)), version, enc([]byte("v")))
+	}
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"no header revision", `{"kvs":[` + kv(key, 3) + `],"count":1}`},
+		{"zero header revision", `{"header":{"revision":0},"kvs":[` + kv(key, 3) + `],"count":1}`},
+		{"count disagrees with kvs", `{"header":{"revision":9},"kvs":[` + kv(key, 3) + `],"count":2}`},
+		{"more than one kv", `{"header":{"revision":9},"kvs":[` + kv(key, 3) + `,` + kv("/registry/pods/ci/q", 3) + `],"count":2}`},
+		{"answers about another key", `{"header":{"revision":9},"kvs":[` + kv("/registry/pods/ci/other", 3) + `],"count":1}`},
+		{"live key reporting version zero", `{"header":{"revision":9},"kvs":[` + kv(key, 0) + `],"count":1}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseEtcdGetJSON([]byte(tc.raw), key); err == nil {
+				t.Errorf("parseEtcdGetJSON() = nil error for %s", tc.name)
+			}
+		})
+	}
+}
+
+// An empty kvs array is a normal not-found answer only when count is zero. A
+// response that claims a key and returns none is inconsistent, and treating it
+// as not-found would quietly demote it to a skipped object.
+func TestParseEtcdGetJSONCountWithoutKvsIsNotNotFound(t *testing.T) {
+	_, err := parseEtcdGetJSON([]byte(`{"header":{"revision":42},"count":1,"kvs":[]}`), "/registry/pods/ci/p")
+	if err == nil {
+		t.Fatal("parseEtcdGetJSON() = nil error for count=1 with no kvs")
+	}
+	if errors.Is(err, errNotFound) {
+		t.Errorf("error %v reports not-found; an inconsistent response must abort instead", err)
+	}
+}
+
+// etcd answers a missing key with a valid header and no kvs, so a response
+// carrying neither is not a missing key: it is an answer that cannot be
+// trusted, and must abort rather than be skipped as merely absent.
+func TestParseEtcdGetJSONEmptyResponseIsNotNotFound(t *testing.T) {
+	for _, raw := range []string{`{}`, `{"count":0}`} {
+		_, err := parseEtcdGetJSON([]byte(raw), "/registry/pods/ci/p")
+		if err == nil {
+			t.Errorf("parseEtcdGetJSON(%s) = nil error", raw)
+			continue
+		}
+		if errors.Is(err, errNotFound) {
+			t.Errorf("parseEtcdGetJSON(%s) reports not-found; a response with no header cannot establish that", raw)
+		}
+	}
+
+	// A real missing key does carry a header, and must still be not-found.
+	_, err := parseEtcdGetJSON([]byte(`{"header":{"revision":42},"count":0}`), "/registry/pods/ci/p")
+	if !errors.Is(err, errNotFound) {
+		t.Errorf("a genuine missing key reported %v, want not-found", err)
+	}
+}

--- a/hack/etcd-revision-profile/wiring_test.go
+++ b/hack/etcd-revision-profile/wiring_test.go
@@ -1,0 +1,481 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeLister struct {
+	refs     []profiledRef
+	notes    []string
+	err      error
+	replaced bool // the API now serves a different generation of the name
+}
+
+func (f fakeLister) list(context.Context, string, string) ([]profiledRef, []string, error) {
+	return f.refs, f.notes, f.err
+}
+
+func (f fakeLister) recheck(context.Context, string, string, []profiledRef, []profiledRef, bool) (recheckResult, error) {
+	if f.replaced {
+		return recheckResult{}, errors.New("TaskRun ci/build-compile now has UID tr-uid-new: it was replaced while being read")
+	}
+	return recheckResult{}, nil
+}
+
+type fakeGetter struct {
+	byKey map[string]etcdObject
+	err   error // when set, returned for every key to simulate a hard failure
+}
+
+func (f fakeGetter) get(_ context.Context, key string, _ int64) (etcdObject, error) {
+	if f.err != nil {
+		return etcdObject{}, f.err
+	}
+	o, ok := f.byKey[key]
+	if !ok {
+		return etcdObject{}, errNotFound
+	}
+	return o, nil
+}
+
+func TestBuildProfile(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+		{Kind: kindTaskRun, Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "build-compile"}},
+		{Kind: kindPod, Ref: objectRef{Resource: resPods, Namespace: "ci", Name: "build-compile-pod"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build":     {Version: 9, ValueBytes: 4000},
+		"/registry/tekton.dev/taskruns/ci/build-compile": {Version: 14, ValueBytes: 68000},
+		"/registry/pods/ci/build-compile-pod":            {Version: 8, ValueBytes: 12000},
+	}}
+
+	p, diag, err := buildProfile(context.Background(), fakeLister{refs: refs}, getter, defaultEtcdPrefix, "ci", "build", true)
+	if err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	if !diag.complete() {
+		t.Fatalf("buildProfile() incomplete: %v", diag.Incomplete)
+	}
+	if p.Total.Count != 3 {
+		t.Errorf("Total.Count = %d, want 3", p.Total.Count)
+	}
+	if p.Total.TotalRevisions != 31 {
+		t.Errorf("Total.TotalRevisions = %d, want 31", p.Total.TotalRevisions)
+	}
+	// EstRevisionBytes = 9*4000 + 14*68000 + 8*12000 = 36000 + 952000 + 96000 = 1084000
+	if p.Total.EstRevisionBytes != 1084000 {
+		t.Errorf("Total.EstRevisionBytes = %d, want 1084000", p.Total.EstRevisionBytes)
+	}
+}
+
+// A missing key (object deleted mid-run) is skipped and the profile continues.
+func TestBuildProfile_MissingKeyIsSkipped(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+		{Kind: kindEvent, Ref: objectRef{Resource: resEvents, Namespace: "ci", Name: "gone"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build": {Version: 3, ValueBytes: 4000},
+	}}
+
+	p, diag, err := buildProfile(context.Background(), fakeLister{refs: refs}, getter, defaultEtcdPrefix, "ci", "build", true)
+	if err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	if len(diag.Incomplete) != 1 {
+		t.Fatalf("got %d skipped, want 1: %v", len(diag.Incomplete), diag.Incomplete)
+	}
+	if p.Total.Count != 1 {
+		t.Errorf("Total.Count = %d, want 1 (missing object skipped)", p.Total.Count)
+	}
+}
+
+// A getter error that is not "not found" (bad certs, unreachable endpoint) must
+// abort the profile, not silently produce a partial result.
+func TestBuildProfile_HardErrorAborts(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+	}
+	getter := fakeGetter{err: errors.New("context deadline exceeded")}
+
+	if _, _, err := buildProfile(context.Background(), fakeLister{refs: refs}, getter, defaultEtcdPrefix, "ci", "build", true); err == nil {
+		t.Fatal("buildProfile() = nil error on a hard getter failure, want an error")
+	}
+}
+
+// The root PipelineRun anchors the report. If its key now holds a different
+// generation there is nothing to attribute the children to, so this must abort
+// rather than print a profile built from whatever is left.
+func TestBuildProfile_RootRecreatedIsFatal(t *testing.T) {
+	const discovered, recreated = "uid-generation-1", "uid-generation-2"
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, UID: discovered, Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+		{Kind: kindTaskRun, UID: "tr-uid", Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "build-compile"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build": {
+			Version: 3, ValueBytes: 100,
+			value: []byte(`{"metadata":{"uid":"` + recreated + `"}}`),
+		},
+		// The child survives, which is what made this look like a success
+		// before: a non-zero object count hid the replaced root.
+		"/registry/tekton.dev/taskruns/ci/build-compile": {
+			Version: 5, ValueBytes: 200, value: []byte("tr-uid"),
+		},
+	}}
+
+	if _, _, err := buildProfile(context.Background(), fakeLister{refs: refs}, getter, defaultEtcdPrefix, "ci", "build", true); err == nil {
+		t.Fatal("buildProfile() = nil error when the root PipelineRun was replaced, want an error")
+	}
+
+	// Encrypted values carry no plaintext UID, so the check has to be defeatable.
+	p, _, err := buildProfile(context.Background(), fakeLister{refs: refs}, getter, defaultEtcdPrefix, "ci", "build", false)
+	if err != nil {
+		t.Fatalf("buildProfile() with -verify-uid=false error: %v", err)
+	}
+	if p.Total.Count != 2 {
+		t.Errorf("with verification off: Count = %d, want 2", p.Total.Count)
+	}
+}
+
+// A child replaced after discovery is skipped and reported, but the run
+// continues, since one stale child does not invalidate the anchor.
+func TestBuildProfile_RecreatedChildIsSkipped(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, UID: "pr-uid", Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+		{Kind: kindTaskRun, UID: "tr-uid-old", Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "build-compile"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build":     {Version: 3, ValueBytes: 100, value: []byte("pr-uid")},
+		"/registry/tekton.dev/taskruns/ci/build-compile": {Version: 5, ValueBytes: 200, value: []byte("tr-uid-new")},
+	}}
+
+	p, diag, err := buildProfile(context.Background(), fakeLister{refs: refs}, getter, defaultEtcdPrefix, "ci", "build", true)
+	if err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	if p.Total.Count != 1 {
+		t.Errorf("Total.Count = %d, want 1 (the replaced TaskRun must not be counted)", p.Total.Count)
+	}
+	if len(diag.Incomplete) != 1 || !strings.Contains(diag.Incomplete[0], "tr-uid-old") {
+		t.Errorf("incomplete = %v, want one naming the discovered UID", diag.Incomplete)
+	}
+}
+
+// Every key after the root is read at the revision the root read was served
+// at, so the rows describe one point in time instead of a rolling read.
+func TestBuildProfile_ReadsChildrenAtRootRevision(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+		{Kind: kindTaskRun, Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "build-compile"}},
+	}
+	getter := &revRecordingGetter{fakeGetter: fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build":     {Version: 3, ValueBytes: 100, headerRevision: 4242},
+		"/registry/tekton.dev/taskruns/ci/build-compile": {Version: 5, ValueBytes: 200, headerRevision: 4300},
+	}}}
+
+	if _, _, err := buildProfile(context.Background(), fakeLister{refs: refs}, getter, defaultEtcdPrefix, "ci", "build", false); err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	if got := getter.revs["/registry/tekton.dev/pipelineruns/ci/build"]; got != 0 {
+		t.Errorf("root was read at rev %d, want 0 (latest)", got)
+	}
+	if got := getter.revs["/registry/tekton.dev/taskruns/ci/build-compile"]; got != 4242 {
+		t.Errorf("child was read at rev %d, want the root's revision 4242", got)
+	}
+}
+
+type revRecordingGetter struct {
+	fakeGetter
+	revs map[string]int64
+}
+
+func (r *revRecordingGetter) get(ctx context.Context, key string, rev int64) (etcdObject, error) {
+	if r.revs == nil {
+		r.revs = map[string]int64{}
+	}
+	r.revs[key] = rev
+	return r.fakeGetter.get(ctx, key, rev)
+}
+
+// The value a matching object stores must satisfy the check, so a healthy
+// profile is not turned into warnings.
+func TestBuildProfile_MatchingUIDIsCounted(t *testing.T) {
+	const uid = "uid-generation-1"
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, UID: uid, Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build": {
+			Version: 3, ValueBytes: 100,
+			value: []byte("\x0a\x24" + uid + "trailing-protobuf-bytes"),
+		},
+	}}
+
+	p, diag, err := buildProfile(context.Background(), fakeLister{refs: refs}, getter, defaultEtcdPrefix, "ci", "build", true)
+	if err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	if p.Total.Count != 1 {
+		t.Errorf("Total.Count = %d, want 1", p.Total.Count)
+	}
+	if len(diag.Incomplete) != 0 {
+		t.Errorf("incomplete = %v, want none", diag.Incomplete)
+	}
+}
+
+// On a cluster that encrypts values at rest the stored bytes carry no readable
+// UID, so -verify-uid=false is the documented escape hatch. That must not also
+// give up the anchor: if the PipelineRun was replaced while it was being read,
+// the API still says so.
+func TestBuildProfile_RootReplacedIsCaughtWithoutValueCheck(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, UID: "pr-uid", Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build": {Version: 3, ValueBytes: 100, value: []byte("ciphertext")},
+	}}
+
+	_, _, err := buildProfile(context.Background(), fakeLister{refs: refs, replaced: true}, getter, defaultEtcdPrefix, "ci", "build", false)
+	if err == nil {
+		t.Fatal("buildProfile() = nil error when the PipelineRun was replaced, want an error")
+	}
+	if !strings.Contains(err.Error(), "replaced") {
+		t.Errorf("error = %v, want it to say the object was replaced", err)
+	}
+}
+
+// On an encrypted cluster -verify-uid=false turns off the only check the
+// stored bytes can support, so the API recheck has to cover the children too:
+// a TaskRun recreated under the same name would otherwise be reported with the
+// figures of the object that replaced it.
+func TestBuildProfile_EncryptedChildReplacedIsCaught(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, UID: "pr-uid", Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+		{Kind: kindTaskRun, UID: "tr-uid-old", Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "build-compile"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build":     {Version: 3, ValueBytes: 100, value: []byte("ciphertext")},
+		"/registry/tekton.dev/taskruns/ci/build-compile": {Version: 5, ValueBytes: 200, value: []byte("ciphertext")},
+	}}
+
+	_, _, err := buildProfile(context.Background(), fakeLister{refs: refs, replaced: true}, getter, defaultEtcdPrefix, "ci", "build", false)
+	if err == nil {
+		t.Fatal("buildProfile() = nil error when a child was replaced, want an error")
+	}
+}
+
+// A child skipped as incomplete is expected to look replaced. Rechecking it
+// would turn a result -allow-partial exists to accept back into a fatal error,
+// so only what the profile counted is rechecked.
+func TestBuildProfile_SkippedChildIsNotRechecked(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, UID: "pr-uid", Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+		{Kind: kindTaskRun, UID: "tr-old", Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "compile"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build": {Version: 1, ValueBytes: 10, value: []byte("pr-uid"), headerRevision: 5},
+		"/registry/tekton.dev/taskruns/ci/compile":   {Version: 1, ValueBytes: 10, value: []byte("tr-NEW"), headerRevision: 5},
+	}}
+
+	l := &recordingLister{refs: refs}
+	p, d, err := buildProfile(context.Background(), l, getter, defaultEtcdPrefix, "ci", "build", true)
+	if err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	if p.Total.Count != 1 || len(d.Incomplete) != 1 {
+		t.Fatalf("Count = %d, incomplete = %d, want the replaced child skipped", p.Total.Count, len(d.Incomplete))
+	}
+	for _, r := range l.rechecked {
+		if r.Ref.Name == "compile" {
+			t.Errorf("the skipped child was rechecked, which would make -allow-partial useless")
+		}
+	}
+}
+
+// A measured object that vanished before its identity could be confirmed, with
+// the stored-value check off, leaves the numbers unproven rather than wrong.
+// Objects expire routinely, Events most of all, so this makes the profile short
+// and lets -allow-partial accept it instead of discarding the whole run.
+func TestBuildProfile_UnverifiableDisappearanceIsIncomplete(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, UID: "pr-uid", Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build": {Version: 1, ValueBytes: 10, value: []byte("pr-uid"), headerRevision: 5},
+	}}
+
+	p, d, err := buildProfile(context.Background(), &recordingLister{refs: refs, gone: true}, getter, defaultEtcdPrefix, "ci", "build", false)
+	if err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	if d.complete() {
+		t.Error("an unconfirmable object left the profile looking complete")
+	}
+	if p.Total.Count != 1 {
+		t.Errorf("Total.Count = %d, want the object still counted so -allow-partial can accept it", p.Total.Count)
+	}
+}
+
+// recordingLister reports what it was asked to recheck, and can pretend every
+// name has vanished from the API.
+type recordingLister struct {
+	refs           []profiledRef
+	gone           bool
+	unverifiedRoot bool
+	appeared       []profiledRef
+	rechecked      []profiledRef
+}
+
+func (l *recordingLister) list(context.Context, string, string) ([]profiledRef, []string, error) {
+	return l.refs, nil, nil
+}
+
+func (l *recordingLister) recheck(_ context.Context, _, _ string, _ []profiledRef, measured []profiledRef, storedUIDVerified bool) (recheckResult, error) {
+	l.rechecked = measured
+	if l.unverifiedRoot {
+		return recheckResult{Unverified: []profiledRef{{Kind: kindPipelineRun, UID: "pr", Ref: objectRef{Namespace: "ci", Name: "build"}}}}, nil
+	}
+	if len(l.appeared) > 0 {
+		return recheckResult{Appeared: l.appeared}, nil
+	}
+	if l.gone && !storedUIDVerified {
+		// A child, not the anchor: an unverified root is fatal on its own.
+		return recheckResult{Unverified: []profiledRef{{Kind: kindTaskRun, UID: "tr", Ref: objectRef{Namespace: "ci", Name: "ghost"}}}}, nil
+	}
+	return recheckResult{}, nil
+}
+
+// The PipelineRun anchors the report and its read fixes the revision every
+// other key is read at, so a lister that does not put it first must not be
+// allowed to anchor the profile to some other object.
+func TestBuildProfile_RootMustBeThePipelineRun(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindEvent, UID: "ev-uid", Ref: objectRef{Resource: resEvents, Namespace: "ci", Name: "build.17abc"}},
+		{Kind: kindPipelineRun, UID: "pr-uid", Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/events/ci/build.17abc":            {Version: 1, ValueBytes: 10, value: []byte("ev-uid"), headerRevision: 999},
+		"/registry/tekton.dev/pipelineruns/ci/build": {Version: 1, ValueBytes: 10, value: []byte("pr-uid"), headerRevision: 5},
+	}}
+
+	if _, _, err := buildProfile(context.Background(), fakeLister{refs: refs}, getter, defaultEtcdPrefix, "ci", "build", true); err == nil {
+		t.Fatal("buildProfile() = nil error when an Event was first, want it to refuse that anchor")
+	}
+}
+
+// The reported revision is the one the reads were pinned to. It cannot be read
+// off a row: rows are sorted for output, and only the PipelineRun is read at
+// latest, so a child's header carries the store revision at its own read rather
+// than the pinned one.
+func TestBuildProfile_ReportsThePinnedRevision(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, UID: "pr-uid", Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+		// An Event sorts before PipelineRun, so it heads the rendered rows.
+		{Kind: kindEvent, UID: "ev-uid", Ref: objectRef{Resource: resEvents, Namespace: "ci", Name: "build.17abc"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build": {Version: 1, ValueBytes: 10, value: []byte("pr-uid"), headerRevision: 100},
+		"/registry/events/ci/build.17abc":            {Version: 1, ValueBytes: 10, value: []byte("ev-uid"), headerRevision: 999},
+	}}
+
+	p, _, err := buildProfile(context.Background(), fakeLister{refs: refs}, getter, defaultEtcdPrefix, "ci", "build", true)
+	if err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	if p.Revision != 100 {
+		t.Errorf("Revision = %d, want the PipelineRun's 100", p.Revision)
+	}
+	if p.Objects[0].Kind == kindPipelineRun {
+		t.Fatal("test setup: the Event should sort first, or this proves nothing")
+	}
+}
+
+// An object whose identity could not be confirmed must not contribute figures
+// that were just declared unattributable.
+func TestBuildProfile_UnverifiedRowIsNotCounted(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, UID: "pr", Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+		{Kind: kindTaskRun, UID: "tr", Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "ghost"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build": {Version: 1, ValueBytes: 100, value: []byte("pr"), headerRevision: 7},
+		"/registry/tekton.dev/taskruns/ci/ghost":     {Version: 9, ValueBytes: 3000, value: []byte("tr"), headerRevision: 7},
+	}}
+
+	p, d, err := buildProfile(context.Background(), &recordingLister{refs: refs, gone: true}, getter, defaultEtcdPrefix, "ci", "build", false)
+	if err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	if p.Total.Count != 1 || p.Total.TotalRevisions != 1 {
+		t.Errorf("Total = %d objects / %d revisions, want only the PipelineRun: the unattributable row must be left out",
+			p.Total.Count, p.Total.TotalRevisions)
+	}
+	if d.complete() {
+		t.Error("dropping a row left the profile looking complete")
+	}
+}
+
+// Losing the anchor is worse than losing a row: nothing else can be attributed.
+func TestBuildProfile_UnverifiedRootIsFatal(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, UID: "pr", Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build": {Version: 1, ValueBytes: 100, value: []byte("pr"), headerRevision: 7},
+	}}
+	l := &recordingLister{refs: refs, unverifiedRoot: true}
+
+	if _, _, err := buildProfile(context.Background(), l, getter, defaultEtcdPrefix, "ci", "build", false); err == nil {
+		t.Fatal("buildProfile() = nil error when the anchor could not be confirmed, want an error")
+	}
+}
+
+// A candidate that turned up after the reads is only a real omission if it
+// existed at the pinned revision. One created later is rightly absent.
+func TestBuildProfile_AppearedIsProbedAtThePinnedRevision(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: kindPipelineRun, UID: "pr", Ref: objectRef{Group: groupTektonDev, Resource: resPipelineRuns, Namespace: "ci", Name: "build"}},
+	}
+	existed := profiledRef{Kind: kindTaskRun, UID: "t1", Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "early"}}
+	later := profiledRef{Kind: kindTaskRun, UID: "t2", Ref: objectRef{Group: groupTektonDev, Resource: resTaskRuns, Namespace: "ci", Name: "late"}}
+
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build": {Version: 1, ValueBytes: 100, value: []byte("pr"), headerRevision: 7},
+		// "early" is readable at the pinned revision; "late" is absent from the map.
+		"/registry/tekton.dev/taskruns/ci/early": {Version: 1, ValueBytes: 10, value: []byte("t1"), headerRevision: 7},
+	}}
+	l := &recordingLister{refs: refs, appeared: []profiledRef{existed, later}}
+
+	_, d, err := buildProfile(context.Background(), l, getter, defaultEtcdPrefix, "ci", "build", true)
+	if err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	joined := strings.Join(d.Incomplete, " | ")
+	if !strings.Contains(joined, "early") {
+		t.Errorf("an object that existed at the pinned revision was not reported: %v", d.Incomplete)
+	}
+	if strings.Contains(joined, "late") {
+		t.Errorf("an object created after the pinned revision was reported as missing: %v", d.Incomplete)
+	}
+}


### PR DESCRIPTION
# Changes

Adds a developer guide on profiling the etcd revision overhead of Tekton objects, plus a small helper under `hack/etcd-revision-profile` that reports the revision and byte footprint of a PipelineRun, its TaskRuns, their Pods and the Events for all of those, per object and summarised by kind. The measurable primitive is each key's etcd `version`, which counts writes and so equals its revision count.

Membership is settled by the controller owner reference, and labels are not used to find children at all. Labels are mutable, can be copied onto an unrelated object, and the UID one only exists from Tekton v0.63, so selecting on them both misses a child whose labels were stripped and picks up objects that merely look related. Listing the namespace and keeping what this run owns costs one call per resource and cannot be fooled either way. It is also what rejects objects orphaned by an earlier run of the same name and TaskRuns a custom task created for itself.

The PipelineRun is read first and insisted on, since without it there is nothing to attribute the children to, and the revision that read was served at is reused for every other key so every value in the table comes from one revision. The identity of everything the profile counted is rechecked through the API afterwards, listing without a selector so a same-name replacement cannot hide by dropping its labels, and comparing the controller owner as well as the UID. Objects already reported as missing are left out of that check, so `-allow-partial` can still accept them. That recheck reads no stored values, so it is what keeps the report honest where encryption at rest leaves no readable UID.

Storage keys are built under the apiserver's `--etcd-prefix`; an explicitly empty or root prefix is honoured rather than turned back into `/registry`. etcd keys hold names rather than UIDs, so an object recreated under the same name between discovery and the read would otherwise be counted as the object that was discovered; the stored value still carries the real UID in both the JSON used for CRDs and the protobuf used for core resources, so the helper compares them, with `-verify-uid` to turn that off where values are ciphertext.

Diagnostics are split by what they mean. `note:` lines are things worth knowing that do not affect the numbers, such as the CustomRuns or child PipelineRuns a run owns but the helper does not profile, so a pipeline built out of those is not mistaken for one with no children. `missing:` lines are objects that could not be measured, and the run exits non-zero unless `-allow-partial` is passed.

The pure analysis (key layout, etcdctl JSON parsing, aggregation, rendering) is unit-tested with no cluster dependency. The kubectl/etcdctl shell goes through a runner seam so discovery and argument building are covered with a fake. The guide's figures and its sample output are pasted from a real pipeline run.

Implements deliverables 1 and 3 of #10322 (kept in one PR since the guide documents the helper). The reconcile span attribute (deliverable 2) is in #10330.

/kind feature

# Release Notes

```release-note
NONE
```