### PR TITLE
fix(release): copy vendor tarball into kodata instead of symlink

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -162,11 +162,15 @@ spec:
       # probably get it wrong), we'll just targz up the whole vendor tree and
       # include it. As of 9/20/2019, this amounts to about 11MB of additional
       # data in each image.
+      # ko >= v0.19.0 rejects kodata symlinks that resolve outside the
+      # kodata root (ko-build/ko#1619), so the tarball is copied into
+      # each kodata/ directory instead of being symlinked from a
+      # shared tmpdir.
       TMPDIR=$(mktemp -d)
       tar cfz ${TMPDIR}/source.tar.gz vendor/
       for d in cmd/*; do
         if [ -d ${d}/kodata/ ]; then
-          ln -s ${TMPDIR}/source.tar.gz ${d}/kodata/
+          cp ${TMPDIR}/source.tar.gz ${d}/kodata/
         fi
       done
 


### PR DESCRIPTION
# Changes

`ko` v0.19.0 enforces that `kodata/` symlinks must not resolve outside the
kodata root (ko-build/ko#1619), a deliberate security hardening. The
`run-ko` step in `tekton/publish.yaml` symlinks `cmd/*/kodata/source.tar.gz`
to a tarball written to an external `mktemp -d` directory:

```
TMPDIR=$(mktemp -d)
tar cfz ${TMPDIR}/source.tar.gz vendor/
for d in cmd/*; do
  if [ -d ${d}/kodata/ ]; then
    ln -s ${TMPDIR}/source.tar.gz ${d}/kodata/
  fi
done
```

Once `ko` resolves against an image built with `ko` >= v0.19.0, this
symlink gets rejected:

```
Error: error processing import paths in "config/100-deployment.yaml":
error resolving image references: tarring kodata: kodata symlink
"cmd/controller/kodata/source.tar.gz" resolves to "/tmp/tmp.XXXXXX/source.tar.gz"
which is outside the kodata root "cmd/controller/kodata"
```

We hit this exact error in `tektoncd/chains`' release pipeline after
bumping the pinned `ghcr.io/tektoncd/plumbing/ko` image digest, which
pulled in `ko` v0.19.1 (fixed there in
[tektoncd/chains#1791](https://github.com/tektoncd/chains/pull/1791)).
I checked and `tekton/publish.yaml`'s currently pinned `ko` image digest
also resolves to `ko` v0.19.1, so `pipeline`'s release pipeline is exposed
to the same failure the next time it publishes images.

This is the same class of issue already fixed for the `kodata/LICENSE`
symlinks in #10358 — this PR applies the same style of fix to the
remaining `source.tar.gz` symlink.

## Fix

Copy the tarball into each `cmd/*/kodata/` directory instead of
symlinking to it from a shared tmpdir. `ko` already dereferences symlinks
and embeds the resolved file's bytes into the image layer when tarring
kodata (that's the reason the check exists — to stop arbitrary host file
*content* from leaking into images), so this has no effect on the final
image size for any `cmd/*` binary; only the symlink itself was rejected,
not the underlying content. It does mean the vendor tarball is now
written to disk once per `cmd/*/kodata/` directory during the build
instead of shared via symlink, which is a small, bounded amount of extra
temporary disk usage during `ko resolve` (not in the final image).

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps — N/A
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed — N/A, release pipeline script fix
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind bug`
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release — not applicable, no user action required

# Release Notes

```release-note
Fix release pipeline `ko resolve` failure caused by `ko` >= v0.19.0 rejecting
the `kodata/source.tar.gz` symlink used to bundle vendored source.
```

Made with [Cursor](https://cursor.com)