### PR TITLE
Mount debug scripts read-only in step containers

### DIFF
--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2713,7 +2713,7 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 		Name:         "place-scripts",
 		Image:        "busybox",
 		Command:      []string{"sh"},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, writeDebugScriptsVolumeMount},
 		Args: []string{"-c", `tmpfile="/tekton/debug/scripts/debug-continue"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << 'debug-continue-heredoc-randomly-generated-9l9zj'

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -62,6 +62,12 @@ var (
 	debugScriptsVolumeMount = corev1.VolumeMount{
 		Name:      debugScriptsVolumeName,
 		MountPath: debugScriptsDir,
+		ReadOnly:  true,
+	}
+	writeDebugScriptsVolumeMount = corev1.VolumeMount{
+		Name:      debugScriptsVolumeName,
+		MountPath: debugScriptsDir,
+		ReadOnly:  false,
 	}
 	debugInfoVolume = corev1.Volume{
 		Name:         debugInfoVolumeName,
@@ -109,7 +115,7 @@ func convertScripts(shellImageLinux string, shellImageWin string, steps []v1.Ste
 
 	// Add mounts for debug
 	if debugConfig != nil && debugConfig.NeedsDebug() {
-		placeScriptsInit.VolumeMounts = append(placeScriptsInit.VolumeMounts, debugScriptsVolumeMount)
+		placeScriptsInit.VolumeMounts = append(placeScriptsInit.VolumeMounts, writeDebugScriptsVolumeMount)
 	}
 
 	convertedStepContainers := convertListOfSteps(steps, &placeScriptsInit, debugConfig, "script")

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -464,7 +464,7 @@ else
 fi
 debug-fail-continue-heredoc-randomly-generated-6nl7g
 `},
-				VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
+				VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount, writeDebugScriptsVolumeMount},
 				SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 			},
 			wantSteps: []corev1.Container{{
@@ -607,7 +607,7 @@ else
 fi
 debug-beforestep-fail-continue-heredoc-randomly-generated-6nl7g
 `},
-				VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
+				VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount, writeDebugScriptsVolumeMount},
 				SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true}.GetSecurityContext(false),
 			},
 			wantSteps: []corev1.Container{{
@@ -629,6 +629,22 @@ debug-beforestep-fail-continue-heredoc-randomly-generated-6nl7g
 
 			if d := cmp.Diff(tc.wantSteps, gotSteps); d != "" {
 				t.Errorf("Containers Diff %s", diff.PrintWantGot(d))
+			}
+
+			// The init container generates the debug scripts and needs write access,
+			// while step containers must mount them read-only so a step cannot corrupt
+			// the breakpoint scripts before the user execs in.
+			for _, vm := range gotInit.VolumeMounts {
+				if vm.Name == debugScriptsVolumeName && vm.ReadOnly {
+					t.Errorf("init container debug scripts mount should be read-write, got ReadOnly=true")
+				}
+			}
+			for _, c := range gotSteps {
+				for _, vm := range c.VolumeMounts {
+					if vm.Name == debugScriptsVolumeName && !vm.ReadOnly {
+						t.Errorf("step container %q debug scripts mount should be read-only, got ReadOnly=false", c.Name)
+					}
+				}
 			}
 
 			if len(gotSidecars) != 0 {


### PR DESCRIPTION
# Changes

Fixes #9718.

The `place-scripts` init container generates the debug breakpoint scripts
(`debug-continue`, `debug-fail-continue`, `debug-beforestep-continue`,
`debug-beforestep-fail-continue`) into the `/tekton/debug/scripts` emptyDir, but
the step containers mounted that same volume read-write. A step could overwrite
those scripts before a user `kubectl exec`s in to continue or fail a breakpoint,
allowing arbitrary code to run in their place.

This mounts the debug-scripts volume read-only for step containers and adds a
separate read-write mount for the init container that produces the scripts,
mirroring the existing `scriptsVolumeMount` (RO) / `writeScriptsVolumeMount` (RW)
split already used for the regular script volume. No API types change, so no
codegen.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps (no user-facing/doc change; internal pod construction)
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed (gofmt clean; `go build`, `go vet`, `go test ./pkg/pod/...` pass)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release (not required)

# Release Notes

```release-note
Debug breakpoint scripts are now mounted read-only in step containers, so a step can no longer overwrite them before a user execs in to continue or fail a breakpoint.
```
