### PR TITLE
feat(tracing): record reconcile.write_intent span attribute

### DIFF
--- a/docs/developers/tracing.md
+++ b/docs/developers/tracing.md
@@ -48,3 +48,43 @@ equivalent to or stricter than the CloudEvents sink.
 Before enabling tracing in multi-tenant environments, review your trace backend
 retention and access control policies to ensure that resource identifiers
 exposed in span attributes are appropriately protected.
+
+## Reading the reconcile.write_intent attribute
+
+The `PipelineRun:ReconcileKind` and `TaskRun:ReconcileKind` spans carry a
+`reconcile.write_intent` attribute with one of four values:
+
+| Value | Meaning | Writes intended |
+| --- | --- | --- |
+| `no-op` | nothing changed, so the framework's `DeepEqual` check short-circuits the write | 0 |
+| `status-only` | only the status changed, which the generated reconciler writes to the status subresource | 1 |
+| `metadata-only` | the reconcile updated the object's labels or annotations | 1 |
+| `metadata-and-status` | both changed | 2 |
+
+The last value is not a formality. Tekton updates labels and annotations while
+`ReconcileKind` runs, and the framework updates the status subresource after it
+returns; both land on the same etcd key, so such a pass intends two writes and
+raises its `version` twice when both succeed. Being an intent, it cannot say
+whether they did: either update can still conflict, be retried, or be rejected.
+
+It answers "how many reconciliations actually intend to write, versus being
+short-circuited", which is the question behind profiling a workload's etcd
+revision overhead.
+
+Read it with its limits in mind:
+
+- It is an intent, not an outcome. The metadata half is taken from the branch
+  that issues the update, and the status half from the same comparison the
+  generated reconciler makes after `ReconcileKind` returns, by which point this
+  span has ended. Either update can still be rejected, conflict, or be retried,
+  and it is counted here regardless.
+- It describes the reconciled object, not everything the pass touched. Creating
+  a Pod or a child TaskRun is a write to a different object and is not counted
+  here, though it almost always changes the parent's status too. Writes by other
+  actors, Chains and Results among them, raise the same key's `version` without
+  appearing on these spans at all.
+- It exists only on recording spans, so the counts are of the reconciliations
+  that were sampled and exported. A known, uniform probabilistic sampler can be
+  corrected for by its probability; tail- or content-based sampling keeps traces
+  for reasons correlated with what happened in them, and no single multiplier
+  recovers a total from that.

--- a/docs/developers/tracing.md
+++ b/docs/developers/tracing.md
@@ -48,3 +48,56 @@ equivalent to or stricter than the CloudEvents sink.
 Before enabling tracing in multi-tenant environments, review your trace backend
 retention and access control policies to ensure that resource identifiers
 exposed in span attributes are appropriately protected.
+
+## Reading the reconcile.write_intent attribute
+
+The `PipelineRun:ReconcileKind` and `TaskRun:ReconcileKind` spans carry a
+`reconcile.write_intent` attribute with one of four values:
+
+| Value | Meaning | Update paths taken |
+| --- | --- | --- |
+| `no-op` | nothing changed, so the framework's `DeepEqual` check short-circuits the write | 0 |
+| `status-only` | the status differs from what the reconcile started with, so the generated reconciler goes on to write the status subresource | up to 1 |
+| `metadata-only` | the reconcile took the branch that updates the object's labels or annotations | up to 1 |
+| `metadata-and-status` | both | up to 2 |
+
+The last value is not a formality. Tekton updates labels and annotations while
+`ReconcileKind` runs, and the framework updates the status subresource after it
+returns; both land on the same etcd key, so such a pass can account for two
+revisions. It is an upper bound rather than a count: either request can
+conflict or be rejected, and one carrying nothing the stored object does not
+already have is a no-op below the API.
+
+It answers "how many reconciliations actually intend to write, versus being
+short-circuited", which is the question behind profiling a workload's etcd
+revision overhead.
+
+Read it with its limits in mind:
+
+- It is an intent, not an outcome. The metadata half is taken from the branch
+  that issues the update, and the status half from the same comparison the
+  generated reconciler makes after `ReconcileKind` returns, by which point this
+  span has ended. Either update can still be rejected, conflict, or be retried,
+  and it is counted here regardless.
+- It describes the reconciled object, not everything the pass touched. Creating
+  a Pod or a child TaskRun is a write to a different object and is not counted
+  here, though it almost always changes the parent's status too. Writes by other
+  actors, Chains and Results among them, raise the same key's `version` without
+  appearing on these spans at all.
+- It is computed only on recording spans, which is not the same set as the ones
+  a backend ends up holding. A span can record while its trace is unsampled, and
+  a Collector can drop a recorded span later, so what you can count is whatever
+  the SDK, the export pipeline and the backend retained.
+- Sampling is not an independent draw per reconcile. Tekton persists the
+  `traceparent` in the status and restores it on the next pass, and a PipelineRun
+  passes it to its TaskRuns, so with a parent-based sampler the decision is made
+  once for a trace and inherited by everything under it. Scaling by `1/p` is
+  reasonable across many independent runs, and not for one run or a handful of
+  objects. Tail- or content-based sampling keeps traces for reasons correlated
+  with what happened in them, and no single multiplier recovers a total from
+  that.
+- Turning tracing on is not free of the thing it measures. The first traced pass
+  persists the span context into the status, which is itself a write: it often
+  rides along with a status update the reconcile was making anyway, but on an
+  otherwise idle or completed object it is the write, and the update it causes
+  brings the next reconcile with it.

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -190,10 +191,30 @@ var (
 // resource with the current status of the resource.
 func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
+
+	// initTracing can persist span context into the status, a real write. Hold
+	// the prior value so that write is not lost when the baseline is taken
+	// after. Holding the map rather than copying it is safe because initTracing
+	// assigns a whole new map, and never writes through the one already there.
+	oldSpanContext := pr.Status.SpanContext
+
 	ctx, rootSpan := initTracing(ctx, c.tracerProvider, pr)
 	defer rootSpan.End()
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "PipelineRun:ReconcileKind")
 	defer span.End()
+
+	// Everything the attribute needs is set up here rather than above, so a
+	// reconcile whose span does not record pays for none of it. A cluster with
+	// tracing off, or one whose trace was not sampled, reconciles as before.
+	if span.IsRecording() {
+		var metadataUpdateAttempted *atomic.Bool
+		ctx, metadataUpdateAttempted = tknreconciler.TrackMetadataUpdate(ctx)
+		oldStatus := pr.Status.DeepCopy()
+		oldStatus.SpanContext = oldSpanContext // restore the pre-initTracing value
+		defer func() {
+			tknreconciler.RecordWriteIntent(span, oldStatus, &pr.Status, metadataUpdateAttempted.Load())
+		}()
+	}
 
 	span.SetAttributes(
 		attribute.String("pipelinerun", pr.Name), attribute.String("namespace", pr.Namespace),
@@ -1948,6 +1969,7 @@ func (c *Reconciler) updateLabelsAndAnnotations(ctx context.Context, pr *v1.Pipe
 		// Properly merge labels and annotations, as the labels *might* have changed during the reconciliation
 		newPr.Labels = kmap.Union(newPr.Labels, pr.Labels)
 		newPr.Annotations = kmap.Union(newPr.Annotations, pr.Annotations)
+		tknreconciler.MarkMetadataUpdate(ctx)
 		return c.PipelineClientSet.TektonV1().PipelineRuns(pr.Namespace).Update(ctx, newPr, metav1.UpdateOptions{})
 	}
 	return newPr, nil

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -204,13 +204,15 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 	defer span.End()
 
 	// Everything the attribute needs is set up here rather than above, so a
-	// reconcile whose span does not record pays for none of it. A cluster with
-	// tracing off, or one whose trace was not sampled, reconciles as before.
+	// reconcile whose span does not record pays for none of it. Recording is
+	// the only thing checked: a span can record without being exported.
 	if span.IsRecording() {
 		var metadataUpdateAttempted *atomic.Bool
 		ctx, metadataUpdateAttempted = tknreconciler.TrackMetadataUpdate(ctx)
 		oldStatus := pr.Status.DeepCopy()
-		oldStatus.SpanContext = oldSpanContext // restore the pre-initTracing value
+		// Cloned, so the baseline does not depend on initTracing never writing
+		// into a map it was handed.
+		oldStatus.SpanContext = maps.Clone(oldSpanContext)
 		defer func() {
 			tknreconciler.RecordWriteIntent(span, oldStatus, &pr.Status, metadataUpdateAttempted.Load())
 		}()

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -184,9 +184,25 @@ var (
 // resource with the current status of the resource.
 func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
+
+	// initTracing can persist span context into the status, a real write. Note
+	// its prior value so that write is not lost when the baseline is taken after.
+	oldSpanContext := maps.Clone(pr.Status.SpanContext)
+	ctx, metadataWritten := tknreconciler.TrackMetadataWrite(ctx)
+
 	ctx = initTracing(ctx, c.tracerProvider, pr)
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "PipelineRun:ReconcileKind")
 	defer span.End()
+
+	// Copy the status to compare write intent only when the span records, so an
+	// untraced cluster does not copy it on every reconcile.
+	if span.IsRecording() {
+		oldStatus := pr.Status.DeepCopy()
+		oldStatus.SpanContext = oldSpanContext // restore the pre-initTracing value
+		defer func() {
+			tknreconciler.RecordWriteIntent(span, *oldStatus, pr.Status, metadataWritten.Load())
+		}()
+	}
 
 	span.SetAttributes(
 		attribute.String("pipelinerun", pr.Name), attribute.String("namespace", pr.Namespace),
@@ -1937,6 +1953,7 @@ func (c *Reconciler) updateLabelsAndAnnotations(ctx context.Context, pr *v1.Pipe
 		// Properly merge labels and annotations, as the labels *might* have changed during the reconciliation
 		newPr.Labels = kmap.Union(newPr.Labels, pr.Labels)
 		newPr.Annotations = kmap.Union(newPr.Annotations, pr.Annotations)
+		tknreconciler.MetadataWritten(ctx)
 		return c.PipelineClientSet.TektonV1().PipelineRuns(pr.Namespace).Update(ctx, newPr, metav1.UpdateOptions{})
 	}
 	return newPr, nil

--- a/pkg/reconciler/pipelinerun/write_intent_test.go
+++ b/pkg/reconciler/pipelinerun/write_intent_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/pipelinerunmetrics"
+	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	"github.com/tektoncd/pipeline/test"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+// TestReconcileKindRecordsWriteIntent drives the real ReconcileKind against a
+// recording tracer and reads the attribute back off the span it produced.
+//
+// A completed PipelineRun is used because that path returns early and skips the
+// labels and annotations update, so the only thing left to change is the span
+// context initTracing persists. That is a real write and must not be reported
+// as a no-op, which is why the baseline is captured before initTracing.
+func TestReconcileKindRecordsWriteIntent(t *testing.T) {
+	tests := []struct {
+		name        string
+		spanContext map[string]string
+		want        string
+	}{{
+		name: "only the span context initTracing persists changed",
+		want: "status-only",
+	}, {
+		name:        "span context already stored, so nothing changed",
+		spanContext: map[string]string{"traceparent": "00-0f57e147e992b304d977436289d10628-73d5909e31793992-01"},
+		want:        "no-op",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pipelinerun-done", Namespace: "foo"},
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionTrue,
+						Reason: v1.PipelineRunReasonSuccessful.String(),
+					}}},
+				},
+			}
+			pr.Status.SpanContext = tc.spanContext
+
+			ctx, _ := ttesting.SetupFakeContext(t)
+			clients, informers := test.SeedTestData(t, ctx, test.Data{PipelineRuns: []*v1.PipelineRun{pr}})
+			metrics, err := pipelinerunmetrics.NewRecorder(ctx)
+			if err != nil {
+				t.Fatalf("pipelinerunmetrics.NewRecorder() error: %v", err)
+			}
+
+			recorder := tracetest.NewSpanRecorder()
+			c := &Reconciler{
+				KubeClientSet:     clients.Kube,
+				PipelineClientSet: clients.Pipeline,
+				Clock:             testClock,
+				pipelineRunLister: informers.PipelineRun.Lister(),
+				metrics:           metrics,
+				tracerProvider:    tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(recorder)),
+			}
+
+			if err := c.ReconcileKind(ctx, pr); err != nil {
+				t.Fatalf("ReconcileKind() error: %v", err)
+			}
+
+			got, found := "", false
+			for _, s := range recorder.Ended() {
+				if s.Name() != "PipelineRun:ReconcileKind" {
+					continue
+				}
+				for _, attr := range s.Attributes() {
+					if string(attr.Key) == "reconcile.write_intent" {
+						got, found = attr.Value.AsString(), true
+					}
+				}
+			}
+			if !found {
+				t.Fatal("no reconcile.write_intent attribute on the PipelineRun:ReconcileKind span")
+			}
+			if got != tc.want {
+				t.Errorf("reconcile.write_intent = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/pipelinerun/write_intent_test.go
+++ b/pkg/reconciler/pipelinerun/write_intent_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"errors"
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/pipelinerunmetrics"
+	tknreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
+	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	"github.com/tektoncd/pipeline/test"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+// TestReconcileKindRecordsWriteIntent drives the real ReconcileKind against a
+// recording tracer and reads the attribute back off the span it produced.
+//
+// A completed PipelineRun is used because that path returns early and skips the
+// labels and annotations update, so the only thing left to change is the span
+// context initTracing persists. That is a real write and must not be reported
+// as a no-op, which is why the baseline is captured before initTracing.
+func TestReconcileKindRecordsWriteIntent(t *testing.T) {
+	tests := []struct {
+		name        string
+		spanContext map[string]string
+		want        string
+	}{{
+		name: "only the span context initTracing persists changed",
+		want: "status-only",
+	}, {
+		name:        "span context already stored, so nothing changed",
+		spanContext: map[string]string{"traceparent": "00-0f57e147e992b304d977436289d10628-73d5909e31793992-01"},
+		want:        "no-op",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pipelinerun-done", Namespace: "foo"},
+				Status: v1.PipelineRunStatus{
+					Status: duckv1.Status{Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionTrue,
+						Reason: v1.PipelineRunReasonSuccessful.String(),
+					}}},
+				},
+			}
+			pr.Status.SpanContext = tc.spanContext
+
+			ctx, _ := ttesting.SetupFakeContext(t)
+			clients, informers := test.SeedTestData(t, ctx, test.Data{PipelineRuns: []*v1.PipelineRun{pr}})
+			metrics, err := pipelinerunmetrics.NewRecorder(ctx)
+			if err != nil {
+				t.Fatalf("pipelinerunmetrics.NewRecorder() error: %v", err)
+			}
+
+			recorder := tracetest.NewSpanRecorder()
+			c := &Reconciler{
+				KubeClientSet:     clients.Kube,
+				PipelineClientSet: clients.Pipeline,
+				Clock:             testClock,
+				pipelineRunLister: informers.PipelineRun.Lister(),
+				metrics:           metrics,
+				tracerProvider:    tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(recorder)),
+			}
+
+			if err := c.ReconcileKind(ctx, pr); err != nil {
+				t.Fatalf("ReconcileKind() error: %v", err)
+			}
+
+			got, found := "", false
+			for _, s := range recorder.Ended() {
+				if s.Name() != "PipelineRun:ReconcileKind" {
+					continue
+				}
+				for _, attr := range s.Attributes() {
+					if string(attr.Key) == "reconcile.write_intent" {
+						got, found = attr.Value.AsString(), true
+					}
+				}
+			}
+			if !found {
+				t.Fatal("no reconcile.write_intent attribute on the PipelineRun:ReconcileKind span")
+			}
+			if got != tc.want {
+				t.Errorf("reconcile.write_intent = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The metadata half is taken from the branch that actually updates the object,
+// not from comparing its labels and annotations before and after. Those differ:
+// updateLabelsAndAnnotations compares against the informer lister's copy, so
+// metadata another actor changed during the reconcile makes it take the branch
+// even though nothing local moved. Inferring from the local object reports
+// no-op for that.
+//
+// Driving updateLabelsAndAnnotations rather than the whole reconcile keeps this
+// to the branch under test: what it proves is that taking the branch is what
+// sets the flag, and that a request really went out when it did.
+func TestUpdateLabelsAndAnnotationsMarksTheMetadataUpdate(t *testing.T) {
+	// What the API already holds: this reconcile never touches the extra key.
+	stored := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pipelinerun-metadata", Namespace: "foo",
+			Annotations: map[string]string{"example.dev/added-by": "another-controller"},
+		},
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	clients, informers := test.SeedTestData(t, ctx, test.Data{PipelineRuns: []*v1.PipelineRun{stored}})
+
+	// The object this pass is reconciling, from before the other actor wrote.
+	reconciling := stored.DeepCopy()
+	delete(reconciling.Annotations, "example.dev/added-by")
+
+	c := &Reconciler{
+		PipelineClientSet: clients.Pipeline,
+		pipelineRunLister: informers.PipelineRun.Lister(),
+		tracerProvider:    tracesdk.NewTracerProvider(),
+	}
+
+	ctx, attempted := tknreconciler.TrackMetadataUpdate(ctx)
+	if _, err := c.updateLabelsAndAnnotations(ctx, reconciling); err != nil {
+		t.Fatalf("updateLabelsAndAnnotations() error: %v", err)
+	}
+
+	if !attempted.Load() {
+		t.Error("the metadata update was not marked, so a reconcile taking this branch would be classified as if it had not")
+	}
+
+	// Read the flag against what the client saw, so a marker left in the wrong
+	// place cannot report an update that never went out.
+	updated := false
+	for _, action := range clients.Pipeline.Actions() {
+		if action.Matches("update", "pipelineruns") && action.GetSubresource() == "" {
+			updated = true
+		}
+	}
+	if !updated {
+		t.Error("no PipelineRun update reached the client, so the flag above is not describing a request")
+	}
+}
+
+// A request that fails is still a request the reconcile made, and the attribute
+// is an upper bound on the update paths a pass selected rather than a count of
+// what committed. The flag is set before the call for that reason, so a
+// conflict or any other rejection leaves it set.
+func TestUpdateLabelsAndAnnotationsMarksAnUpdateThatFails(t *testing.T) {
+	stored := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pipelinerun-metadata-fails", Namespace: "foo",
+			Annotations: map[string]string{"example.dev/added-by": "another-controller"},
+		},
+	}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	clients, informers := test.SeedTestData(t, ctx, test.Data{PipelineRuns: []*v1.PipelineRun{stored}})
+
+	rejected := errors.New("the apiserver rejected it")
+	clients.Pipeline.PrependReactor("update", "pipelineruns", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, rejected
+	})
+
+	reconciling := stored.DeepCopy()
+	delete(reconciling.Annotations, "example.dev/added-by")
+
+	c := &Reconciler{
+		PipelineClientSet: clients.Pipeline,
+		pipelineRunLister: informers.PipelineRun.Lister(),
+		tracerProvider:    tracesdk.NewTracerProvider(),
+	}
+
+	ctx, attempted := tknreconciler.TrackMetadataUpdate(ctx)
+	if _, err := c.updateLabelsAndAnnotations(ctx, reconciling); !errors.Is(err, rejected) {
+		t.Fatalf("updateLabelsAndAnnotations() error = %v, want %v", err, rejected)
+	}
+	if !attempted.Load() {
+		t.Error("the failed update was not marked, so a pass that issued a request would be reported as if it had not")
+	}
+}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -150,13 +150,15 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	defer span.End()
 
 	// Everything the attribute needs is set up here rather than above, so a
-	// reconcile whose span does not record pays for none of it. A cluster with
-	// tracing off, or one whose trace was not sampled, reconciles as before.
+	// reconcile whose span does not record pays for none of it. Recording is
+	// the only thing checked: a span can record without being exported.
 	if span.IsRecording() {
 		var metadataUpdateAttempted *atomic.Bool
 		ctx, metadataUpdateAttempted = tknreconciler.TrackMetadataUpdate(ctx)
 		oldStatus := tr.Status.DeepCopy()
-		oldStatus.SpanContext = oldSpanContext // restore the pre-initTracing value
+		// Cloned, so the baseline does not depend on initTracing never writing
+		// into a map it was handed.
+		oldStatus.SpanContext = maps.Clone(oldSpanContext)
 		defer func() {
 			tknreconciler.RecordWriteIntent(span, oldStatus, &tr.Status, metadataUpdateAttempted.Load())
 		}()

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/tektoncd/pipeline/internal/sidecarlogresults"
@@ -136,10 +137,30 @@ var (
 // resource with the current status of the resource.
 func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
+
+	// initTracing can persist span context into the status, a real write. Hold
+	// the prior value so that write is not lost when the baseline is taken
+	// after. Holding the map rather than copying it is safe because initTracing
+	// assigns a whole new map, and never writes through the one already there.
+	oldSpanContext := tr.Status.SpanContext
+
 	ctx, rootSpan := initTracing(ctx, c.tracerProvider, tr)
 	defer rootSpan.End()
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "TaskRun:ReconcileKind")
 	defer span.End()
+
+	// Everything the attribute needs is set up here rather than above, so a
+	// reconcile whose span does not record pays for none of it. A cluster with
+	// tracing off, or one whose trace was not sampled, reconciles as before.
+	if span.IsRecording() {
+		var metadataUpdateAttempted *atomic.Bool
+		ctx, metadataUpdateAttempted = tknreconciler.TrackMetadataUpdate(ctx)
+		oldStatus := tr.Status.DeepCopy()
+		oldStatus.SpanContext = oldSpanContext // restore the pre-initTracing value
+		defer func() {
+			tknreconciler.RecordWriteIntent(span, oldStatus, &tr.Status, metadataUpdateAttempted.Load())
+		}()
+	}
 
 	span.SetAttributes(attribute.String("taskrun", tr.Name), attribute.String("namespace", tr.Namespace))
 	if spanCtx := span.SpanContext(); spanCtx.IsValid() {
@@ -896,6 +917,7 @@ func (c *Reconciler) updateLabelsAndAnnotations(ctx context.Context, tr *v1.Task
 		newTr = newTr.DeepCopy()
 		newTr.Labels = kmap.Union(newTr.Labels, tr.Labels)
 		newTr.Annotations = kmap.Union(kmap.ExcludeKeys(newTr.Annotations, tknreconciler.KubectlLastAppliedAnnotationKey), tr.Annotations)
+		tknreconciler.MarkMetadataUpdate(ctx)
 		return c.PipelineClientSet.TektonV1().TaskRuns(tr.Namespace).Update(ctx, newTr, metav1.UpdateOptions{})
 	}
 	return newTr, nil

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -131,9 +131,25 @@ var (
 // resource with the current status of the resource.
 func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
+
+	// initTracing can persist span context into the status, a real write. Note
+	// its prior value so that write is not lost when the baseline is taken after.
+	oldSpanContext := maps.Clone(tr.Status.SpanContext)
+	ctx, metadataWritten := tknreconciler.TrackMetadataWrite(ctx)
+
 	ctx = initTracing(ctx, c.tracerProvider, tr)
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "TaskRun:ReconcileKind")
 	defer span.End()
+
+	// Copy the status to compare write intent only when the span records, so an
+	// untraced cluster does not copy it on every reconcile.
+	if span.IsRecording() {
+		oldStatus := tr.Status.DeepCopy()
+		oldStatus.SpanContext = oldSpanContext // restore the pre-initTracing value
+		defer func() {
+			tknreconciler.RecordWriteIntent(span, *oldStatus, tr.Status, metadataWritten.Load())
+		}()
+	}
 
 	span.SetAttributes(attribute.String("taskrun", tr.Name), attribute.String("namespace", tr.Namespace))
 	if spanCtx := span.SpanContext(); spanCtx.IsValid() {
@@ -868,6 +884,7 @@ func (c *Reconciler) updateLabelsAndAnnotations(ctx context.Context, tr *v1.Task
 		newTr = newTr.DeepCopy()
 		newTr.Labels = kmap.Union(newTr.Labels, tr.Labels)
 		newTr.Annotations = kmap.Union(kmap.ExcludeKeys(newTr.Annotations, tknreconciler.KubectlLastAppliedAnnotationKey), tr.Annotations)
+		tknreconciler.MetadataWritten(ctx)
 		return c.PipelineClientSet.TektonV1().TaskRuns(tr.Namespace).Update(ctx, newTr, metav1.UpdateOptions{})
 	}
 	return newTr, nil

--- a/pkg/reconciler/taskrun/write_intent_test.go
+++ b/pkg/reconciler/taskrun/write_intent_test.go
@@ -114,7 +114,7 @@ func TestReconcileKindRecordsWriteIntent(t *testing.T) {
 
 // The metadata half is taken from the branch that actually updates the object,
 // not from comparing its labels and annotations before and after. Those differ:
-// updateLabelsAndAnnotations compares against a freshly read object, so metadata
+// updateLabelsAndAnnotations compares against the informer lister's copy, so metadata
 // another actor changed during the reconcile makes it write even though nothing
 // local moved. Inferring from the local object reports no-op for that.
 func TestReconcileKindRecordsMetadataWriteAnotherActorCaused(t *testing.T) {

--- a/pkg/reconciler/taskrun/write_intent_test.go
+++ b/pkg/reconciler/taskrun/write_intent_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	podconvert "github.com/tektoncd/pipeline/pkg/pod"
+	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	"github.com/tektoncd/pipeline/test"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/changeset"
+)
+
+// TestReconcileKindRecordsWriteIntent drives the real ReconcileKind against a
+// recording tracer and reads the attribute back off the span it produced.
+//
+// A pending TaskRun is used because that path returns before anything needs the
+// metrics recorder or a pod, and because one already marked pending changes no
+// condition of its own. What is left is what the reconcile itself writes: the
+// release annotation, and the span context initTracing persists. The latter is
+// a real write that must not be reported as a no-op, which is why the baseline
+// is captured before initTracing.
+func TestReconcileKindRecordsWriteIntent(t *testing.T) {
+	release := map[string]string{podconvert.ReleaseAnnotation: changeset.Get()}
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		spanContext map[string]string
+		want        string
+	}{{
+		// The reconcile stamps the controller version on the object, which
+		// updateLabelsAndAnnotations persists with a full object Update, and
+		// initTracing persists span context into the status, which the
+		// framework writes separately. Two writes to one key.
+		name: "the reconcile writes both the release annotation and the status",
+		want: "metadata-and-status",
+	}, {
+		name:        "only the span context initTracing persists changed",
+		annotations: release,
+		want:        "status-only",
+	}, {
+		name:        "span context already stored, so nothing changed",
+		annotations: release,
+		spanContext: map[string]string{"traceparent": "00-0f57e147e992b304d977436289d10628-73d5909e31793992-01"},
+		want:        "no-op",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-taskrun-pending", Namespace: "foo", Annotations: tc.annotations},
+				Spec:       v1.TaskRunSpec{Status: v1.TaskRunSpecStatusPending},
+			}
+			tr.Status.MarkResourceOngoing(v1.TaskRunReasonPending, fmt.Sprintf("TaskRun %q is pending", tr.Name))
+			tr.Status.SpanContext = tc.spanContext
+
+			ctx, _ := ttesting.SetupFakeContext(t)
+			clients, informers := test.SeedTestData(t, ctx, test.Data{TaskRuns: []*v1.TaskRun{tr}})
+
+			recorder := tracetest.NewSpanRecorder()
+			c := &Reconciler{
+				KubeClientSet:     clients.Kube,
+				PipelineClientSet: clients.Pipeline,
+				Clock:             testClock,
+				taskRunLister:     informers.TaskRun.Lister(),
+				podLister:         informers.Pod.Lister(),
+				tracerProvider:    tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(recorder)),
+			}
+
+			if err := c.ReconcileKind(ctx, tr); err != nil {
+				t.Fatalf("ReconcileKind() error: %v", err)
+			}
+
+			got, found := "", false
+			for _, s := range recorder.Ended() {
+				if s.Name() != "TaskRun:ReconcileKind" {
+					continue
+				}
+				for _, attr := range s.Attributes() {
+					if string(attr.Key) == "reconcile.write_intent" {
+						got, found = attr.Value.AsString(), true
+					}
+				}
+			}
+			if !found {
+				t.Fatal("no reconcile.write_intent attribute on the TaskRun:ReconcileKind span")
+			}
+			if got != tc.want {
+				t.Errorf("reconcile.write_intent = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The metadata half is taken from the branch that actually updates the object,
+// not from comparing its labels and annotations before and after. Those differ:
+// updateLabelsAndAnnotations compares against a freshly read object, so metadata
+// another actor changed during the reconcile makes it write even though nothing
+// local moved. Inferring from the local object reports no-op for that.
+func TestReconcileKindRecordsMetadataWriteAnotherActorCaused(t *testing.T) {
+	release := changeset.Get()
+	// What the API already holds: this reconcile never touches the extra key.
+	stored := &v1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-taskrun-pending", Namespace: "foo",
+			Annotations: map[string]string{
+				podconvert.ReleaseAnnotation: release,
+				"example.dev/added-by":       "another-controller",
+			},
+		},
+		Spec: v1.TaskRunSpec{Status: v1.TaskRunSpecStatusPending},
+	}
+	stored.Status.MarkResourceOngoing(v1.TaskRunReasonPending, fmt.Sprintf("TaskRun %q is pending", stored.Name))
+	stored.Status.SpanContext = map[string]string{"traceparent": "00-0f57e147e992b304d977436289d10628-73d5909e31793992-01"}
+
+	ctx, _ := ttesting.SetupFakeContext(t)
+	clients, informers := test.SeedTestData(t, ctx, test.Data{TaskRuns: []*v1.TaskRun{stored}})
+
+	// The object this pass is reconciling, from before the other actor wrote.
+	// Nothing in the reconcile changes its metadata or its status.
+	reconciling := stored.DeepCopy()
+	delete(reconciling.Annotations, "example.dev/added-by")
+
+	recorder := tracetest.NewSpanRecorder()
+	c := &Reconciler{
+		KubeClientSet:     clients.Kube,
+		PipelineClientSet: clients.Pipeline,
+		Clock:             testClock,
+		taskRunLister:     informers.TaskRun.Lister(),
+		podLister:         informers.Pod.Lister(),
+		tracerProvider:    tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(recorder)),
+	}
+	if err := c.ReconcileKind(ctx, reconciling); err != nil {
+		t.Fatalf("ReconcileKind() error: %v", err)
+	}
+
+	got := ""
+	for _, s := range recorder.Ended() {
+		if s.Name() != "TaskRun:ReconcileKind" {
+			continue
+		}
+		for _, attr := range s.Attributes() {
+			if string(attr.Key) == "reconcile.write_intent" {
+				got = attr.Value.AsString()
+			}
+		}
+	}
+	if got != "metadata-only" {
+		t.Errorf("reconcile.write_intent = %q, want %q: the reconcile issued a metadata update even though its own copy did not change", got, "metadata-only")
+	}
+}

--- a/pkg/reconciler/write_intent.go
+++ b/pkg/reconciler/write_intent.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+	"sync/atomic"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+// writeIntentAttributeKey is the span attribute recording which update paths a
+// reconcile pass selected. It is an upper bound on the revisions that pass can
+// account for, not a count of the ones etcd committed: a request can be
+// rejected, and an update carrying nothing the stored object does not already
+// have is a no-op below the API.
+const writeIntentAttributeKey = "reconcile.write_intent"
+
+const (
+	writeIntentMetadata   = "metadata-only"
+	writeIntentStatusOnly = "status-only"
+	writeIntentBoth       = "metadata-and-status"
+	writeIntentNoOp       = "no-op"
+)
+
+// classifyWriteIntent maps the update paths a reconcile selected to an intent.
+//
+// The metadata path and the status path are separate requests against the same
+// key: the reconciler updates the object itself while ReconcileKind runs, and
+// the generated reconciler updates the status subresource after it returns. A
+// pass that takes both can therefore account for two revisions, and reporting
+// it as one would undercount them.
+func classifyWriteIntent(metadataUpdateAttempted, statusDirty bool) string {
+	switch {
+	case metadataUpdateAttempted && statusDirty:
+		return writeIntentBoth
+	case metadataUpdateAttempted:
+		return writeIntentMetadata
+	case statusDirty:
+		return writeIntentStatusOnly
+	default:
+		return writeIntentNoOp
+	}
+}
+
+// metadataUpdateKey carries the flag a reconcile sets when it takes the branch
+// that updates an object's labels or annotations.
+type metadataUpdateKey struct{}
+
+// TrackMetadataUpdate returns a context carrying a flag for this reconcile to
+// set when it takes the branch that updates the object's labels or annotations,
+// and the flag itself.
+//
+// The intent is classified from that flag rather than from comparing the
+// object's metadata before and after, because the two are not the same
+// decision. The update compares against the informer lister's copy, so metadata
+// another actor changed during the reconcile makes it take the branch when
+// nothing local moved, and metadata that copy already agrees with makes it skip
+// the branch when something local did.
+func TrackMetadataUpdate(ctx context.Context) (context.Context, *atomic.Bool) {
+	attempted := &atomic.Bool{}
+	return context.WithValue(ctx, metadataUpdateKey{}, attempted), attempted
+}
+
+// MarkMetadataUpdate records that this reconcile is about to update the
+// object's labels or annotations. It is set before the request, so it survives
+// a conflict or any other failure. It does nothing when the context is not
+// tracking, so callers outside a tracked reconcile need no special case.
+func MarkMetadataUpdate(ctx context.Context) {
+	if attempted, ok := ctx.Value(metadataUpdateKey{}).(*atomic.Bool); ok {
+		attempted.Store(true)
+	}
+}
+
+// RecordWriteIntent tags span with the update paths a reconcile pass selected:
+// metadataUpdateAttempted is whether it took the branch that updates the
+// object, and the status is compared with the same equality the generated
+// reconciler uses to decide whether to write the status subresource. It no-ops
+// when the span is not recording.
+//
+// The status parameters share one type so that passing one of each does not
+// compile. Left untyped they would both satisfy any, and the comparison would
+// report a difference on every single reconcile.
+func RecordWriteIntent[S any](span trace.Span, oldStatus, newStatus *S, metadataUpdateAttempted bool) {
+	if !span.IsRecording() {
+		return
+	}
+	statusDirty := !equality.Semantic.DeepEqual(oldStatus, newStatus)
+	span.SetAttributes(attribute.String(writeIntentAttributeKey, classifyWriteIntent(metadataUpdateAttempted, statusDirty)))
+}

--- a/pkg/reconciler/write_intent.go
+++ b/pkg/reconciler/write_intent.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+	"sync/atomic"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+// writeIntentAttributeKey is the span attribute recording what a reconcile pass
+// intends to write to etcd. The generated reconciler issues the status update
+// after ReconcileKind returns, so a rejected update is not reflected here.
+const writeIntentAttributeKey = "reconcile.write_intent"
+
+const (
+	writeIntentMetadata   = "metadata-only"
+	writeIntentStatusOnly = "status-only"
+	writeIntentBoth       = "metadata-and-status"
+	writeIntentNoOp       = "no-op"
+)
+
+// classifyWriteIntent maps what changed during a reconcile to a write intent.
+//
+// A labels or annotations change and a status change are separate writes to the
+// same key: the reconciler updates the object itself while ReconcileKind runs,
+// and the generated reconciler updates the status subresource after it returns.
+// A pass that does both therefore intends two writes, and reporting it as one
+// would undercount the revisions it accounts for.
+func classifyWriteIntent(metadataChanged, statusChanged bool) string {
+	switch {
+	case metadataChanged && statusChanged:
+		return writeIntentBoth
+	case metadataChanged:
+		return writeIntentMetadata
+	case statusChanged:
+		return writeIntentStatusOnly
+	default:
+		return writeIntentNoOp
+	}
+}
+
+// metadataWriteKey carries the flag a reconcile sets when it updates an
+// object's labels or annotations.
+type metadataWriteKey struct{}
+
+// TrackMetadataWrite returns a context carrying a flag for this reconcile to
+// set when it updates the object's labels or annotations, and the flag itself.
+//
+// The write intent is classified from that flag rather than from comparing the
+// object's metadata before and after. The two are not the same decision: the
+// update compares the object against a freshly read one, so metadata another
+// actor changed during the reconcile makes it write when nothing local moved,
+// and metadata it already agrees with makes it skip when something local did.
+func TrackMetadataWrite(ctx context.Context) (context.Context, *atomic.Bool) {
+	wrote := &atomic.Bool{}
+	return context.WithValue(ctx, metadataWriteKey{}, wrote), wrote
+}
+
+// MetadataWritten records that this reconcile is updating the object's labels
+// or annotations. It does nothing when the context is not tracking, so callers
+// outside a tracked reconcile need no special case.
+func MetadataWritten(ctx context.Context) {
+	if wrote, ok := ctx.Value(metadataWriteKey{}).(*atomic.Bool); ok {
+		wrote.Store(true)
+	}
+}
+
+// RecordWriteIntent tags span with what a reconcile pass intends to write:
+// metadataWritten is whether it took the branch that updates the object, and
+// the status is compared with the same equality the generated reconciler uses
+// to decide whether to write the status subresource. It no-ops when the span is
+// not recording.
+//
+// The status parameters share one type so that passing a pointer for one and a
+// value for the other does not compile. Left untyped they would both satisfy
+// any, and the comparison would report a difference on every single reconcile.
+func RecordWriteIntent[S any](span trace.Span, oldStatus, newStatus S, metadataWritten bool) {
+	if !span.IsRecording() {
+		return
+	}
+	statusChanged := !equality.Semantic.DeepEqual(oldStatus, newStatus)
+	span.SetAttributes(attribute.String(writeIntentAttributeKey, classifyWriteIntent(metadataWritten, statusChanged)))
+}

--- a/pkg/reconciler/write_intent_test.go
+++ b/pkg/reconciler/write_intent_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel/attribute"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClassifyWriteIntent(t *testing.T) {
+	tests := []struct {
+		name            string
+		metadataChanged bool
+		statusChanged   bool
+		want            string
+	}{{
+		name: "nothing changed is a no-op",
+		want: "no-op",
+	}, {
+		name:          "only the status changed",
+		statusChanged: true,
+		want:          "status-only",
+	}, {
+		name:            "a labels/annotations change is a full object write",
+		metadataChanged: true,
+		want:            "metadata-only",
+	}, {
+		// Two writes to the same key: the object update inside ReconcileKind
+		// and the status update the framework issues after it returns.
+		name:            "metadata and status are two separate writes",
+		metadataChanged: true,
+		statusChanged:   true,
+		want:            "metadata-and-status",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyWriteIntent(tc.metadataChanged, tc.statusChanged)
+			if got != tc.want {
+				t.Errorf("classifyWriteIntent(%t, %t) = %q, want %q", tc.metadataChanged, tc.statusChanged, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRecordWriteIntent runs the same comparison and span tagging the
+// reconcilers do, on real PipelineRunStatus values, and reads the resulting
+// attribute back off a recorded span.
+func TestRecordWriteIntent(t *testing.T) {
+	started := v1.PipelineRunStatus{}
+	started.StartTime = &metav1.Time{}
+	// initTracing persists span context into the status, which is a real write.
+	spanCtxOnly := v1.PipelineRunStatus{}
+	spanCtxOnly.SpanContext = map[string]string{"traceparent": "abc"}
+
+	tests := []struct {
+		name                    string
+		oldStatus, newStatus    v1.PipelineRunStatus
+		metadataUpdateAttempted bool
+		want                    string
+	}{{
+		name: "untouched run is a no-op",
+		want: "no-op",
+	}, {
+		name:      "status moved but no metadata update was issued",
+		newStatus: started, want: "status-only",
+	}, {
+		name:      "span context persisted into status is still a write",
+		newStatus: spanCtxOnly, want: "status-only",
+	}, {
+		name: "the reconcile updated labels or annotations", metadataUpdateAttempted: true,
+		want: "metadata-only",
+	}, {
+		name: "it updated both", metadataUpdateAttempted: true, newStatus: started,
+		want: "metadata-and-status",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			provider := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(recorder))
+			_, span := provider.Tracer("test").Start(t.Context(), "reconcile")
+
+			RecordWriteIntent(span, &tc.oldStatus, &tc.newStatus, tc.metadataUpdateAttempted)
+			span.End()
+
+			ended := recorder.Ended()
+			if len(ended) != 1 {
+				t.Fatalf("recorded %d spans, want 1", len(ended))
+			}
+			value, found := "", false
+			for _, attr := range ended[0].Attributes() {
+				if string(attr.Key) == writeIntentAttributeKey {
+					value, found = attr.Value.AsString(), true
+				}
+			}
+			if !found {
+				t.Fatalf("span is missing the %q attribute, got %v", writeIntentAttributeKey, ended[0].Attributes())
+			}
+			if value != tc.want {
+				t.Errorf("write_intent = %q, want %q", value, tc.want)
+			}
+		})
+	}
+}
+
+// spanSpy is a trace.Span that reports a fixed recording state and remembers
+// whether SetAttributes was reached, so the recording guard can be observed.
+type spanSpy struct {
+	noop.Span
+	recording bool
+	attrsSet  bool
+}
+
+func (s *spanSpy) IsRecording() bool                   { return s.recording }
+func (s *spanSpy) SetAttributes(...attribute.KeyValue) { s.attrsSet = true }
+
+// A non-recording span must be left untouched: RecordWriteIntent returns before
+// comparing anything or setting the attribute, so a sampled-out reconcile pays
+// nothing. Dropping the guard would make the not-recording case fail.
+func TestRecordWriteIntentGuardsOnRecording(t *testing.T) {
+	moved := v1.PipelineRunStatus{}
+	moved.StartTime = &metav1.Time{}
+
+	tests := []struct {
+		name      string
+		recording bool
+		wantSet   bool
+	}{
+		{name: "not recording sets nothing", recording: false, wantSet: false},
+		{name: "recording sets the attribute", recording: true, wantSet: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spy := &spanSpy{recording: tc.recording}
+			RecordWriteIntent(spy, &v1.PipelineRunStatus{}, &moved, false)
+			if spy.attrsSet != tc.wantSet {
+				t.Errorf("SetAttributes reached = %t, want %t", spy.attrsSet, tc.wantSet)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/write_intent_test.go
+++ b/pkg/reconciler/write_intent_test.go
@@ -29,35 +29,35 @@ import (
 
 func TestClassifyWriteIntent(t *testing.T) {
 	tests := []struct {
-		name            string
-		metadataChanged bool
-		statusChanged   bool
-		want            string
+		name                    string
+		metadataUpdateAttempted bool
+		statusDirty             bool
+		want                    string
 	}{{
 		name: "nothing changed is a no-op",
 		want: "no-op",
 	}, {
-		name:          "only the status changed",
-		statusChanged: true,
-		want:          "status-only",
+		name:        "only the status changed",
+		statusDirty: true,
+		want:        "status-only",
 	}, {
-		name:            "a labels/annotations change is a full object write",
-		metadataChanged: true,
-		want:            "metadata-only",
+		name:                    "a labels/annotations change is a full object write",
+		metadataUpdateAttempted: true,
+		want:                    "metadata-only",
 	}, {
 		// Two writes to the same key: the object update inside ReconcileKind
 		// and the status update the framework issues after it returns.
-		name:            "metadata and status are two separate writes",
-		metadataChanged: true,
-		statusChanged:   true,
-		want:            "metadata-and-status",
+		name:                    "metadata and status are two separate writes",
+		metadataUpdateAttempted: true,
+		statusDirty:             true,
+		want:                    "metadata-and-status",
 	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := classifyWriteIntent(tc.metadataChanged, tc.statusChanged)
+			got := classifyWriteIntent(tc.metadataUpdateAttempted, tc.statusDirty)
 			if got != tc.want {
-				t.Errorf("classifyWriteIntent(%t, %t) = %q, want %q", tc.metadataChanged, tc.statusChanged, got, tc.want)
+				t.Errorf("classifyWriteIntent(%t, %t) = %q, want %q", tc.metadataUpdateAttempted, tc.statusDirty, got, tc.want)
 			}
 		})
 	}
@@ -136,7 +136,7 @@ func (s *spanSpy) IsRecording() bool                   { return s.recording }
 func (s *spanSpy) SetAttributes(...attribute.KeyValue) { s.attrsSet = true }
 
 // A non-recording span must be left untouched: RecordWriteIntent returns before
-// comparing anything or setting the attribute, so a sampled-out reconcile pays
+// comparing anything or setting the attribute, so a non-recording reconcile pays
 // nothing. Dropping the guard would make the not-recording case fail.
 func TestRecordWriteIntentGuardsOnRecording(t *testing.T) {
 	moved := v1.PipelineRunStatus{}

--- a/pkg/reconciler/write_intent_test.go
+++ b/pkg/reconciler/write_intent_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel/attribute"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClassifyWriteIntent(t *testing.T) {
+	tests := []struct {
+		name            string
+		metadataChanged bool
+		statusChanged   bool
+		want            string
+	}{{
+		name: "nothing changed is a no-op",
+		want: "no-op",
+	}, {
+		name:          "only the status changed",
+		statusChanged: true,
+		want:          "status-only",
+	}, {
+		name:            "a labels/annotations change is a full object write",
+		metadataChanged: true,
+		want:            "metadata-only",
+	}, {
+		// Two writes to the same key: the object update inside ReconcileKind
+		// and the status update the framework issues after it returns.
+		name:            "metadata and status are two separate writes",
+		metadataChanged: true,
+		statusChanged:   true,
+		want:            "metadata-and-status",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyWriteIntent(tc.metadataChanged, tc.statusChanged)
+			if got != tc.want {
+				t.Errorf("classifyWriteIntent(%t, %t) = %q, want %q", tc.metadataChanged, tc.statusChanged, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRecordWriteIntent runs the same comparison and span tagging the
+// reconcilers do, on real PipelineRunStatus values, and reads the resulting
+// attribute back off a recorded span.
+func TestRecordWriteIntent(t *testing.T) {
+	started := v1.PipelineRunStatus{}
+	started.StartTime = &metav1.Time{}
+	// initTracing persists span context into the status, which is a real write.
+	spanCtxOnly := v1.PipelineRunStatus{}
+	spanCtxOnly.SpanContext = map[string]string{"traceparent": "abc"}
+
+	tests := []struct {
+		name                 string
+		oldStatus, newStatus v1.PipelineRunStatus
+		metadataWritten      bool
+		want                 string
+	}{{
+		name: "untouched run is a no-op",
+		want: "no-op",
+	}, {
+		name:      "status moved but no metadata update was issued",
+		newStatus: started, want: "status-only",
+	}, {
+		name:      "span context persisted into status is still a write",
+		newStatus: spanCtxOnly, want: "status-only",
+	}, {
+		name: "the reconcile updated labels or annotations", metadataWritten: true,
+		want: "metadata-only",
+	}, {
+		name: "it updated both", metadataWritten: true, newStatus: started,
+		want: "metadata-and-status",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			provider := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(recorder))
+			_, span := provider.Tracer("test").Start(t.Context(), "reconcile")
+
+			RecordWriteIntent(span, tc.oldStatus, tc.newStatus, tc.metadataWritten)
+			span.End()
+
+			ended := recorder.Ended()
+			if len(ended) != 1 {
+				t.Fatalf("recorded %d spans, want 1", len(ended))
+			}
+			value, found := "", false
+			for _, attr := range ended[0].Attributes() {
+				if string(attr.Key) == writeIntentAttributeKey {
+					value, found = attr.Value.AsString(), true
+				}
+			}
+			if !found {
+				t.Fatalf("span is missing the %q attribute, got %v", writeIntentAttributeKey, ended[0].Attributes())
+			}
+			if value != tc.want {
+				t.Errorf("write_intent = %q, want %q", value, tc.want)
+			}
+		})
+	}
+}
+
+// spanSpy is a trace.Span that reports a fixed recording state and remembers
+// whether SetAttributes was reached, so the recording guard can be observed.
+type spanSpy struct {
+	noop.Span
+	recording bool
+	attrsSet  bool
+}
+
+func (s *spanSpy) IsRecording() bool                   { return s.recording }
+func (s *spanSpy) SetAttributes(...attribute.KeyValue) { s.attrsSet = true }
+
+// A non-recording span must be left untouched: RecordWriteIntent returns before
+// comparing anything or setting the attribute, so a sampled-out reconcile pays
+// nothing. Dropping the guard would make the not-recording case fail.
+func TestRecordWriteIntentGuardsOnRecording(t *testing.T) {
+	moved := v1.PipelineRunStatus{}
+	moved.StartTime = &metav1.Time{}
+
+	tests := []struct {
+		name      string
+		recording bool
+		wantSet   bool
+	}{
+		{name: "not recording sets nothing", recording: false, wantSet: false},
+		{name: "recording sets the attribute", recording: true, wantSet: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spy := &spanSpy{recording: tc.recording}
+			RecordWriteIntent(spy, v1.PipelineRunStatus{}, moved, false)
+			if spy.attrsSet != tc.wantSet {
+				t.Errorf("SetAttributes reached = %t, want %t", spy.attrsSet, tc.wantSet)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

Adds a `reconcile.write_intent` attribute to the PipelineRun and TaskRun `ReconcileKind` spans so operators can see how many reconciliations intend an etcd write versus being short-circuited by the framework's `DeepEqual` check.

It takes four values rather than three. Tekton updates labels and annotations while `ReconcileKind` runs, and the generated reconciler updates the status subresource after it returns; both land on the same etcd key, so a pass that takes both paths asks for two writes rather than one. Reporting that as a single value would understate what it selected, though neither request is guaranteed to commit a revision. `status-only` is a write too, so the metadata case is named after what changed rather than called `write`.

| Value | Meaning | Update paths selected |
| --- | --- | --- |
| `no-op` | the metadata update path was not taken and the status matches the reconcile's baseline | 0 |
| `status-only` | the status is dirty when `ReconcileKind` returns | up to 1 |
| `metadata-only` | the full-object metadata update path was taken | up to 1 |
| `metadata-and-status` | both paths were selected | up to 2 |

This is an upper bound on update paths the reconcile selected, not a count of API requests that succeeded or of etcd revisions that committed. A request can conflict, be rejected, or be a storage no-op.

The value is computed inside `ReconcileKind` and only when the span is recording, so a cluster without tracing does not copy the status on every reconcile. `initTracing` can persist span context into the status, so its prior value is kept first and a copy of it is restored onto the copied baseline; the baseline is then compared against the final status using the same `equality.Semantic.DeepEqual` the generated reconciler uses to decide the status write, so a span-context-only reconcile is reported as `status-only` rather than `no-op`.

It is named `write_intent` rather than `write_outcome` because the generated reconciler issues the status update *after* `ReconcileKind` returns, by which point this span has ended. A rejected update (conflict, requeue) is therefore not reflected. Recording the true outcome would mean instrumenting the update call itself, which is generated code. The issue asks for `reconcile.write_outcome` "or similar", and intent is what answers its question (how often the `DeepEqual` short-circuit skips a write).

Scope worth stating: the attribute exists only on recording spans, so the counts are of reconciliations whose span recorded. A recording span is not necessarily exported, and parent-based sampling decides once per trace rather than once per reconcile, so a single ratio does not turn these into totals. It covers the reconciled PipelineRun or TaskRun, not writes to Pods, Events, or writes other actors such as Chains and Results make to the same key. `docs/developers/tracing.md` documents all of this.

The metadata half comes from the branch that actually issues the update, not from comparing the object's labels and annotations before and after. Those are not the same decision: `updateLabelsAndAnnotations` compares the object against the informer lister's copy, so metadata another actor changed mid-reconcile makes it write when nothing local moved, and metadata it already agrees with makes it skip when something local did. The reconcile carries a flag for that branch to set, which also removed the four map parameters the helper used to take.

A shared `RecordWriteIntent` helper in `pkg/reconciler` does the status comparison and returns early when the span is not recording. Its status parameters share one type variable, so passing a pointer for one and a value for the other does not compile. Each reconciler is covered by a test that runs the real `ReconcileKind` against a recording tracer and reads the attribute back off the span.

Implements deliverable 2 of #10322.

/kind feature

# Release Notes

```release-note
Add a `reconcile.write_intent` attribute (no-op, status-only, metadata-only, metadata-and-status) to the PipelineRun and TaskRun reconcile spans so operators can see how many reconciliations intend an etcd write.
```
