### PR TITLE
Fix broken object param example links in API spec

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -184,7 +184,7 @@ Declares a parameter whose value has to be provided at runtime
 | `name`        | string                      | REQUIRED            |                                                                                                                                                                                          |
 | `description` | string                      | REQUIRED            |                                                                                                                                                                                          |
 | `type`        | [`ParamType`](#paramtype)   | REQUIRED (see note) | The values `string` and `array` for this field are REQUIRED, and the value `object` is RECOMMENDED.                                                                                      |
-| `properties`  | map<string,PropertySpec>    | RECOMMENDED         | `PropertySpec` is a type that defines the spec of an individual key. See how to define the `properties` section in the [example](../examples/v1/taskruns/beta/object-param-result.yaml). |
+| `properties`  | map<string,PropertySpec>    | RECOMMENDED         | `PropertySpec` is a type that defines the spec of an individual key. See how to define the `properties` section in the [example](../examples/v1/taskruns/object-param-result.yaml).      |
 | `default`     | [`ParamValue`](#paramvalue) | REQUIRED            |                                                                                                                                                                                          |
 
 ### ParamType
@@ -239,7 +239,7 @@ Defines a result produced by a Task
 | `name`        | string                        | REQUIRED    | Declares the name by which a parameter is referenced.                                                                                                                                    |
 | `type`        | [`ResultsType`](#resultstype) | REQUIRED    | Type is the user-specified type of the result.  The values `string` this field is REQUIRED, and the values `array` and `object` are RECOMMENDED.                                         |
 | `description` | string                        | RECOMMENDED | Description of the result                                                                                                                                                                |
-| `properties`  | map<string,PropertySpec>      | RECOMMENDED | `PropertySpec` is a type that defines the spec of an individual key. See how to define the `properties` section in the [example](../examples/v1/taskruns/beta/object-param-result.yaml). |
+| `properties`  | map<string,PropertySpec>      | RECOMMENDED | `PropertySpec` is a type that defines the spec of an individual key. See how to define the `properties` section in the [example](../examples/v1/taskruns/object-param-result.yaml).      |
 
 ### ResultsType
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `ParamSpec` and `ResultSpec` "properties" rows in `docs/api-spec.md` both
link to `examples/v1/taskruns/beta/object-param-result.yaml` to show how to
define the `properties` section, but that path 404s.

When TEP-0075 (object params and results) was promoted to stable, the example
moved out of `beta/`:

```
$ git show fe47c9bc8 --stat -- examples/v1/taskruns/beta/object-param-result.yaml
  examples/v1/taskruns/{beta => }/object-param-result.yaml   (R100)
```

so the file now lives at `examples/v1/taskruns/object-param-result.yaml`, but
these two doc links were missed. This points both at the current location so
readers no longer hit a 404. `docs/tasks.md` already references the non-beta
path, which corroborates the intended target.

Docs-only, two lines changed. The two markdown table cells are re-padded so the
existing width-aligned tables stay aligned.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

<!-- Note on the checklist above:
  - "Has Tests": docs-only link fix, no functionality added or changed, so no
    code tests apply. The repo has no markdown link-check CI harness; the fix is
    proven by the target resolving and no stale beta links remaining.
  - "pre-commit Passed": no Go/config changed; nothing for pre-commit to reformat.
  - "kind label" is left unchecked because it is applied via a `/kind documentation`
    comment after the PR is opened, not in the body. -->

# Release Notes

```release-note
NONE
```
