### PR TITLE
Use io.ReadFull to read OCI bundle tar layer

### DIFF
--- a/pkg/remote/oci/resolver.go
+++ b/pkg/remote/oci/resolver.go
@@ -193,7 +193,7 @@ func readTarLayer(layer v1.Layer) (runtime.Object, error) {
 	}
 
 	contents := make([]byte, header.Size)
-	if _, err := treader.Read(contents); err != nil && !errors.Is(err, io.EOF) {
+	if _, err := io.ReadFull(treader, contents); err != nil && !errors.Is(err, io.EOF) {
 		// We only allow 1 resource per layer so this tar bundle should have one and only one file.
 		return nil, fmt.Errorf("failed to read tar bundle: %w", err)
 	}

--- a/pkg/remote/oci/resolver_test.go
+++ b/pkg/remote/oci/resolver_test.go
@@ -128,6 +128,33 @@ func TestOCIResolver(t *testing.T) {
 			},
 		},
 		{
+			// A task whose serialized form is larger than a single chunk of the
+			// registry's gzip stream. readTarLayer must keep reading until the
+			// buffer is full (io.ReadFull); a single tar.Reader.Read short-reads
+			// here and silently truncates the object, breaking deserialization.
+			name: "large-task",
+			objs: []runtime.Object{
+				&v1beta1.Task{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "large-task",
+					},
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "tekton.dev/v1beta1",
+						Kind:       "Task",
+					},
+					Spec: v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{
+							Name:   "step",
+							Image:  "busybox",
+							Script: strings.Repeat("x", 128*1024),
+						}},
+					},
+				},
+			},
+			mapper:       test.DefaultObjectAnnotationMapper,
+			listExpected: []remote.ResolvedObject{{Kind: "task", APIVersion: "v1beta1", Name: "large-task"}},
+		},
+		{
 			name:         "too-many-objects",
 			objs:         toManyObj,
 			mapper:       test.DefaultObjectAnnotationMapper,


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`readTarLayer` in `pkg/remote/oci/resolver.go` read the tar entry with a single
`tar.Reader.Read` into a buffer sized to the header. The `io.Reader` contract
only promises up to `len(p)` bytes per call, and the layer is served through a
streaming gunzip reader over the registry response (`layer.Uncompressed()`), so a
bundle whose serialized form spans more than one stream chunk short-reads. The
unread tail was silently dropped and the truncated bytes were handed to
`UniversalDeserializer().Decode`, which then failed to parse the object.

This mirrors the same bug already fixed in the sibling bundle resolver in #8389
("Use io.ReadFull to read the bundle content", commit `c7ebd724e`), which changed
`pkg/resolution/resolver/bundle/bundle.go`. The `pkg/remote/oci` copy was left
with the raw single `Read`.

The fix reads the full entry with `io.ReadFull`. `io` is already imported; the
existing `io.EOF` tolerance (for a zero-length entry at EOF) and the `%w` error
wrapping are unchanged.

A regression case is added to `TestOCIResolver`: a `Task` with a 128 KB embedded
`Script`, which is large enough to span multiple chunks of the registry's gzip
stream. The existing harness pushes a real image to an `httptest` registry and
round-trips it through `resolver.Get` (the real remote gunzip path), asserting
`cmp.Diff(obj, actual) == ""`. It fails before this change (the truncated bytes
produce `yaml: control characters are not allowed`) and passes after.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

/kind bug

# Release Notes

```release-note
Fix truncation of large Tekton bundles resolved from OCI images, which
could cause the bundle to fail to parse.
```

<!-- NOTE: `/kind bug` must be posted as a PR comment after opening so Prow applies
     the label; it is included in the body above for reviewer visibility. -->
