### PR TITLE
Add branch prefix to Dependabot PR titles for release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -137,6 +137,8 @@ updates:
       target-branch: release-v1.12.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.12.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -170,6 +172,8 @@ updates:
       target-branch: release-v1.12.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.12.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -203,6 +207,8 @@ updates:
       target-branch: release-v1.12.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.12.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -236,6 +242,8 @@ updates:
       target-branch: release-v1.12.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.12.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -253,6 +261,8 @@ updates:
       target-branch: release-v1.12.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.12.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -274,6 +284,8 @@ updates:
       target-branch: release-v1.12.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.12.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -295,6 +307,8 @@ updates:
       target-branch: release-v1.9.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.9.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -328,6 +342,8 @@ updates:
       target-branch: release-v1.9.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.9.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -361,6 +377,8 @@ updates:
       target-branch: release-v1.9.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.9.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -394,6 +412,8 @@ updates:
       target-branch: release-v1.9.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.9.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -411,6 +431,8 @@ updates:
       target-branch: release-v1.9.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.9.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -432,6 +454,8 @@ updates:
       target-branch: release-v1.9.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.9.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -453,6 +477,8 @@ updates:
       target-branch: release-v1.6.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.6.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -486,6 +512,8 @@ updates:
       target-branch: release-v1.6.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.6.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -519,6 +547,8 @@ updates:
       target-branch: release-v1.6.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.6.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -552,6 +582,8 @@ updates:
       target-branch: release-v1.6.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.6.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -569,6 +601,8 @@ updates:
       target-branch: release-v1.6.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.6.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -590,6 +624,8 @@ updates:
       target-branch: release-v1.6.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.6.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -611,6 +647,8 @@ updates:
       target-branch: release-v1.3.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.3.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -644,6 +682,8 @@ updates:
       target-branch: release-v1.3.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.3.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -677,6 +717,8 @@ updates:
       target-branch: release-v1.3.x
       schedule:
         interval: daily
+      commit-message:
+        prefix: '[release-v1.3.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -710,6 +752,8 @@ updates:
       target-branch: release-v1.3.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.3.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -727,6 +771,8 @@ updates:
       target-branch: release-v1.3.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.3.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -748,6 +794,8 @@ updates:
       target-branch: release-v1.3.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v1.3.x] '
       labels:
         - ok-to-test
         - dependencies

--- a/hack/generate-dependabot.go
+++ b/hack/generate-dependabot.go
@@ -41,6 +41,11 @@ type Ecosystem struct {
 	Cooldown         map[string]interface{}   `yaml:"cooldown,omitempty"`
 }
 
+// CommitMessage configures the prefix for Dependabot commit messages and PR titles
+type CommitMessage struct {
+	Prefix string `yaml:"prefix"`
+}
+
 // DependabotConfig represents the generated dependabot.yml structure
 type DependabotConfig struct {
 	Version int      `yaml:"version"`
@@ -53,6 +58,7 @@ type Update struct {
 	Directory        string                   `yaml:"directory"`
 	TargetBranch     string                   `yaml:"target-branch,omitempty"`
 	Schedule         map[string]interface{}   `yaml:"schedule"`
+	CommitMessage    *CommitMessage           `yaml:"commit-message,omitempty"`
 	Labels           []string                 `yaml:"labels"`
 	Ignore           []map[string]interface{} `yaml:"ignore,omitempty"`
 	Groups           map[string]interface{}   `yaml:"groups,omitempty"`
@@ -160,6 +166,7 @@ func generateDependabotConfig(config Config) DependabotConfig {
 				Directory:        ecosystem.Directory,
 				TargetBranch:     branch,
 				Schedule:         ecosystem.Schedule,
+				CommitMessage:    &CommitMessage{Prefix: "[" + branch + "] "},
 				Labels:           ecosystem.Labels,
 				Ignore:           ignore,
 				Groups:           ecosystem.Groups,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adds `[release-vX.Y.x]` prefix to Dependabot commit messages (and PR titles) for all release branch entries, so it is immediately clear which branch a Dependabot PR targets.

### Modified files
- `hack/generate-dependabot.go` — Added `CommitMessage` struct with `Prefix` field; set prefix for release branch update entries during generation.
- `.github/dependabot.yml` — Regenerated to include `commit-message.prefix` for all release branch blocks.

### Example

A Dependabot PR targeting `release-v1.12.x` will now have a title like:
```
[release-v1.12.x] Bump golang.org/x/net from 0.30.0 to 0.33.0
```

Ported from tektoncd/cli#3017.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```