### PR TITLE
Fix sidecar-logs result extraction for results exceeding 4096 bytes

### DIFF
--- a/internal/sidecarlogresults/sidecarlogresults.go
+++ b/internal/sidecarlogresults/sidecarlogresults.go
@@ -261,7 +261,7 @@ func GetResultsFromSidecarLogs(ctx context.Context, clientset kubernetes.Interfa
 }
 
 func extractResultsFromLogs(logs io.Reader, sidecarLogResults []result.RunResult, maxResultLimit int) ([]result.RunResult, error) {
-	reader := bufio.NewReader(logs)
+	reader := bufio.NewReaderSize(logs, maxResultLimit)
 	for {
 		line, isPrefix, err := reader.ReadLine()
 		if err != nil {
@@ -271,6 +271,11 @@ func extractResultsFromLogs(logs io.Reader, sidecarLogResults []result.RunResult
 			return nil, err
 		}
 
+		if isPrefix {
+			// Take ownership of the buffer before further ReadLine calls,
+			// since ReadLine's returned slice is only valid until the next call.
+			line = append([]byte(nil), line...)
+		}
 		lineLength := len(line)
 		for isPrefix {
 			more, nextPrefix, err := reader.ReadLine()

--- a/internal/sidecarlogresults/sidecarlogresults_test.go
+++ b/internal/sidecarlogresults/sidecarlogresults_test.go
@@ -259,6 +259,63 @@ func TestExtractResultsFromLogs(t *testing.T) {
 	}
 }
 
+// TestExtractResultsFromLogs_LargeResult is a regression test for
+// https://github.com/tektoncd/pipeline/issues/10402
+// Results whose JSON line exceeds bufio.Reader's default 4096-byte buffer
+// but is within maxResultLimit must be extracted correctly.
+func TestExtractResultsFromLogs_LargeResult(t *testing.T) {
+	// Value >4096 bytes but within maxResultLimit (8192)
+	largeValue := strings.Repeat("x", 5000)
+	inputResults := []SidecarLogResult{
+		{
+			Name:  "small-result",
+			Value: "hello",
+			Type:  "task",
+		},
+		{
+			Name:  "large-result",
+			Value: largeValue,
+			Type:  "task",
+		},
+		{
+			Name:  "after-large",
+			Value: "world",
+			Type:  "task",
+		},
+	}
+	podLogs := ""
+	for _, r := range inputResults {
+		res, _ := json.Marshal(&r)
+		podLogs = fmt.Sprintf("%s%s\n", podLogs, string(res))
+	}
+	logs := strings.NewReader(podLogs)
+
+	results, err := extractResultsFromLogs(logs, []result.RunResult{}, 8192)
+	if err != nil {
+		t.Fatalf("expected no error but got: %v", err)
+	}
+	want := []result.RunResult{
+		{
+			Key:        "small-result",
+			Value:      "hello",
+			ResultType: result.TaskRunResultType,
+		},
+		{
+			Key:        "large-result",
+			Value:      largeValue,
+			ResultType: result.TaskRunResultType,
+		},
+		{
+			Key:        "after-large",
+			Value:      "world",
+			ResultType: result.TaskRunResultType,
+		},
+	}
+	if d := cmp.Diff(want, results); d != "" {
+		t.Fatalf("results mismatch (-want +got):\n%s", d)
+	}
+}
+
 func TestExtractResultsFromLogs_Failure(t *testing.T) {
 	inputResults := []SidecarLogResult{
 		{


### PR DESCRIPTION
# Changes

Fix sidecar-logs result extraction corruption when a single result's JSON line exceeds `bufio.Reader`'s default 4096-byte internal buffer but is within the configured `max-result-size`.

Since v1.9.0 (commit d2b0894, PR #8869), `bufio.NewReader` replaced `bufio.Scanner` without sizing the buffer to `maxResultLimit`. When a result line exceeds 4096 bytes, `ReadLine` returns `isPrefix=true` and the code appends subsequent chunks to `line` — but per Go docs, `ReadLine`'s returned buffer is only valid until the next call, so the data gets corrupted. This causes `json.Unmarshal` to fail, which aborts the entire extraction loop and drops **all** results for the TaskRun.

**Fix:**
1. Use `bufio.NewReaderSize(logs, maxResultLimit)` to size the buffer properly (restoring parity with pre-v1.9.0 `bufio.Scanner` behavior)
2. Copy the `line` slice before the `isPrefix` loop to take ownership before further `ReadLine` calls

**Regression test:** `TestExtractResultsFromLogs_LargeResult` — 3 results where the middle one is 5000+ bytes, verifying all are extracted correctly.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string \"action required\" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix sidecar-logs result extraction dropping all TaskRun results when a single result's JSON exceeds 4096 bytes but is within the configured max-result-size. Regression since v1.9.0.
```