### PR TITLE
Fix dead links in feature versioning guide

### DIFF
--- a/docs/developers/feature-versioning.md
+++ b/docs/developers/feature-versioning.md
@@ -16,8 +16,8 @@ All new features added after [v0.53.0](https://github.com/tektoncd/pipeline/rele
 - Add default values to the new per-feature flag for the new API-driven feature following the `PerFeatureFlag` struct in [feature_flags.go](./../../pkg/apis/config/feature_flags.go).
 - Write unit tests to verify the new feature flag and update all test cases that require the configMap setting, such as those related to provenance propagation.
 - To add integration tests:
-    - First, add the tests to `pull-tekton-pipeline-alpha-integration-test` by enabling the newly-introduced per-feature flag at [alpha test Prow environment](./../../test/e2e-tests-kind-prow-alpha.env).
-    - When the flag is promoted to `beta` stability level, change the test to use [beta Prow environment setup](./../../test/e2e-tests-kind-prow-beta.env).
+    - First, add the tests to `pull-tekton-pipeline-alpha-integration-test` by enabling the newly-introduced per-feature flag at [alpha test Prow environment](./../../test/e2e-tests-kind-alpha.env).
+    - When the flag is promoted to `beta` stability level, change the test to use [beta Prow environment setup](./../../test/e2e-tests-kind-beta.env).
     - To add additional CI tests for combinations of feature flags, add tests for all alpha feature flags being turned on, with one alpha feature turned off at a time.
 - Add the tested new per-feature flag key value to the [the pipeline configMap](./../../config/config-feature-flags.yaml).
 - Update documentations for the new alpha feature at [alpha-stability-level](./../additional-configs.md#alpha-features).
@@ -35,7 +35,7 @@ var DefaultExampleNewFeatre = PerFeatureFlag {
 ```
 2. Add unit tests with the newly-introduced yamls `feature-flags-example-new-feature` and `feature-flags-invalid-example-new-feature` according to the existing testing framework.
 
-3. For integration tests, add `example-new-feature: true` to [alpha test Prow environment](./../../test/e2e-tests-kind-prow-alpha.env).
+3. For integration tests, add `example-new-feature: true` to [alpha test Prow environment](./../../test/e2e-tests-kind-alpha.env).
 
 4. Add `example-new-feature: false` to [the pipeline configMap](./../../config/config-feature-flags.yaml) with a release note.
 
@@ -85,7 +85,7 @@ flag doesn't mean you're done yet! When a user submits a Tekton resource it's
 validated by Pipelines' webhook. Here too you'll need to ensure your new
 features aren't accidentally accepted when the feature gate suggests they
 shouldn't be. We've got a helper function,
-[`ValidateEnabledAPIFields`](../../pkg/apis/version/version_validation.go),
+[`ValidateEnabledAPIFields`](../../pkg/apis/config/featureflags_validation.go),
 to make validating the current feature gate easier. Use it like this:
 
 ```go
@@ -155,7 +155,7 @@ examples under alpha conditions.
 ### Integration Tests
 
 For integration tests we provide the
-[`requireAnyGate` function](../../test/gate.go) which should be passed to the
+[`requireAnyGate` function](../../test/featureflags.go) which should be passed to the
 `setup` function used by tests:
 
 ```go


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Several relative links in `docs/developers/feature-versioning.md` pointed at
files that have since been renamed or removed, so they return a 404 in the
developer guide. This updates them to the current file locations. Docs-only, no
behavior change.

- The e2e env files dropped the `-prow` segment
  (`e2e-tests-kind-prow-{alpha,beta}.env` became
  `e2e-tests-kind-{alpha,beta}.env`), so the alpha/beta integration-test links
  (3 occurrences) now point at the renamed files.
- `version.ValidateEnabledAPIFields` was moved to the `config` package and the
  old `pkg/apis/version/version_validation.go` was deleted. The link now points
  at the live implementation in `pkg/apis/config/featureflags_validation.go`
  (the symbol remaining in the `version` package is a deprecated alias).
- `test/gate.go` was renamed to `test/featureflags.go`, where `requireAnyGate`
  now lives, so that link is updated too.

Each link keeps its existing relative-path prefix; only the target file names
change.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
