### PR TITLE
fix(validation): report mutual exclusion for taskRef name and resolver

### DIFF
--- a/pkg/apis/pipeline/v1/container_validation.go
+++ b/pkg/apis/pipeline/v1/container_validation.go
@@ -59,13 +59,13 @@ func validateRef(ctx context.Context, refName string, refResolver ResolverName, 
 		if refResolver != "" {
 			errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "resolver", config.BetaAPIFields).ViaField("resolver"))
 			if refName != "" {
-				// make sure that the name is url-like.
-				err := RefNameLikeUrl(refName)
-				if err == nil && !config.FromContextOrDefaults(ctx).FeatureFlags.EnableConciseResolverSyntax {
-					// If name is url-like then concise resolver syntax must be enabled
-					errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use concise resolver syntax", config.EnableConciseResolverSyntax), ""))
-				}
-				if err != nil {
+				if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableConciseResolverSyntax {
+					if err := RefNameLikeUrl(refName); err != nil {
+						errs = errs.Also(apis.ErrMultipleOneOf("name", "resolver"))
+					} else {
+						errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use concise resolver syntax", config.EnableConciseResolverSyntax), ""))
+					}
+				} else if err := RefNameLikeUrl(refName); err != nil {
 					errs = errs.Also(apis.ErrInvalidValue(err, "name"))
 				}
 			}

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -680,6 +680,17 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 		},
 		configMap: map[string]string{"enable-concise-resolver-syntax": "true"},
 	}, {
+		name: "pipeline task - taskRef with resolver and k8s style name without enable-concise-resolver-syntax",
+		task: PipelineTask{
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo", ResolverRef: ResolverRef{Resolver: "git"}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got both`,
+			Paths:   []string{"taskRef.name", "taskRef.resolver"},
+		},
+		configMap: map[string]string{"enable-api-fields": "beta"},
+	}, {
 		name: "pipeline task - taskRef with url-like name without enable-concise-resolver-syntax",
 		task: PipelineTask{
 			Name:    "foo",

--- a/pkg/apis/pipeline/v1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelineref_validation_test.go
@@ -106,6 +106,16 @@ func TestPipelineRef_Invalid(t *testing.T) {
 			Message: `feature flag enable-concise-resolver-syntax should be set to true to use concise resolver syntax`,
 		}),
 	}, {
+		name: "pipelineRef with resolver and k8s style name without enable-concise-resolver-syntax",
+		ref: &v1.PipelineRef{
+			Name: "foo",
+			ResolverRef: v1.ResolverRef{
+				Resolver: "git",
+			},
+		},
+		wantErr:     apis.ErrMultipleOneOf("name", "resolver"),
+		withContext: cfgtesting.EnableBetaAPIFields,
+	}, {
 		name: "pipelineRef without enable-concise-resolver-syntax",
 		ref:  &v1.PipelineRef{Name: "https://foo.com/bar", ResolverRef: v1.ResolverRef{Resolver: "git"}},
 		wantErr: &apis.FieldError{

--- a/pkg/apis/pipeline/v1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskref_validation_test.go
@@ -154,6 +154,16 @@ func TestTaskRef_Invalid(t *testing.T) {
 			Message: `feature flag enable-concise-resolver-syntax should be set to true to use concise resolver syntax`,
 		}),
 	}, {
+		name: "taskRef with resolver and k8s style name without enable-concise-resolver-syntax",
+		taskRef: &v1.TaskRef{
+			Name: "foo",
+			ResolverRef: v1.ResolverRef{
+				Resolver: "git",
+			},
+		},
+		wantErr: apis.ErrMultipleOneOf("name", "resolver"),
+		wc:      cfgtesting.EnableBetaAPIFields,
+	}, {
 		name:    "taskRef without enable-concise-resolver-syntax",
 		taskRef: &v1.TaskRef{Name: "https://foo.com/bar", ResolverRef: v1.ResolverRef{Resolver: "git"}},
 		wantErr: &apis.FieldError{

--- a/pkg/apis/pipeline/v1beta1/container_validation.go
+++ b/pkg/apis/pipeline/v1beta1/container_validation.go
@@ -44,13 +44,13 @@ func validateRef(ctx context.Context, refName string, refResolver ResolverName, 
 		if refResolver != "" {
 			errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "resolver", config.BetaAPIFields).ViaField("resolver"))
 			if refName != "" {
-				// make sure that the name is url-like.
-				err := RefNameLikeUrl(refName)
-				if err == nil && !config.FromContextOrDefaults(ctx).FeatureFlags.EnableConciseResolverSyntax {
-					// If name is url-like then concise resolver syntax must be enabled
-					errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use concise resolver syntax", config.EnableConciseResolverSyntax), ""))
-				}
-				if err != nil {
+				if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableConciseResolverSyntax {
+					if err := RefNameLikeUrl(refName); err != nil {
+						errs = errs.Also(apis.ErrMultipleOneOf("name", "resolver"))
+					} else {
+						errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use concise resolver syntax", config.EnableConciseResolverSyntax), ""))
+					}
+				} else if err := RefNameLikeUrl(refName); err != nil {
 					errs = errs.Also(apis.ErrInvalidValue(err, "name"))
 				}
 			}

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -676,6 +676,17 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 		},
 		configMap: map[string]string{"enable-concise-resolver-syntax": "true"},
 	}, {
+		name: "pipeline task - taskRef with resolver and k8s style name without enable-concise-resolver-syntax",
+		task: PipelineTask{
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo", ResolverRef: ResolverRef{Resolver: "git"}},
+		},
+		expectedError: apis.FieldError{
+			Message: `expected exactly one, got both`,
+			Paths:   []string{"taskRef.name", "taskRef.resolver"},
+		},
+		configMap: map[string]string{"enable-api-fields": "beta"},
+	}, {
 		name: "pipeline task - taskRef with url-like name without enable-concise-resolver-syntax",
 		task: PipelineTask{
 			Name:    "foo",

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation.go
@@ -50,13 +50,13 @@ func (ref *PipelineRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 		if ref.Resolver != "" {
 			errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "resolver", config.BetaAPIFields).ViaField("resolver"))
 			if ref.Name != "" {
-				// make sure that the name is url-like.
-				err := RefNameLikeUrl(ref.Name)
-				if err == nil && !config.FromContextOrDefaults(ctx).FeatureFlags.EnableConciseResolverSyntax {
-					// If name is url-like then concise resolver syntax must be enabled
-					errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use concise resolver syntax", config.EnableConciseResolverSyntax), ""))
-				}
-				if err != nil {
+				if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableConciseResolverSyntax {
+					if err := RefNameLikeUrl(ref.Name); err != nil {
+						errs = errs.Also(apis.ErrMultipleOneOf("name", "resolver"))
+					} else {
+						errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use concise resolver syntax", config.EnableConciseResolverSyntax), ""))
+					}
+				} else if err := RefNameLikeUrl(ref.Name); err != nil {
 					errs = errs.Also(apis.ErrInvalidValue(err, "name"))
 				}
 			}

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
@@ -106,6 +106,16 @@ func TestPipelineRef_Invalid(t *testing.T) {
 			Message: `feature flag enable-concise-resolver-syntax should be set to true to use concise resolver syntax`,
 		}),
 	}, {
+		name: "pipelineRef with resolver and k8s style name without enable-concise-resolver-syntax",
+		ref: &v1beta1.PipelineRef{
+			Name: "foo",
+			ResolverRef: v1beta1.ResolverRef{
+				Resolver: "git",
+			},
+		},
+		wantErr:     apis.ErrMultipleOneOf("name", "resolver"),
+		withContext: cfgtesting.EnableBetaAPIFields,
+	}, {
 		name: "pipelineRef without enable-concise-resolver-syntax",
 		ref:  &v1beta1.PipelineRef{Name: "https://foo.com/bar", ResolverRef: v1beta1.ResolverRef{Resolver: "git"}},
 		wantErr: &apis.FieldError{

--- a/pkg/apis/pipeline/v1beta1/taskref_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation.go
@@ -50,13 +50,13 @@ func (ref *TaskRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 		if ref.Resolver != "" {
 			errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "resolver", config.BetaAPIFields).ViaField("resolver"))
 			if ref.Name != "" {
-				// make sure that the name is url-like.
-				err := RefNameLikeUrl(ref.Name)
-				if err == nil && !config.FromContextOrDefaults(ctx).FeatureFlags.EnableConciseResolverSyntax {
-					// If name is url-like then concise resolver syntax must be enabled
-					errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use concise resolver syntax", config.EnableConciseResolverSyntax), ""))
-				}
-				if err != nil {
+				if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableConciseResolverSyntax {
+					if err := RefNameLikeUrl(ref.Name); err != nil {
+						errs = errs.Also(apis.ErrMultipleOneOf("name", "resolver"))
+					} else {
+						errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use concise resolver syntax", config.EnableConciseResolverSyntax), ""))
+					}
+				} else if err := RefNameLikeUrl(ref.Name); err != nil {
 					errs = errs.Also(apis.ErrInvalidValue(err, "name"))
 				}
 			}

--- a/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
@@ -113,6 +113,16 @@ func TestTaskRef_Invalid(t *testing.T) {
 		wantErr: apis.ErrMultipleOneOf("name", "params"),
 		wc:      enableConciseResolverSyntax,
 	}, {
+		name: "taskRef with resolver and k8s style name without enable-concise-resolver-syntax",
+		taskRef: &v1beta1.TaskRef{
+			Name: "foo",
+			ResolverRef: v1beta1.ResolverRef{
+				Resolver: "git",
+			},
+		},
+		wantErr: apis.ErrMultipleOneOf("name", "resolver"),
+		wc:      cfgtesting.EnableBetaAPIFields,
+	}, {
 		name:    "taskRef with url-like name without enable-concise-resolver-syntax",
 		taskRef: &v1beta1.TaskRef{Name: "https://foo.com/bar"},
 		wantErr: apis.ErrMissingField("resolver").Also(&apis.FieldError{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When `enable-concise-resolver-syntax` is disabled, a `taskRef`/`pipelineRef` that sets both a Kubernetes-style `name` and a `resolver` now fails validation with a mutual exclusion error instead of reporting `invalid URI for request` against `name`.

URL-style names used with a resolver while concise syntax is disabled still receive the existing feature-flag error.

Fixes #10370

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
When concise resolver syntax is disabled, taskRef and pipelineRef with both name and resolver set now fail validation with a mutual exclusion error instead of an invalid URI message.
```
