### PR TITLE
feat: add a helper to profile etcd revision overhead of a PipelineRun

### DIFF
--- a/hack/etcd-revision-profile/README.md
+++ b/hack/etcd-revision-profile/README.md
@@ -1,0 +1,41 @@
+# etcd-revision-profile
+
+A profiling helper that reports the etcd MVCC footprint of a PipelineRun: how
+many revisions and bytes its PipelineRun, child TaskRuns, their Pods, and
+associated Events have accumulated in etcd.
+
+It is an operator tool, not part of the Tekton control plane. See
+[docs/developers/etcd-revision-profiling.md](../../docs/developers/etcd-revision-profiling.md)
+for the concepts and methodology.
+
+## Usage
+
+Run from a control-plane node (etcd client keys are root-only, so `etcdctl`
+runs via `sudo` by default):
+
+```bash
+# Whole PipelineRun (PipelineRun + TaskRuns + Pods + Events)
+go run ./hack/etcd-revision-profile -n <namespace> -pipelinerun <name>
+
+# A single raw etcd key
+go run ./hack/etcd-revision-profile -etcd-key /registry/minions/<node-name>
+```
+
+Flags: `-kubectl`, `-etcdctl` (binary paths), `-endpoints`, `-cacert`, `-cert`,
+`-key` (etcd client TLS), `-sudo` (default true).
+
+## Design
+
+The pure analysis lives in `profile.go`: etcd key layout (`etcdKeyFor`),
+`etcdctl ... -w json` parsing (`parseEtcdGetJSON`), and aggregation
+(`aggregate`). It is unit-tested in `profile_test.go` and `wiring_test.go` with
+no cluster required.
+
+`main.go` is the thin `kubectl`/`etcdctl` shell. It runs the same commands an
+operator would run by hand, which keeps the helper free of client libraries.
+The exec calls go through a `commandRunner` seam, so the discovery and
+argument-building logic is covered by `main_test.go` with a fake runner.
+
+```bash
+go test ./hack/etcd-revision-profile/
+```

--- a/hack/etcd-revision-profile/main.go
+++ b/hack/etcd-revision-profile/main.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command etcd-revision-profile reports the etcd MVCC footprint of a single
+// PipelineRun: how many revisions and how many bytes its PipelineRun, child
+// TaskRuns, their Pods, and associated Events have accumulated in etcd.
+//
+// It is a profiling helper for operators, not part of the Tekton control plane.
+// The pure analysis (key layout, etcdctl JSON parsing, aggregation) lives in
+// profile.go and is unit-tested; this file is the thin kubectl/etcdctl shell.
+//
+// Usage:
+//
+//	etcd-revision-profile -n <namespace> -pipelinerun <name> [etcd flags]
+//
+// etcd flags default to a kubeadm control-plane node's local endpoint and
+// client certificates; -sudo runs etcdctl via sudo because those keys are
+// root-only.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var errNotFound = errors.New("key not found in etcd")
+
+// profiledRef is one object to profile, tagged with the Kind to group it under.
+type profiledRef struct {
+	Kind string
+	Ref  objectRef
+}
+
+// objectLister discovers the object set belonging to a PipelineRun.
+type objectLister interface {
+	list(namespace, pipelineRun string) ([]profiledRef, error)
+}
+
+// etcdGetter returns the etcd footprint of a single storage key.
+type etcdGetter interface {
+	get(key string) (etcdObject, error)
+}
+
+// buildProfile resolves every discovered object to its etcd key, fetches its
+// revision footprint, and aggregates the result. Objects whose key is missing
+// (e.g. deleted mid-run) are returned as per-object errors and skipped rather
+// than aborting the whole profile.
+func buildProfile(l objectLister, g etcdGetter, namespace, pipelineRun string) (profile, []error, error) {
+	refs, err := l.list(namespace, pipelineRun)
+	if err != nil {
+		return profile{}, nil, fmt.Errorf("discovering objects: %w", err)
+	}
+	var objs []etcdObject
+	var objErrs []error
+	for _, r := range refs {
+		key := etcdKeyFor(r.Ref)
+		o, err := g.get(key)
+		if err != nil {
+			objErrs = append(objErrs, fmt.Errorf("%s %s/%s (%s): %w", r.Kind, r.Ref.Namespace, r.Ref.Name, key, err))
+			continue
+		}
+		o.Kind = r.Kind
+		o.Namespace = r.Ref.Namespace
+		o.Name = r.Ref.Name
+		objs = append(objs, o)
+	}
+	return aggregate(objs), objErrs, nil
+}
+
+// commandRunner runs an external command and returns its stdout (a test seam).
+type commandRunner func(name string, args ...string) ([]byte, error)
+
+func execRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// kubectlLister discovers the object set with `kubectl`.
+type kubectlLister struct {
+	bin string
+	run commandRunner
+}
+
+func (k kubectlLister) names(namespace, resource, labelSelector string) ([]string, error) {
+	args := []string{"get", resource, "-n", namespace, "-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"}
+	if labelSelector != "" {
+		args = append(args, "-l", labelSelector)
+	}
+	out, err := k.run(k.bin, args...)
+	if err != nil {
+		return nil, fmt.Errorf("kubectl get %s: %w", resource, err)
+	}
+	var names []string
+	for _, n := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if n = strings.TrimSpace(n); n != "" {
+			names = append(names, n)
+		}
+	}
+	return names, nil
+}
+
+func (k kubectlLister) eventNames(namespace, involvedName string) ([]string, error) {
+	out, err := k.run(k.bin, "get", "events", "-n", namespace,
+		"--field-selector", "involvedObject.name="+involvedName,
+		"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
+	if err != nil {
+		return nil, fmt.Errorf("kubectl get events for %s: %w", involvedName, err)
+	}
+	var names []string
+	for _, n := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if n = strings.TrimSpace(n); n != "" {
+			names = append(names, n)
+		}
+	}
+	return names, nil
+}
+
+func (k kubectlLister) list(namespace, pipelineRun string) ([]profiledRef, error) {
+	refs := []profiledRef{{
+		Kind: "PipelineRun",
+		Ref:  objectRef{Group: "tekton.dev", Resource: "pipelineruns", Namespace: namespace, Name: pipelineRun},
+	}}
+	involved := []string{pipelineRun}
+
+	taskRuns, err := k.names(namespace, "taskruns.tekton.dev", "tekton.dev/pipelineRun="+pipelineRun)
+	if err != nil {
+		return nil, err
+	}
+	for _, tr := range taskRuns {
+		refs = append(refs, profiledRef{Kind: "TaskRun", Ref: objectRef{Group: "tekton.dev", Resource: "taskruns", Namespace: namespace, Name: tr}})
+		involved = append(involved, tr)
+	}
+
+	pods, err := k.names(namespace, "pods", "tekton.dev/pipelineRun="+pipelineRun)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range pods {
+		refs = append(refs, profiledRef{Kind: "Pod", Ref: objectRef{Resource: "pods", Namespace: namespace, Name: p}})
+		involved = append(involved, p)
+	}
+
+	for _, name := range involved {
+		events, err := k.eventNames(namespace, name)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range events {
+			refs = append(refs, profiledRef{Kind: "Event", Ref: objectRef{Resource: "events", Namespace: namespace, Name: e}})
+		}
+	}
+	return refs, nil
+}
+
+// etcdctlGetter fetches keys with `etcdctl ... get <key> -w json`.
+type etcdctlGetter struct {
+	bin       string
+	run       commandRunner
+	sudo      bool
+	endpoints string
+	cacert    string
+	cert      string
+	key       string
+}
+
+func (e etcdctlGetter) get(key string) (etcdObject, error) {
+	name, args := e.bin, []string{
+		"--endpoints=" + e.endpoints,
+		"--cacert=" + e.cacert,
+		"--cert=" + e.cert,
+		"--key=" + e.key,
+		"get", key, "-w", "json",
+	}
+	if e.sudo {
+		args = append([]string{name}, args...)
+		name = "sudo"
+	}
+	out, err := e.run(name, args...)
+	if err != nil {
+		return etcdObject{}, fmt.Errorf("etcdctl get %s: %w", key, err)
+	}
+	return parseEtcdGetJSON(out)
+}
+
+func main() {
+	var (
+		namespace   = flag.String("n", "default", "namespace of the PipelineRun")
+		pipelineRun = flag.String("pipelinerun", "", "name of the PipelineRun to profile (required unless -key is set)")
+		probeKey    = flag.String("etcd-key", "", "profile a single raw etcd key (e.g. /registry/minions/<node>) and exit; bypasses kubectl discovery")
+		kubectlBin  = flag.String("kubectl", "kubectl", "path to the kubectl binary")
+		etcdctlBin  = flag.String("etcdctl", "etcdctl", "path to the etcdctl binary")
+		sudo        = flag.Bool("sudo", true, "run etcdctl via sudo (etcd client keys are root-only)")
+		endpoints   = flag.String("endpoints", "https://127.0.0.1:2379", "etcd client endpoint")
+		cacert      = flag.String("cacert", "/etc/kubernetes/pki/etcd/ca.crt", "etcd CA certificate")
+		cert        = flag.String("cert", "/etc/kubernetes/pki/etcd/healthcheck-client.crt", "etcd client certificate")
+		keyFile     = flag.String("key", "/etc/kubernetes/pki/etcd/healthcheck-client.key", "etcd client key")
+	)
+	flag.Parse()
+
+	getter := etcdctlGetter{bin: *etcdctlBin, run: execRunner, sudo: *sudo, endpoints: *endpoints, cacert: *cacert, cert: *cert, key: *keyFile}
+
+	if *probeKey != "" {
+		o, err := getter.get(*probeKey)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("%s\n  revisions (version): %d\n  current value bytes: %d\n", o.Key, o.Version, o.ValueBytes)
+		return
+	}
+
+	if *pipelineRun == "" {
+		fmt.Fprintln(os.Stderr, "error: -pipelinerun is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	lister := kubectlLister{bin: *kubectlBin, run: execRunner}
+
+	p, objErrs, err := buildProfile(lister, getter, *namespace, *pipelineRun)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("etcd revision profile for PipelineRun %s/%s\n\n", *namespace, *pipelineRun)
+	fmt.Print(renderTable(p))
+	if p.Total.CurrentBytes > 0 {
+		fmt.Printf("\nrevision amplification (est-rev-bytes / current-bytes): %.1fx\n",
+			float64(p.Total.EstRevisionBytes)/float64(p.Total.CurrentBytes))
+	}
+	for _, e := range objErrs {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", e)
+	}
+}

--- a/hack/etcd-revision-profile/main_test.go
+++ b/hack/etcd-revision-profile/main_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fake kubectl: answers each `get` by the resource it asks for.
+func fakeKubectl(_ string, args ...string) ([]byte, error) {
+	joined := strings.Join(args, " ")
+	switch {
+	case strings.Contains(joined, "taskruns.tekton.dev"):
+		return []byte("demo-build\ndemo-test\n"), nil
+	case strings.Contains(joined, "get pods"):
+		return []byte("demo-build-pod\n"), nil
+	case strings.Contains(joined, "get events"):
+		return []byte("ev-1\n"), nil
+	default:
+		return nil, nil
+	}
+}
+
+func TestKubectlListerList(t *testing.T) {
+	lister := kubectlLister{bin: "kubectl", run: fakeKubectl}
+	refs, err := lister.list("ci", "demo")
+	if err != nil {
+		t.Fatalf("list() error: %v", err)
+	}
+
+	// 1 PipelineRun + 2 TaskRuns + 1 Pod, and one Event per involved object
+	// (the PipelineRun, both TaskRuns and the Pod) = 4 events.
+	counts := map[string]int{}
+	for _, r := range refs {
+		counts[r.Kind]++
+	}
+	want := map[string]int{"PipelineRun": 1, "TaskRun": 2, "Pod": 1, "Event": 4}
+	for kind, n := range want {
+		if counts[kind] != n {
+			t.Errorf("Kind %s: got %d refs, want %d (all: %v)", kind, counts[kind], n, refs)
+		}
+	}
+
+	if key := etcdKeyFor(refs[0].Ref); key != "/registry/tekton.dev/pipelineruns/ci/demo" {
+		t.Errorf("PipelineRun resolves to key %q", key)
+	}
+}
+
+func TestEtcdctlGetterGet(t *testing.T) {
+	key := "/registry/tekton.dev/pipelineruns/ci/demo"
+	value := []byte("some-protobuf")
+
+	var gotName string
+	var gotArgs []string
+	run := func(name string, args ...string) ([]byte, error) {
+		gotName, gotArgs = name, args
+		raw := fmt.Sprintf(`{"kvs":[{"key":%q,"version":7,"value":%q}],"count":1}`,
+			base64.StdEncoding.EncodeToString([]byte(key)),
+			base64.StdEncoding.EncodeToString(value))
+		return []byte(raw), nil
+	}
+
+	getter := etcdctlGetter{bin: "etcdctl", run: run, sudo: true, endpoints: "https://127.0.0.1:2379", cacert: "ca", cert: "crt", key: "k"}
+	obj, err := getter.get(key)
+	if err != nil {
+		t.Fatalf("get() error: %v", err)
+	}
+	if obj.Version != 7 {
+		t.Errorf("Version = %d, want 7", obj.Version)
+	}
+	if obj.ValueBytes != len(value) {
+		t.Errorf("ValueBytes = %d, want %d", obj.ValueBytes, len(value))
+	}
+
+	// with -sudo the etcdctl binary is shifted to be sudo's first argument
+	if gotName != "sudo" || len(gotArgs) == 0 || gotArgs[0] != "etcdctl" {
+		t.Errorf("got command %q %v, want sudo etcdctl ...", gotName, gotArgs)
+	}
+	if !strings.Contains(strings.Join(gotArgs, " "), key) {
+		t.Errorf("get args do not mention key %q: %v", key, gotArgs)
+	}
+}

--- a/hack/etcd-revision-profile/profile.go
+++ b/hack/etcd-revision-profile/profile.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// etcdObject is the etcd MVCC footprint of one stored Kubernetes object.
+//
+// Version is etcd's per-key write counter: it starts at 1 when the key is
+// created and increments on every write, so it equals the number of revisions
+// the object has accumulated since creation. ValueBytes is the size of the
+// object's current serialized value (the live snapshot), not the sum across
+// revisions.
+type etcdObject struct {
+	Key        string
+	Kind       string
+	Namespace  string
+	Name       string
+	Version    int64
+	ValueBytes int
+}
+
+// objectRef identifies a Kubernetes object well enough to construct its
+// apiserver storage key. Group is "" for the core API group.
+type objectRef struct {
+	Group     string
+	Resource  string
+	Namespace string
+	Name      string
+}
+
+// etcdKeyFor reproduces the apiserver's etcd storage key layout:
+//
+//	core group:  /registry/<resource>/<namespace>/<name>
+//	other group: /registry/<group>/<resource>/<namespace>/<name>
+//
+// Cluster-scoped objects (empty Namespace) drop the namespace segment.
+//
+// Note: a handful of built-in core resources use legacy prefixes that do not
+// match their API name (most notably Node, stored under /registry/minions/).
+// Callers profiling those must pass the storage name in Resource.
+func etcdKeyFor(ref objectRef) string {
+	parts := []string{"registry"}
+	if ref.Group != "" {
+		parts = append(parts, ref.Group)
+	}
+	parts = append(parts, ref.Resource)
+	if ref.Namespace != "" {
+		parts = append(parts, ref.Namespace)
+	}
+	parts = append(parts, ref.Name)
+	return "/" + strings.Join(parts, "/")
+}
+
+// etcdGetResponse is the subset of `etcdctl get <key> -w json` we consume.
+type etcdGetResponse struct {
+	Count int `json:"count"`
+	Kvs   []struct {
+		Key            string `json:"key"`
+		Version        int64  `json:"version"`
+		Value          string `json:"value"`
+		CreateRevision int64  `json:"create_revision"`
+		ModRevision    int64  `json:"mod_revision"`
+	} `json:"kvs"`
+}
+
+// parseEtcdGetJSON parses the JSON emitted by `etcdctl get <key> -w json` for a
+// single key and returns its decoded key, version, and current value size.
+// A response with no kvs (count 0) is reported as an error rather than a
+// zero-valued success, since that means the key does not exist.
+func parseEtcdGetJSON(raw []byte) (etcdObject, error) {
+	var resp etcdGetResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return etcdObject{}, fmt.Errorf("decoding etcdctl json: %w", err)
+	}
+	if len(resp.Kvs) == 0 {
+		return etcdObject{}, fmt.Errorf("key not found in etcd (count=%d)", resp.Count)
+	}
+	kv := resp.Kvs[0]
+	key, err := base64.StdEncoding.DecodeString(kv.Key)
+	if err != nil {
+		return etcdObject{}, fmt.Errorf("decoding key: %w", err)
+	}
+	value, err := base64.StdEncoding.DecodeString(kv.Value)
+	if err != nil {
+		return etcdObject{}, fmt.Errorf("decoding value: %w", err)
+	}
+	return etcdObject{
+		Key:        string(key),
+		Version:    kv.Version,
+		ValueBytes: len(value),
+	}, nil
+}
+
+// kindProfile aggregates the etcd footprint of every object of one Kind.
+type kindProfile struct {
+	Kind             string
+	Count            int
+	TotalRevisions   int64 // sum of per-object Version
+	CurrentBytes     int64 // sum of current value sizes (live snapshot)
+	EstRevisionBytes int64 // sum of Version*ValueBytes, a rough estimate of
+	// pre-compaction storage assuming each revision is about the current size
+}
+
+// profile is the full per-Kind breakdown plus a grand total.
+type profile struct {
+	Kinds []kindProfile
+	Total kindProfile
+}
+
+// aggregate buckets objects by Kind (rows sorted by Kind name) and computes the
+// per-Kind and overall revision/size totals.
+func aggregate(objs []etcdObject) profile {
+	byKind := map[string]*kindProfile{}
+	for _, o := range objs {
+		kp := byKind[o.Kind]
+		if kp == nil {
+			kp = &kindProfile{Kind: o.Kind}
+			byKind[o.Kind] = kp
+		}
+		kp.Count++
+		kp.TotalRevisions += o.Version
+		kp.CurrentBytes += int64(o.ValueBytes)
+		kp.EstRevisionBytes += o.Version * int64(o.ValueBytes)
+	}
+
+	kinds := make([]string, 0, len(byKind))
+	for k := range byKind {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+
+	p := profile{Total: kindProfile{Kind: "TOTAL"}}
+	for _, k := range kinds {
+		kp := byKind[k]
+		p.Kinds = append(p.Kinds, *kp)
+		p.Total.Count += kp.Count
+		p.Total.TotalRevisions += kp.TotalRevisions
+		p.Total.CurrentBytes += kp.CurrentBytes
+		p.Total.EstRevisionBytes += kp.EstRevisionBytes
+	}
+	return p
+}
+
+// renderTable formats a profile as a fixed-width text table.
+func renderTable(p profile) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%-14s %6s %10s %14s %18s\n", "KIND", "COUNT", "REVISIONS", "CURRENT(B)", "EST-REV-BYTES(B)")
+	row := func(kp kindProfile) {
+		fmt.Fprintf(&b, "%-14s %6d %10d %14d %18d\n",
+			kp.Kind, kp.Count, kp.TotalRevisions, kp.CurrentBytes, kp.EstRevisionBytes)
+	}
+	for _, kp := range p.Kinds {
+		row(kp)
+	}
+	fmt.Fprintf(&b, "%s\n", strings.Repeat("-", 66))
+	row(p.Total)
+	return b.String()
+}

--- a/hack/etcd-revision-profile/profile_test.go
+++ b/hack/etcd-revision-profile/profile_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// parseEtcdGetJSON must understand the real shape emitted by
+// `etcdctl get <key> -w json`: a header plus a kvs array whose key/value are
+// base64-encoded and whose `version` is etcd's per-key write count.
+func TestParseEtcdGetJSON(t *testing.T) {
+	key := "/registry/tekton.dev/taskruns/default/demo-run-build"
+	value := []byte("0123456789") // 10 bytes once base64-decoded
+
+	raw := fmt.Sprintf(
+		`{"header":{"revision":42},"kvs":[{"key":%q,"create_revision":6,"mod_revision":40,"version":17,"value":%q}],"count":1}`,
+		base64.StdEncoding.EncodeToString([]byte(key)),
+		base64.StdEncoding.EncodeToString(value),
+	)
+
+	got, err := parseEtcdGetJSON([]byte(raw))
+	if err != nil {
+		t.Fatalf("parseEtcdGetJSON() unexpected error: %v", err)
+	}
+	if got.Key != key {
+		t.Errorf("Key = %q, want %q", got.Key, key)
+	}
+	if got.Version != 17 {
+		t.Errorf("Version = %d, want 17", got.Version)
+	}
+	if got.ValueBytes != len(value) {
+		t.Errorf("ValueBytes = %d, want %d", got.ValueBytes, len(value))
+	}
+}
+
+// A get against a non-existent key returns count:0 and an empty kvs array;
+// that must be surfaced as an error, not a zero-valued success.
+func TestParseEtcdGetJSON_NotFound(t *testing.T) {
+	raw := []byte(`{"header":{"revision":42},"count":0}`)
+	if _, err := parseEtcdGetJSON(raw); err == nil {
+		t.Fatal("parseEtcdGetJSON() on count:0 = nil error, want an error")
+	}
+}
+
+// etcdKeyFor must reproduce the apiserver storage key layout: core resources
+// have no group segment, CRDs and other API groups do.
+func TestEtcdKeyFor(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  objectRef
+		want string
+	}{{
+		name: "tekton CRD (namespaced)",
+		ref:  objectRef{Group: "tekton.dev", Resource: "pipelineruns", Namespace: "default", Name: "r1"},
+		want: "/registry/tekton.dev/pipelineruns/default/r1",
+	}, {
+		name: "core pod",
+		ref:  objectRef{Group: "", Resource: "pods", Namespace: "default", Name: "r1-build-pod"},
+		want: "/registry/pods/default/r1-build-pod",
+	}, {
+		name: "core event",
+		ref:  objectRef{Group: "", Resource: "events", Namespace: "ci", Name: "r1.17abc"},
+		want: "/registry/events/ci/r1.17abc",
+	}, {
+		name: "cluster-scoped (no namespace)",
+		ref:  objectRef{Group: "", Resource: "nodes", Namespace: "", Name: "node-1"},
+		want: "/registry/nodes/node-1",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := etcdKeyFor(tc.ref); got != tc.want {
+				t.Errorf("etcdKeyFor(%+v) = %q, want %q", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+// aggregate groups objects by Kind (sorted), summing the revision count, the
+// current value size, and the upper-bound revision-bytes estimate
+// (sum of version*size), and produces a grand total.
+func TestAggregate(t *testing.T) {
+	objs := []etcdObject{
+		{Kind: "PipelineRun", Version: 9, ValueBytes: 4000},
+		{Kind: "TaskRun", Version: 14, ValueBytes: 68000},
+		{Kind: "TaskRun", Version: 11, ValueBytes: 64000},
+		{Kind: "Pod", Version: 8, ValueBytes: 12000},
+		{Kind: "Pod", Version: 6, ValueBytes: 11000},
+		{Kind: "Event", Version: 1, ValueBytes: 600},
+		{Kind: "Event", Version: 1, ValueBytes: 600},
+		{Kind: "Event", Version: 1, ValueBytes: 600},
+	}
+
+	got := aggregate(objs)
+
+	// Rows are sorted by Kind name: "PipelineRun" sorts before "Pod"
+	// (they differ first at the 2nd character, 'i' < 'o').
+	wantKinds := []kindProfile{
+		{Kind: "Event", Count: 3, TotalRevisions: 3, CurrentBytes: 1800, EstRevisionBytes: 1800},
+		{Kind: "PipelineRun", Count: 1, TotalRevisions: 9, CurrentBytes: 4000, EstRevisionBytes: 36000},
+		{Kind: "Pod", Count: 2, TotalRevisions: 14, CurrentBytes: 23000, EstRevisionBytes: 162000},
+		{Kind: "TaskRun", Count: 2, TotalRevisions: 25, CurrentBytes: 132000, EstRevisionBytes: 1656000},
+	}
+	if len(got.Kinds) != len(wantKinds) {
+		t.Fatalf("got %d kind rows, want %d (%+v)", len(got.Kinds), len(wantKinds), got.Kinds)
+	}
+	for i, w := range wantKinds {
+		if got.Kinds[i] != w {
+			t.Errorf("Kinds[%d] = %+v, want %+v", i, got.Kinds[i], w)
+		}
+	}
+
+	wantTotal := kindProfile{Kind: "TOTAL", Count: 8, TotalRevisions: 51, CurrentBytes: 160800, EstRevisionBytes: 1855800}
+	if got.Total != wantTotal {
+		t.Errorf("Total = %+v, want %+v", got.Total, wantTotal)
+	}
+}
+
+func TestRenderTableContainsTotals(t *testing.T) {
+	p := aggregate([]etcdObject{
+		{Kind: "PipelineRun", Version: 9, ValueBytes: 4000},
+		{Kind: "TaskRun", Version: 14, ValueBytes: 68000},
+	})
+	out := renderTable(p)
+	for _, want := range []string{"PipelineRun", "TaskRun", "TOTAL", "REVISIONS"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("renderTable() output missing %q\n%s", want, out)
+		}
+	}
+}

--- a/hack/etcd-revision-profile/wiring_test.go
+++ b/hack/etcd-revision-profile/wiring_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+type fakeLister struct {
+	refs []profiledRef
+	err  error
+}
+
+func (f fakeLister) list(string, string) ([]profiledRef, error) { return f.refs, f.err }
+
+type fakeGetter struct {
+	byKey map[string]etcdObject
+}
+
+func (f fakeGetter) get(key string) (etcdObject, error) {
+	o, ok := f.byKey[key]
+	if !ok {
+		return etcdObject{}, errNotFound
+	}
+	return o, nil
+}
+
+// buildProfile must resolve each discovered object to its etcd key, fetch its
+// revision footprint, tag it with Kind, and aggregate the result.
+func TestBuildProfile(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: "PipelineRun", Ref: objectRef{Group: "tekton.dev", Resource: "pipelineruns", Namespace: "ci", Name: "build"}},
+		{Kind: "TaskRun", Ref: objectRef{Group: "tekton.dev", Resource: "taskruns", Namespace: "ci", Name: "build-compile"}},
+		{Kind: "Pod", Ref: objectRef{Resource: "pods", Namespace: "ci", Name: "build-compile-pod"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build":     {Version: 9, ValueBytes: 4000},
+		"/registry/tekton.dev/taskruns/ci/build-compile": {Version: 14, ValueBytes: 68000},
+		"/registry/pods/ci/build-compile-pod":            {Version: 8, ValueBytes: 12000},
+	}}
+
+	p, objErrs, err := buildProfile(fakeLister{refs: refs}, getter, "ci", "build")
+	if err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	if len(objErrs) != 0 {
+		t.Fatalf("buildProfile() per-object errors: %v", objErrs)
+	}
+	if p.Total.Count != 3 {
+		t.Errorf("Total.Count = %d, want 3", p.Total.Count)
+	}
+	if p.Total.TotalRevisions != 31 {
+		t.Errorf("Total.TotalRevisions = %d, want 31", p.Total.TotalRevisions)
+	}
+	// EstRevisionBytes = 9*4000 + 14*68000 + 8*12000 = 36000 + 952000 + 96000 = 1084000
+	if p.Total.EstRevisionBytes != 1084000 {
+		t.Errorf("Total.EstRevisionBytes = %d, want 1084000", p.Total.EstRevisionBytes)
+	}
+}
+
+// A missing key (e.g. the object was deleted mid-run) must be collected as a
+// per-object error and skipped, not abort the whole profile.
+func TestBuildProfile_MissingKeyIsCollected(t *testing.T) {
+	refs := []profiledRef{
+		{Kind: "PipelineRun", Ref: objectRef{Group: "tekton.dev", Resource: "pipelineruns", Namespace: "ci", Name: "build"}},
+		{Kind: "Event", Ref: objectRef{Resource: "events", Namespace: "ci", Name: "gone"}},
+	}
+	getter := fakeGetter{byKey: map[string]etcdObject{
+		"/registry/tekton.dev/pipelineruns/ci/build": {Version: 3, ValueBytes: 4000},
+	}}
+
+	p, objErrs, err := buildProfile(fakeLister{refs: refs}, getter, "ci", "build")
+	if err != nil {
+		t.Fatalf("buildProfile() error: %v", err)
+	}
+	if len(objErrs) != 1 {
+		t.Fatalf("got %d per-object errors, want 1: %v", len(objErrs), objErrs)
+	}
+	if p.Total.Count != 1 {
+		t.Errorf("Total.Count = %d, want 1 (missing object skipped)", p.Total.Count)
+	}
+}


### PR DESCRIPTION
# Changes

Adds `hack/etcd-revision-profile`, a helper that reports the revision and byte footprint of a PipelineRun and its child TaskRuns, Pods and Events in etcd. The measurable primitive is each key's `version`, which counts writes and so equals its revision count.

The pure analysis (key layout, etcdctl JSON parsing, aggregation) is unit-tested with no cluster dependency. The `kubectl`/`etcdctl` shell runs the same commands an operator would run by hand, which keeps it free of client libraries, and goes through a small runner seam so the discovery and argument-building logic is covered with a fake.

Implements deliverable 3 of #10322. The guide that documents it is in companion PR #10329.

/kind feature

# Release Notes

```release-note
NONE
```
