### PR TITLE
docs: add v1.14.0 release to releases.md

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -41,11 +41,11 @@ Further documentation available:
 
 ## Release
 
-### v1.13
-- **Latest Release**: [v1.13.0][v1.13-0] (2026-05-29) ([docs][v1.13-0-docs], [examples][v1.13-0-examples])
-- **Initial Release**: [v1.13.0][v1.13-0] (2026-05-29)
-- **End of Life**: 2026-06-29
-- **Patch Releases**: [v1.13.0][v1.13-0]
+### v1.14
+- **Latest Release**: [v1.14.0][v1.14-0] (2026-06-30) ([docs][v1.14-0-docs], [examples][v1.14-0-examples])
+- **Initial Release**: [v1.14.0][v1.14-0] (2026-06-30)
+- **End of Life**: 2026-07-30
+- **Patch Releases**: [v1.14.0][v1.14-0]
 
 ### v1.12 (LTS)
 - **Latest Release**: [v1.12.0][v1.12-0] (2026-05-04) ([docs][v1.12-0-docs], [examples][v1.12-0-examples])
@@ -72,6 +72,12 @@ Further documentation available:
 - **Patch Releases**: [v1.3.0][v1.3-0], [v1.3.1][v1.3-1], [v1.3.2][v1.3-2], [v1.3.3][v1.3-3], [v1.3.4][v1.3-4]
 
 ## End of Life Releases
+
+### v1.13
+- **Latest Release**: [v1.13.0][v1.13-0] (2026-05-29) ([docs][v1.13-0-docs], [examples][v1.13-0-examples])
+- **Initial Release**: [v1.13.0][v1.13-0] (2026-05-29)
+- **End of Life**: 2026-06-29
+- **Patch Releases**: [v1.13.0][v1.13-0]
 
 ### v1.11
 - **Latest Release**: [v1.11.1][v1.11-1] (2026-04-21) ([docs][v1.11-1-docs], [examples][v1.11-1-examples])
@@ -346,6 +352,7 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [release-notes-standards]:
     https://github.com/tektoncd/community/blob/main/standards.md#release-notes
 
+[v1.14-0]: https://github.com/tektoncd/pipeline/releases/tag/v1.14.0
 [v1.13-0]: https://github.com/tektoncd/pipeline/releases/tag/v1.13.0
 [v1.12-0]: https://github.com/tektoncd/pipeline/releases/tag/v1.12.0
 [v1.11-1]: https://github.com/tektoncd/pipeline/releases/tag/v1.11.1
@@ -465,6 +472,7 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [v0-37-5]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.5
 [v0-37-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.0
 
+[v1.14-0-docs]: https://github.com/tektoncd/pipeline/tree/v1.14.0/docs#tekton-pipelines
 [v1.13-0-docs]: https://github.com/tektoncd/pipeline/tree/v1.13.0/docs#tekton-pipelines
 [v1.12-0-docs]: https://github.com/tektoncd/pipeline/tree/v1.12.0/docs#tekton-pipelines
 [v1.11-1-docs]: https://github.com/tektoncd/pipeline/tree/v1.11.1/docs#tekton-pipelines
@@ -527,6 +535,7 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [v0-38-4-docs]: https://github.com/tektoncd/pipeline/tree/v0.38.4/docs#tekton-pipelines
 [v0-37-5-docs]: https://github.com/tektoncd/pipeline/tree/v0.37.5/docs#tekton-pipelines
 
+[v1.14-0-examples]: https://github.com/tektoncd/pipeline/tree/v1.14.0/examples#examples
 [v1.13-0-examples]: https://github.com/tektoncd/pipeline/tree/v1.13.0/examples#examples
 [v1.12-0-examples]: https://github.com/tektoncd/pipeline/tree/v1.12.0/examples#examples
 [v1.11-1-examples]: https://github.com/tektoncd/pipeline/tree/v1.11.1/examples#examples


### PR DESCRIPTION
# Changes

Add the `v1.14.0` release entry to `releases.md` and move `v1.13` (EOL 2026-06-29) to the End of Life Releases section.

v1.14.0 is a regular (non-LTS) release; supported until the next release (~2026-07-30).

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Release notes block below has been updated

/kind documentation

# Release Notes

```release-note
NONE
```