### PR TITLE
Preserve Sidecar RestartPolicy on API conversion

### DIFF
--- a/pkg/apis/pipeline/v1beta1/container_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/container_conversion.go
@@ -183,6 +183,7 @@ func (s Sidecar) convertTo(ctx context.Context, sink *v1.Sidecar) {
 		w.convertTo(ctx, &new)
 		sink.Workspaces = append(sink.Workspaces, new)
 	}
+	sink.RestartPolicy = s.RestartPolicy
 }
 
 func (s *Sidecar) convertFrom(ctx context.Context, source v1.Sidecar) {
@@ -215,4 +216,5 @@ func (s *Sidecar) convertFrom(ctx context.Context, source v1.Sidecar) {
 		new.convertFrom(ctx, w)
 		s.Workspaces = append(s.Workspaces, new)
 	}
+	s.RestartPolicy = source.RestartPolicy
 }

--- a/pkg/apis/pipeline/v1beta1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion_test.go
@@ -232,6 +232,7 @@ spec:
       path: /path
     stderrConfig:
       path: /another-path
+    restartPolicy: Always
   volumes:
   - name: volume
   params:


### PR DESCRIPTION

# Changes

The v1beta1 <-> v1 `Sidecar` conversion copies every other field but drops
`RestartPolicy` in both directions. Because v1 is the stored (hub) version, a
`Task` or `TaskRun` applied as v1beta1 with a sidecar that sets
`restartPolicy: Always` had that field stripped when the webhook converted it to
v1, so the native Kubernetes sidecar (available since Kubernetes 1.29) silently
became an ordinary sidecar.

`RestartPolicy` has existed on both `v1.Sidecar`
(`pkg/apis/pipeline/v1/container_types.go`) and `v1beta1.Sidecar`
(`pkg/apis/pipeline/v1beta1/container_types.go`) since native sidecar support was
added, and it is honored at runtime (`Sidecar.ToK8sContainer` sets it and
`pkg/pod/pod.go` relies on it to promote the sidecar to a restartable init
container). But `Sidecar.convertTo` / `Sidecar.convertFrom` in
`pkg/apis/pipeline/v1beta1/container_conversion.go` were never updated to carry
it, and there was no conversion test covering the field.

This change:

- copies `RestartPolicy` in `Sidecar.convertTo` (v1beta1 -> v1) and
  `Sidecar.convertFrom` (v1 -> v1beta1), matching the existing scalar-pointer
  copy style used for `LivenessProbe` / `StartupProbe` and the struct field order
  (`RestartPolicy` follows `Workspaces` on the type);
- extends the existing round-trip conversion test fixture in
  `pkg/apis/pipeline/v1beta1/task_conversion_test.go` (the "all non deprecated
  fields" case) to carry `restartPolicy: Always` on the sidecar, so the loss is
  caught going forward.

No API type changed, so no code generation is required.

Reverting only the two source lines makes the extended round-trip test fail in
both directions with the sole difference being `RestartPolicy` (`Always` vs
`nil`), confirming the test guards exactly this bug.

/kind bug

# Submitter Checklist

- [x] Has Tests included (extended the existing round-trip conversion test to
      cover the field; fails before this fix, passes after).
- [x] pre-commit / gofmt passed (`gofmt -l` clean on both files, `go vet` clean).
- [x] Follows the commit message standard (imperative subject <= 50 chars, no
      conventional-commit prefix, body wrapped ~72 explaining what and why).
- [x] Meets the Tekton contributor standards.
- [ ] Has a kind label (add `/kind bug` via a PR comment).
- [x] Release notes block below updated (user-facing bug fix).
- Docs: no user-facing docs change needed. `RestartPolicy` is already documented
  on the Sidecar types; this only restores its behavior across API conversion.

# Release Notes

```release-note
Fixed a bug where a Sidecar's `restartPolicy` (native Kubernetes sidecar support)
was dropped when converting a Task or TaskRun between the v1beta1 and v1 API
versions, causing a sidecar requested as a native sidecar to be created as an
ordinary sidecar.
```

---

## Note on AI-assisted authorship (to include in the PR conversation)

Per Tekton's practice (observed on prior PRs), disclose candidly that this change
was prepared with AI assistance and was reviewed and tested locally by the author:
gofmt/vet/build clean, the targeted conversion test and the full
`pkg/apis/pipeline/v1beta1` package pass (with `-race`), and the regression was
confirmed red-before-green by reverting only the source fix.

Suggested one-liner for the PR description or first comment:

> This fix was prepared with AI assistance; I reviewed it and verified it locally
> (gofmt/vet/build clean; the conversion test and the full
> `pkg/apis/pipeline/v1beta1` package pass with `-race`, and the new test fails
> before the fix and passes after).
