### PR TITLE
hoist step result name regex to package var

### DIFF
--- a/pkg/apis/pipeline/v1/result_validation.go
+++ b/pkg/apis/pipeline/v1/result_validation.go
@@ -156,7 +156,7 @@ func validateObjectStepResult(sr StepResult) (errs *apis.FieldError) {
 }
 
 // ExtractStepResultName extracts the step name and result name from a string matching
-// formtat $(steps.<stepName>.results.<resultName>).
+// format $(steps.<stepName>.results.<resultName>).
 // If a match is not found, an error is retured.
 func ExtractStepResultName(value string) (string, string, error) {
 	rs := stepResultNameRegex.FindStringSubmatch(value)

--- a/pkg/apis/pipeline/v1/result_validation.go
+++ b/pkg/apis/pipeline/v1/result_validation.go
@@ -22,6 +22,9 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+// stepResultNameRegex matches the format $(steps.<stepName>.results.<resultName>).
+var stepResultNameRegex = regexp.MustCompile(`\$\(steps\.(.*?)\.results\.(.*?)\)`)
+
 // Validate implements apis.Validatable
 func (tr TaskResult) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if !resultNameFormatRegex.MatchString(tr.Name) {
@@ -156,8 +159,7 @@ func validateObjectStepResult(sr StepResult) (errs *apis.FieldError) {
 // formtat $(steps.<stepName>.results.<resultName>).
 // If a match is not found, an error is retured.
 func ExtractStepResultName(value string) (string, string, error) {
-	re := regexp.MustCompile(`\$\(steps\.(.*?)\.results\.(.*?)\)`)
-	rs := re.FindStringSubmatch(value)
+	rs := stepResultNameRegex.FindStringSubmatch(value)
 	if len(rs) != 3 {
 		return "", "", fmt.Errorf("Could not extract step name and result name. Expected value to look like $(steps.<stepName>.results.<resultName>) but got \"%v\"", value)
 	}

--- a/pkg/apis/pipeline/v1/result_validation_test.go
+++ b/pkg/apis/pipeline/v1/result_validation_test.go
@@ -284,6 +284,14 @@ func TestExtractStepResultNameError(t *testing.T) {
 		name:    "invalid string format",
 		value:   "not valid",
 		wantErr: errors.New(`Could not extract step name and result name. Expected value to look like $(steps.<stepName>.results.<resultName>) but got "not valid"`),
+	}, {
+		name:    "singular step and result",
+		value:   "$(step.Foo.result.Bar)",
+		wantErr: errors.New(`Could not extract step name and result name. Expected value to look like $(steps.<stepName>.results.<resultName>) but got "$(step.Foo.result.Bar)"`),
+	}, {
+		name:    "missing steps prefix",
+		value:   "$(Foo.results.Bar)",
+		wantErr: errors.New(`Could not extract step name and result name. Expected value to look like $(steps.<stepName>.results.<resultName>) but got "$(Foo.results.Bar)"`),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -298,6 +306,12 @@ func TestExtractStepResultNameError(t *testing.T) {
 				t.Errorf("Expected an empty string but got: %v", gotResult)
 			}
 		})
+	}
+}
+
+func BenchmarkExtractStepResultName(b *testing.B) {
+	for range b.N {
+		_, _, _ = v1.ExtractStepResultName("$(steps.Foo.results.Bar)")
 	}
 }
 


### PR DESCRIPTION
# Changes

Hoist the constant step result expression regex used by `ExtractStepResultName`
to a package variable so it is compiled once instead of on every call.

Add a benchmark covering the hot path and regression cases confirming malformed
step result expressions are rejected.

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label
- [x] Release notes block below has been updated with any user facing changes
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
