### PR TITLE
docs: fix broken Logs link in developer local-setup guide

### DIFF
--- a/docs/developers/local-setup.md
+++ b/docs/developers/local-setup.md
@@ -33,7 +33,7 @@ Complete these prerequisites to run Tekton locally using Docker Desktop:
   such as [Stackdriver](https://cloud.google.com/logging/).
 - You can deploy Elasticsearch, Beats, or Kibana locally to view logs. You can find an
   example configuration at <https://github.com/mgreau/tekton-pipelines-elastic-tutorials>.
-- To learn more about obtaining logs, see [Logs](logs.md).
+- To learn more about obtaining logs, see [Logs](../logs.md).
 
 ## Using Minikube
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The "Logs" link in `docs/developers/local-setup.md` is written as a
file-relative link `[Logs](logs.md)`. Because that guide lives in
`docs/developers/`, the link resolves to `docs/developers/logs.md`, which does
not exist, so it returns a 404 on GitHub and on the docs site. The logs guide
actually lives one directory up at `docs/logs.md`.

This prefixes the link with `../` so it resolves to `docs/logs.md`:

```
- To learn more about obtaining logs, see [Logs](logs.md).
+ To learn more about obtaining logs, see [Logs](../logs.md).
```

Scope note: `docs/README.md` also references `[Viewing logs](logs.md)`, but that
file is in `docs/`, so its link already resolves to `docs/logs.md` correctly and
is left untouched. Only the developer local-setup guide was broken.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

<!-- Note: "Has Tests" is left unchecked because this is a docs-only link fix with
no code/functionality change; there is nothing to unit test. After opening the PR,
add a kind label by commenting `/kind documentation` (cannot be pre-checked here). -->

# Release Notes

```release-note
NONE
```

---

## Commit (already on branch patch-9)

```
docs: fix broken Logs link in developer local-setup guide

The Logs link in docs/developers/local-setup.md was relative to
docs/developers/, so it resolved to docs/developers/logs.md and returned
a 404. The logs guide lives one directory up at docs/logs.md, so prefix
the link with ../ to point at the correct file.
```

## After opening the PR (manual follow-ups for the human)

- Comment `/kind documentation` on the PR to add the required kind label
  (the template asks for it; it is set via a bot comment, not the body).
- EasyCLA will post a CLA check; authorize it if prompted (no DCO sign-off is
  used by this repo, so no `git commit -s`).
