### PR TITLE
Fix wrong Deprecated godoc in affinity assistant

### DIFF
--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -59,9 +59,9 @@ const (
 )
 
 var (
-	// Deprecated: use volumeclain.ErrPvcCreationFailed instead
+	// Deprecated: use volumeclaim.ErrPvcCreationFailed instead
 	ErrPvcCreationFailed = volumeclaim.ErrPvcCreationFailed
-	// Deprecated: use volumeclaim.ErrAffinityAssistantCreationFailed instead
+	// Deprecated: use volumeclaim.ErrPvcCreationFailedRetryable instead
 	ErrPvcCreationFailedRetryable      = volumeclaim.ErrPvcCreationFailedRetryable
 	ErrAffinityAssistantCreationFailed = errors.New("Affinity Assistant creation error")
 )


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The backward-compat alias block in `pkg/reconciler/pipelinerun/affinity_assistant.go`
declares two exported vars whose `Deprecated:` godoc tells consumers what to use
instead, but both pointers are wrong:

- `ErrPvcCreationFailed` pointed at `volumeclain.ErrPvcCreationFailed`,
  misspelling the `volumeclaim` package (the name `volumeclain` does not exist
  anywhere in the tree). The var it documents is assigned
  `volumeclaim.ErrPvcCreationFailed` on the next line, so the comment should say
  `volumeclaim`.
- `ErrPvcCreationFailedRetryable` pointed at
  `volumeclaim.ErrAffinityAssistantCreationFailed`, which `volumeclaim` does not
  export at all (that name is a local `errors.New(...)` in this same file). The
  var it documents aliases `volumeclaim.ErrPvcCreationFailedRetryable`, so the
  comment should name that symbol.

This corrects both comments to name the symbols the vars actually alias. It is a
godoc-only change; the `var` assignments are already correct and are left
untouched, so there is no behavior change.

```diff
 var (
-	// Deprecated: use volumeclain.ErrPvcCreationFailed instead
+	// Deprecated: use volumeclaim.ErrPvcCreationFailed instead
 	ErrPvcCreationFailed = volumeclaim.ErrPvcCreationFailed
-	// Deprecated: use volumeclaim.ErrAffinityAssistantCreationFailed instead
+	// Deprecated: use volumeclaim.ErrPvcCreationFailedRetryable instead
 	ErrPvcCreationFailedRetryable      = volumeclaim.ErrPvcCreationFailedRetryable
 	ErrAffinityAssistantCreationFailed = errors.New("Affinity Assistant creation error")
 )
```

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

Notes on the unchecked items: no Docs and no Tests are needed - this is a
godoc-comment-only fix to already-deprecated internal error aliases, with no
user-facing surface and no runtime behavior to test. No "action required":
comment-only.

# Release Notes

```release-note
NONE
```
