### PR TITLE
Collapse resolver result channels into one

### DIFF
--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -118,9 +118,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	return r.resolve(ctx, key, rr)
 }
 
+// resolveResult carries the single terminal outcome of a resolver worker
+// goroutine: either err is set or resource is set, never both.
+type resolveResult struct {
+	resource framework.ResolvedResource
+	err      error
+}
+
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
-	errChan := make(chan error, 1)
-	resourceChan := make(chan framework.ResolvedResource, 1)
+	resultChan := make(chan resolveResult, 1)
 
 	paramsMap := make(map[string]string)
 	for _, p := range rr.Spec.Params {
@@ -155,43 +161,42 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	go func() {
 		validationError := r.resolver.Validate(resolutionCtx, &rr.Spec)
 		if validationError != nil {
-			errChan <- &resolutioncommon.InvalidRequestError{
+			resultChan <- resolveResult{err: &resolutioncommon.InvalidRequestError{
 				ResolutionRequestKey: key,
 				Message:              validationError.Error(),
-			}
+			}}
 			return
 		}
 		resource, resolveErr := r.resolver.Resolve(resolutionCtx, &rr.Spec)
 		if resolveErr != nil {
-			errChan <- &resolutioncommon.GetResourceError{
+			resultChan <- resolveResult{err: &resolutioncommon.GetResourceError{
 				ResolverName: r.resolver.GetName(resolutionCtx),
 				Key:          key,
 				Original:     resolveErr,
-			}
+			}}
 			return
 		}
 		if err := framework.ValidateResolvedResource(resource); err != nil {
-			errChan <- &resolutioncommon.GetResourceError{
+			resultChan <- resolveResult{err: &resolutioncommon.GetResourceError{
 				ResolverName: r.resolver.GetName(resolutionCtx),
 				Key:          key,
 				Original:     fmt.Errorf("resolved resource validation error: %w", err),
-			}
+			}}
 			return
 		}
-		resourceChan <- resource
+		resultChan <- resolveResult{resource: resource}
 	}()
 
 	select {
-	case err := <-errChan:
-		if err != nil {
-			return r.OnError(ctx, rr, err)
+	case res := <-resultChan:
+		if res.err != nil {
+			return r.OnError(ctx, rr, res.err)
 		}
+		return r.writeResolvedData(ctx, rr, res.resource)
 	case <-resolutionCtx.Done():
 		if err := resolutionCtx.Err(); err != nil {
 			return r.OnError(ctx, rr, err)
 		}
-	case resource := <-resourceChan:
-		return r.writeResolvedData(ctx, rr, resource)
 	}
 
 	return errors.New("unknown error")

--- a/pkg/resolution/resolver/framework/reconciler.go
+++ b/pkg/resolution/resolver/framework/reconciler.go
@@ -121,9 +121,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	return r.resolve(ctx, key, rr)
 }
 
+// resolveResult carries the single terminal outcome of a resolver worker
+// goroutine: either err is set or resource is set, never both.
+type resolveResult struct {
+	resource ResolvedResource
+	err      error
+}
+
 func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.ResolutionRequest) error {
-	errChan := make(chan error, 1)
-	resourceChan := make(chan ResolvedResource, 1)
+	resultChan := make(chan resolveResult, 1)
 
 	paramsMap := make(map[string]string)
 	for _, p := range rr.Spec.Params {
@@ -148,43 +154,42 @@ func (r *Reconciler) resolve(ctx context.Context, key string, rr *v1beta1.Resolu
 	go func() {
 		validationError := r.resolver.ValidateParams(resolutionCtx, rr.Spec.Params)
 		if validationError != nil {
-			errChan <- &resolutioncommon.InvalidRequestError{
+			resultChan <- resolveResult{err: &resolutioncommon.InvalidRequestError{
 				ResolutionRequestKey: key,
 				Message:              validationError.Error(),
-			}
+			}}
 			return
 		}
 		resource, resolveErr := r.resolver.Resolve(resolutionCtx, rr.Spec.Params)
 		if resolveErr != nil {
-			errChan <- &resolutioncommon.GetResourceError{
+			resultChan <- resolveResult{err: &resolutioncommon.GetResourceError{
 				ResolverName: r.resolver.GetName(resolutionCtx),
 				Key:          key,
 				Original:     resolveErr,
-			}
+			}}
 			return
 		}
 		if err := ValidateResolvedResource(resource); err != nil {
-			errChan <- &resolutioncommon.GetResourceError{
+			resultChan <- resolveResult{err: &resolutioncommon.GetResourceError{
 				ResolverName: r.resolver.GetName(resolutionCtx),
 				Key:          key,
 				Original:     fmt.Errorf("resolved resource validation error: %w", err),
-			}
+			}}
 			return
 		}
-		resourceChan <- resource
+		resultChan <- resolveResult{resource: resource}
 	}()
 
 	select {
-	case err := <-errChan:
-		if err != nil {
-			return r.OnError(ctx, rr, err)
+	case res := <-resultChan:
+		if res.err != nil {
+			return r.OnError(ctx, rr, res.err)
 		}
+		return r.writeResolvedData(ctx, rr, res.resource)
 	case <-resolutionCtx.Done():
 		if err := resolutionCtx.Err(); err != nil {
 			return r.OnError(ctx, rr, err)
 		}
-	case resource := <-resourceChan:
-		return r.writeResolvedData(ctx, rr, resource)
 	}
 
 	return errors.New("unknown error")


### PR DESCRIPTION
# Changes

Both resolver reconcilers used two one-shot buffered channels, `errChan` and
`resourceChan`, to report the single terminal outcome of the worker goroutine.
This replaces them with one buffered (cap 1) channel of a small unexported
`resolveResult{resource, err}` struct so the "worker produces exactly one
result" contract is explicit and future changes cannot accidentally signal on
both channels.

The worker body now lives in `asyncResolve`, which returns a single
`resolveResult`. That makes a second channel send a compile-time error instead
of a possible panic.

The buffer of 1 is preserved, so the goroutine-leak fix from #10098 stays
intact: the worker can still send without blocking after the outer `select`
returns via `resolutionCtx.Done()`. `TestResolveGoroutineLeak` in both
packages continues to guard this. Behavior is unchanged.

Same refactor applied to both reconcilers:
- `pkg/resolution/resolver/framework/reconciler.go`
- `pkg/remoteresolution/resolver/framework/reconciler.go`

Closes #10104

This change was developed with assistance from OpenCode. I reviewed and tested
it before opening and updating the PR (`gofmt`, `go vet`, `TestReconcile`, and
the `-race` `TestResolveGoroutineLeak` in both packages).

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```