### PR TITLE
Fix kind node image digest for k8s v1.33

### DIFF
--- a/hack/setup-kind.sh
+++ b/hack/setup-kind.sh
@@ -111,7 +111,7 @@ case ${K8S_VERSION} in
     ;;
   v1.33.x)
     K8S_VERSION="1.33.4"
-    KIND_IMAGE_SHA="sha256:0f5cc49c5e73c0c2bb6e2df56e7df189240d83cf94edfa30946482eb08ec57d2"
+    KIND_IMAGE_SHA="sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2"
     KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
     ;;
   v1.34.x)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `v1.33.x` case in `hack/setup-kind.sh` pins the wrong `kindest/node`
digest: it uses the v1.31.12 digest
(`sha256:0f5cc49c5e73c0c2bb6e2df56e7df189240d83cf94edfa30946482eb08ec57d2`)
for the `1.33.4` image instead of the actual v1.33.4 digest. Because the pinned
digest does not match the `1.33.4` tag, `kind create cluster` fails digest
verification and cannot pull the node image on the v1.33 leg.

This replaces it with the correct v1.33.4 digest
(`sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2`) as
published in the [kind v0.30.0 release](https://github.com/kubernetes-sigs/kind/releases/tag/v0.30.0),
which is the release that ships these node images and whose other digests in
this file (v1.32.8, v1.34.0) already match.

The slip was introduced when the v1.33.x and v1.34.x cases were added: the
v1.33.x block was pasted with the v1.31.12 digest. `0f5cc49c...` is the only
digest that appears twice in the file today; after this change every entry is
unique.

The v1.33 path is exercised by CI: `.github/workflows/e2e-matrix-extras.yaml`
runs `k8s-version: v1.33.x` (latest-minus-one) through `./hack/setup-kind.sh`,
and `.github/workflows/nightly-builds.yaml` defaults to `v1.33.x`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

---

## First PR comment (post right after opening)

/kind bug
