### PR TITLE
Fix moved example links in pipeline docs

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -1075,7 +1075,7 @@ spec:
 
 In this example, the matrix will create two `TaskRuns` - one for `amd64` and one for `arm64`. Each will have its pod scheduled on the appropriate node architecture using the nodeSelector with the substituted parameter value.
 
-For a complete example, see [`pipelinerun-with-taskrunspecs-matrix-param-substitution.yaml`](../examples/v1/pipelineruns/pipelinerun-with-taskrunspecs-matrix-param-substitution.yaml).
+For a complete example, see [`pipelinerun-with-matrix-and-taskrunspecs-param-substitution.yaml`](../examples/v1/pipelineruns/beta/pipelinerun-with-matrix-and-taskrunspecs-param-substitution.yaml).
 
 ### Specifying `Workspaces`
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1404,7 +1404,7 @@ In the example below, the `Pipeline` collects array and object results from `Tas
         value: $(tasks.task2.results.object-results.foo)
 ```
 
-For an end-to-end example see [`Array and Object Results` in a `PipelineRun`](../examples/v1/pipelineruns/pipeline-emitting-results.yaml).
+For an end-to-end example see [`Array and Object Results` in a `PipelineRun`](../examples/v1/pipelineruns/beta/pipeline-emitting-results.yaml).
 
 A `Pipeline Result` is not emitted if any of the following are true:
 - A `PipelineTask` referenced by the `Pipeline Result` failed. The `PipelineRun` will also


### PR DESCRIPTION
<!-- Thank you for the PR! -->

# Changes

Two example links in the user-facing docs point at example YAMLs that were
relocated into `examples/v1/pipelineruns/beta/` (and one was renamed), so both
currently 404 on GitHub:

- `docs/pipelines.md` (Array and Object Results) links to
  `../examples/v1/pipelineruns/pipeline-emitting-results.yaml`, but that file
  now lives at
  `../examples/v1/pipelineruns/beta/pipeline-emitting-results.yaml`.
- `docs/pipelineruns.md` (Matrix Support with `taskRunSpecs`) links to
  `../examples/v1/pipelineruns/pipelinerun-with-taskrunspecs-matrix-param-substitution.yaml`.
  That file was renamed and moved to
  `../examples/v1/pipelineruns/beta/pipelinerun-with-matrix-and-taskrunspecs-param-substitution.yaml`;
  the visible link text is updated to match the new filename.

This repoints both links at their current locations so readers no longer hit a
404. Docs-only, two lines changed.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

<!-- Note on the checklist:
  - "Has Tests": docs-only link fix, no functionality added or changed, so no
    code tests apply. Proven by both targets resolving and no stale links left.
  - "pre-commit Passed": no Go/config changed; nothing for pre-commit to reformat.
  - "kind label" is left unchecked because it is applied via a /kind documentation
    comment after the PR is opened, not in the body. -->

# Release Notes

```release-note
NONE
```
