### PR TITLE
fix(taskrun): complete pod when a step exits non-zero without OOMKilled reason

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -87,7 +87,9 @@ const (
 
 const (
 	oomKilled = "OOMKilled"
-	evicted   = "Evicted"
+	// externalSigKillCode is the exit code for an external SIGKILL (128 + 9).
+	externalSigKillCode = 137
+	evicted             = "Evicted"
 )
 
 // SidecarsReady returns true if all of the Pod's sidecars are Ready or
@@ -660,7 +662,15 @@ func isPodCompleted(pod *corev1.Pod) bool {
 	for _, s := range pod.Status.ContainerStatuses {
 		if IsContainerStep(s.Name) {
 			if s.State.Terminated != nil {
-				if isOOMKilled(s) {
+				// Depending on how the container is killed during an OOM, kubernetes may not report the container as
+				// explicitly OOM-killed. External SIGKILL and OOM both stop the container before the post file can be
+				// written, preventing the next steps from starting.
+				// Exit code 137 only means the entrypoint was killed if the termination message is empty; a non-empty
+				// message means the entrypoint survived and wrote its results, so we must not short-circuit
+				// areContainersCompleted (the sidecar-log results wait). This relies on the default
+				// terminationMessagePolicy (File), so logs never backfill the message.
+				// Normal failure modes like Step failure are managed elsewhere and update pod.Status.Phase
+				if isOOMKilled(s) || (s.State.Terminated.ExitCode == externalSigKillCode && s.State.Terminated.Message == "") {
 					return true
 				}
 			}

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -1490,6 +1490,123 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			},
 		},
 	}, {
+		desc: "step SIGKILLed without OOMKilled reason completes the pod in advance",
+		podStatus: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "step-one",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Reason:   "Error",
+						ExitCode: 137,
+					},
+				},
+			}, {
+				Name:  "step-two",
+				State: corev1.ContainerState{},
+			}},
+		},
+		want: v1.TaskRunStatus{
+			Status: statusFailure(v1.TaskRunReasonStepFailed.String(), "\"step-one\" exited with code 137: Error"),
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   "Error",
+							ExitCode: 137,
+						},
+					},
+					Name:      "one",
+					Container: "step-one",
+				}, {
+					ContainerState: corev1.ContainerState{},
+					Name:           "two",
+					Container:      "step-two",
+				}},
+				Sidecars:  []v1.SidecarState{},
+				Artifacts: &v1.Artifacts{},
+				// We don't actually care about the time, just that it's not nil
+				CompletionTime: &metav1.Time{Time: time.Now()},
+			},
+		},
+	}, {
+		desc: "ordinary step failure does not complete the pod in advance",
+		podStatus: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "step-one",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Reason:   "Error",
+						ExitCode: 1,
+					},
+				},
+			}, {
+				Name:  "step-two",
+				State: corev1.ContainerState{},
+			}},
+		},
+		want: v1.TaskRunStatus{
+			Status: statusRunning(),
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   "Error",
+							ExitCode: 1,
+						},
+					},
+					Name:      "one",
+					Container: "step-one",
+				}, {
+					ContainerState: corev1.ContainerState{},
+					Name:           "two",
+					Container:      "step-two",
+				}},
+				Sidecars: []v1.SidecarState{},
+			},
+		},
+	}, {
+		desc: "step exits 137 but entrypoint wrote its termination message does not complete the pod in advance",
+		podStatus: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "step-one",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Reason:   "Error",
+						ExitCode: 137,
+						Message:  `[{"key":"StartedAt","value":"2024-01-01T00:00:00.000Z","type":3}]`,
+					},
+				},
+			}, {
+				Name:  "step-two",
+				State: corev1.ContainerState{},
+			}},
+		},
+		want: v1.TaskRunStatus{
+			Status: statusRunning(),
+			TaskRunStatusFields: v1.TaskRunStatusFields{
+				Steps: []v1.StepState{{
+					ContainerState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:    "Error",
+							ExitCode:  137,
+							StartedAt: metav1.Time{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+						},
+					},
+					Name:              "one",
+					Container:         "step-one",
+					TerminationReason: "Error",
+				}, {
+					ContainerState: corev1.ContainerState{},
+					Name:           "two",
+					Container:      "step-two",
+				}},
+				Sidecars: []v1.SidecarState{},
+			},
+		},
+	}, {
 		desc: "the failed task show task results",
 		podStatus: corev1.PodStatus{
 			Phase: corev1.PodFailed,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes #10371.

When a step container is SIGKILLed before its entrypoint can write its post file (e.g. a whole-cgroup OOM kill or an external kill), the container terminates with exit code `137` (128 + SIGKILL) but the runtime may report a `reason` other than the exact string `OOMKilled` (for example `Error`). See kubernetes/kubernetes#122256 for an upstream report of `137`/`Error`. The `isPodCompleted` short-circuit only matched the exact `OOMKilled` reason, so such pods were never considered complete in advance: downstream steps kept polling for a post file that would never be written and the TaskRun hung until its timeout.

This is the surviving portion of #8170: the pure-OOM path (reason `OOMKilled`) was fixed in cf4ccee7, but any `137`/non-`OOMKilled` exit slipped through.

This change makes `isPodCompleted` also treat a step container terminated with exit code `137` (SIGKILL) as completed in advance, in addition to the existing `OOMKilled` reason check.

## Why exit code 137 is gated on an empty termination message

Exit code `137` alone does **not** prove the entrypoint itself was killed. A user command can be SIGKILLed while the entrypoint survives, writes its results, and then propagates `137`. In that case the entrypoint's deferred `writeTerminationMessage` populates the container termination message, so short-circuiting `isPodCompleted` there would bypass `areContainersCompleted` — which, with sidecar-log result extraction, waits for the results sidecar to terminate so results are not missed.

The condition is therefore `ExitCode == 137 && Terminated.Message == ""`:

- **entrypoint killed before writing** (whole-cgroup OOM / external SIGKILL): no termination message → complete in advance (the hang case).
- **child killed, entrypoint survived and wrote results**: termination message present → normal coordination, results preserved.

This relies on step containers using the default `terminationMessagePolicy: File` (Tekton only sets `terminationMessagePath`, not the policy), so container logs never backfill the message: an empty message genuinely means the entrypoint never got to write it.

## Verification

The distinguishing signal was confirmed on a throwaway kind cluster (k8s 1.35, containerd, cgroup v2):

| scenario | exitCode | reason | message | signal |
|---|---|---|---|---|
| clean OOM kill | 137 | `OOMKilled` | *(empty)* | *(absent)* |
| external SIGKILL of the process (= #10371) | 137 | `Error` | *(empty)* | *(absent)* |
| child killed, wrapper writes term-log then exits 137 | 137 | `Error` | *(present)* | *(absent)* |

Note the `Terminated.Signal` field is **always absent (0)** on CRI runtimes: the kubelet never populates it from CRI container status (it was only ever set by the removed dockershim), so gating on the termination message — not on `Signal` — is what reliably separates the two `137`/`Error` cases.

New cases in `TestMakeTaskRunStatus` cover the `137`/empty-message path (completes in advance), the `137`/non-empty-message path (does **not** complete in advance, preserving the sidecar-log results wait), and the ordinary non-zero exit (does not complete in advance), alongside the existing OOMKilled and success paths.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix a bug where a TaskRun would hang until its timeout when a step container was SIGKILLed (e.g. by an out-of-memory whole-cgroup kill) and exited with code 137 but a termination reason other than `OOMKilled`. Such TaskRuns are now failed promptly instead of waiting for the timeout.
```
