### PR TITLE
feat: add default StepAction catalog to Hub Resolver

### DIFF
--- a/config/resolvers/hubresolver-config.yaml
+++ b/config/resolvers/hubresolver-config.yaml
@@ -28,6 +28,8 @@ data:
   default-artifact-hub-task-catalog: "tekton-catalog-tasks"
   # the default Artifact Hub Pipeline catalog from where to pull the resource.
   default-artifact-hub-pipeline-catalog: "tekton-catalog-pipelines"
+  # the default Artifact Hub StepAction catalog from where to pull the resource.
+  default-artifact-hub-stepaction-catalog: "git-clone-stepaction"
   # the default layer kind in the hub image.
   default-kind: "task"
   # the default hub source to pull the resource from.

--- a/docs/hub-resolver.md
+++ b/docs/hub-resolver.md
@@ -13,11 +13,11 @@ Use resolver type `hub`.
 
 | Param Name       | Description                                                                   | Example Value                                              |
 |------------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
-| `catalog`        | The catalog from where to pull the resource (Optional)                        | Default:  `tekton-catalog-tasks` (for `task` kind);  `tekton-catalog-pipelines` (for `pipeline` kind); no default for `stepaction` kind, so `catalog` must be set explicitly |
+| `catalog`        | The catalog from where to pull the resource (Optional)                        | Default:  `tekton-catalog-tasks` (for `task` kind);  `tekton-catalog-pipelines` (for `pipeline` kind); `git-clone-stepaction` (for `stepaction` kind) |
 | `type`           | The type of Hub from where to pull the resource (Optional). Either `artifact` or `tekton` | Default:  `artifact` (recommended). Note: `tekton` type is deprecated.                                         |
 | `kind`           | `task`, `pipeline` or `stepaction` (Optional)                                        | Default: `task`                                                     |
-| `name`           | The name of the task or pipeline to fetch from the hub                        | `golang-build`                                             |
-| `version`        | Version or a Constraint (see [below](#version-constraint) of a task or a pipeline to pull in from. Wrap the number in quotes!   | `"0.5.0"`, `">= 0.5.0"`                                                    |
+| `name`           | The name of the task, pipeline, or StepAction to fetch from the hub            | `golang-build`                                             |
+| `version`        | Version or a Constraint (see [below](#version-constraint)) of a task, pipeline, or StepAction to pull in. Wrap the number in quotes! | `"0.5.0"`, `">= 0.5.0"`                                                    |
 | `url`            | Custom hub API endpoint to query instead of the cluster-configured default (Optional). Must be an absolute HTTP or HTTPS URL. Overrides all other URL configuration (ConfigMap URL lists, environment variables, and defaults). | `https://internal-hub.example.com`                        |
 
 The Catalogs in the Artifact Hub follows the semVer (i.e.` <major-version>.<minor-version>.0`) and the Catalogs in the Tekton Hub follows the simplified semVer (i.e. `<major-version>.<minor-version>`). Both full and simplified semantic versioning will be accepted by the `version` parameter. The Hub Resolver will map the version to the format expected by the target Hub `type`.
@@ -43,7 +43,8 @@ for the name, namespace and defaults that the resolver ships with.
 | `default-tekton-hub-catalog`| The default tekton hub catalog from where to pull the resource.| `Tekton`               |
 | `default-artifact-hub-task-catalog`| The default artifact hub catalog from where to pull the resource for task kind.| `tekton-catalog-tasks`               |
 | `default-artifact-hub-pipeline-catalog`| The default artifact hub catalog from where to pull the resource for pipeline kind.  | `tekton-catalog-pipelines`               |
-| `default-kind`              | The default object kind for references.              | `task`, `pipeline`     |
+| `default-artifact-hub-stepaction-catalog`| The default artifact hub catalog from where to pull the resource for StepAction kind.  | `git-clone-stepaction`               |
+| `default-kind`              | The default object kind for references.              | `task`, `pipeline`, `stepaction`     |
 | `default-type`              | The default hub from where to pull the resource.     | `artifact`, `tekton`   |
 | `artifact-hub-urls`         | Ordered YAML list of Artifact Hub API URLs to try. First successful response wins. If not set, the `ARTIFACT_HUB_API` env var or default is used. URLs must use `http` or `https` scheme. | See [below](#configuring-multiple-hub-urls) |
 | `tekton-hub-urls`           | Ordered YAML list of Tekton Hub API URLs to try. First successful response wins. If not set, the `TEKTON_HUB_API` env var is used. URLs must use `http` or `https` scheme. | See [below](#configuring-multiple-hub-urls) |
@@ -145,8 +146,6 @@ spec:
       ref:
         resolver: hub
         params:
-        - name: catalog
-          value: git-clone-stepaction
         - name: type # optional
           value: artifact
         - name: kind

--- a/pkg/remoteresolution/resolver/hub/resolver.go
+++ b/pkg/remoteresolution/resolver/hub/resolver.go
@@ -213,6 +213,12 @@ func resolveCatalogName(paramsMap, conf map[string]string) (string, error) {
 				return configAHTaskCatalog, nil
 			case "pipeline":
 				return configAHPipelineCatalog, nil
+			case hub.StepActionKind:
+				configAHStepActionCatalog, ok := conf[hub.ConfigArtifactHubStepActionCatalog]
+				if !ok {
+					return "", errors.New("default Artifact Hub StepAction catalog was not set during installation of the hub resolver")
+				}
+				return configAHStepActionCatalog, nil
 			default:
 				return "", fmt.Errorf("failed to resolve catalog name with kind: %s", paramsMap[hub.ParamKind])
 			}

--- a/pkg/remoteresolution/resolver/hub/resolver_test.go
+++ b/pkg/remoteresolution/resolver/hub/resolver_test.go
@@ -136,6 +136,64 @@ func TestValidateMissing(t *testing.T) {
 	}
 }
 
+func TestResolveCatalogNameStepAction(t *testing.T) {
+	params := map[string]string{
+		hubresolver.ParamKind: hubresolver.StepActionKind,
+		hubresolver.ParamType: ArtifactHubType,
+	}
+	conf := resolutionframework.GetResolverConfigFromContext(contextWithConfig())
+
+	got, err := resolveCatalogName(params, conf)
+	if err != nil {
+		t.Fatalf("unexpected error resolving catalog: %v", err)
+	}
+	if want := "git-clone-stepaction"; got != want {
+		t.Errorf("expected catalog %q but got %q", want, got)
+	}
+}
+
+func TestResolveCatalogNameWithoutStepActionCatalog(t *testing.T) {
+	conf := resolutionframework.GetResolverConfigFromContext(contextWithConfig())
+	delete(conf, hubresolver.ConfigArtifactHubStepActionCatalog)
+
+	t.Run("stepaction requires its default", func(t *testing.T) {
+		params := map[string]string{hubresolver.ParamKind: hubresolver.StepActionKind, hubresolver.ParamType: ArtifactHubType}
+		_, err := resolveCatalogName(params, conf)
+		if err == nil {
+			t.Fatal("expected an error when the default StepAction catalog is not configured")
+		}
+		if want := "default Artifact Hub StepAction catalog was not set during installation of the hub resolver"; err.Error() != want {
+			t.Errorf("expected error %q but got %q", want, err)
+		}
+	})
+
+	t.Run("explicit stepaction catalog remains compatible", func(t *testing.T) {
+		params := map[string]string{
+			hubresolver.ParamCatalog: "custom-stepactions",
+			hubresolver.ParamKind:    hubresolver.StepActionKind,
+			hubresolver.ParamType:    ArtifactHubType,
+		}
+		got, err := resolveCatalogName(params, conf)
+		if err != nil {
+			t.Fatalf("unexpected error resolving explicit StepAction catalog: %v", err)
+		}
+		if want := "custom-stepactions"; got != want {
+			t.Errorf("expected catalog %q but got %q", want, got)
+		}
+	})
+
+	t.Run("task remains compatible", func(t *testing.T) {
+		params := map[string]string{hubresolver.ParamKind: "task", hubresolver.ParamType: ArtifactHubType}
+		got, err := resolveCatalogName(params, conf)
+		if err != nil {
+			t.Fatalf("unexpected error resolving task catalog: %v", err)
+		}
+		if want := "tekton-catalog-tasks"; got != want {
+			t.Errorf("expected catalog %q but got %q", want, got)
+		}
+	})
+}
+
 func TestValidateConflictingKindName(t *testing.T) {
 	testCases := []struct {
 		kind    string
@@ -304,10 +362,11 @@ func toParams(m map[string]string) []pipelinev1.Param {
 
 func contextWithConfig() context.Context {
 	config := map[string]string{
-		"default-tekton-hub-catalog":            "Tekton",
-		"default-artifact-hub-task-catalog":     "tekton-catalog-tasks",
-		"default-artifact-hub-pipeline-catalog": "tekton-catalog-pipelines",
-		"default-type":                          "artifact",
+		"default-tekton-hub-catalog":              "Tekton",
+		"default-artifact-hub-task-catalog":       "tekton-catalog-tasks",
+		"default-artifact-hub-pipeline-catalog":   "tekton-catalog-pipelines",
+		"default-artifact-hub-stepaction-catalog": "git-clone-stepaction",
+		"default-type": "artifact",
 	}
 
 	return resolutionframework.InjectResolverConfigToContext(context.Background(), config)

--- a/pkg/resolution/resolver/hub/config.go
+++ b/pkg/resolution/resolver/hub/config.go
@@ -28,6 +28,10 @@ const ConfigArtifactHubTaskCatalog = "default-artifact-hub-task-catalog"
 // the Artifact Hub Pipeline catalog to fetch the remote resource from.
 const ConfigArtifactHubPipelineCatalog = "default-artifact-hub-pipeline-catalog"
 
+// ConfigArtifactHubStepActionCatalog is the configuration field name for controlling
+// the Artifact Hub StepAction catalog to fetch the remote resource from.
+const ConfigArtifactHubStepActionCatalog = "default-artifact-hub-stepaction-catalog"
+
 // ConfigKind is the configuration field name for controlling
 // what the layer name in the hub image is.
 const ConfigKind = "default-kind"

--- a/pkg/resolution/resolver/hub/resolver.go
+++ b/pkg/resolution/resolver/hub/resolver.go
@@ -43,6 +43,9 @@ const (
 	// TektonHubType is the value to use setting the type field to tekton
 	TektonHubType string = "tekton"
 
+	// StepActionKind is the value to use setting the kind field to stepaction
+	StepActionKind = "stepaction"
+
 	disabledError = "cannot handle resolution request, enable-hub-resolver feature flag not true"
 )
 
@@ -267,6 +270,12 @@ func resolveCatalogName(paramsMap, conf map[string]string) (string, error) {
 				return configAHTaskCatalog, nil
 			case "pipeline":
 				return configAHPipelineCatalog, nil
+			case StepActionKind:
+				configAHStepActionCatalog, ok := conf[ConfigArtifactHubStepActionCatalog]
+				if !ok {
+					return "", errors.New("default Artifact Hub StepAction catalog was not set during installation of the hub resolver")
+				}
+				return configAHStepActionCatalog, nil
 			default:
 				return "", fmt.Errorf("failed to resolve catalog name with kind: %s", paramsMap[ParamKind])
 			}

--- a/pkg/resolution/resolver/hub/resolver_test.go
+++ b/pkg/resolution/resolver/hub/resolver_test.go
@@ -463,6 +463,12 @@ func TestResolveCatalogName(t *testing.T) {
 			expectedCat: "tekton-catalog-pipelines",
 		},
 		{
+			name:        "artifact type default stepaction catalog",
+			kind:        StepActionKind,
+			hubType:     "artifact",
+			expectedCat: "git-clone-stepaction",
+		},
+		{
 			name:        "custom catalog",
 			inputCat:    "custom-catalog",
 			kind:        "task",
@@ -493,6 +499,48 @@ func TestResolveCatalogName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveCatalogNameWithoutStepActionCatalog(t *testing.T) {
+	conf := framework.GetResolverConfigFromContext(contextWithConfig())
+	delete(conf, ConfigArtifactHubStepActionCatalog)
+
+	t.Run("stepaction requires its default", func(t *testing.T) {
+		params := map[string]string{ParamKind: StepActionKind, ParamType: ArtifactHubType}
+		_, err := resolveCatalogName(params, conf)
+		if err == nil {
+			t.Fatal("expected an error when the default StepAction catalog is not configured")
+		}
+		if want := "default Artifact Hub StepAction catalog was not set during installation of the hub resolver"; err.Error() != want {
+			t.Errorf("expected error %q but got %q", want, err)
+		}
+	})
+
+	t.Run("explicit stepaction catalog remains compatible", func(t *testing.T) {
+		params := map[string]string{
+			ParamCatalog: "custom-stepactions",
+			ParamKind:    StepActionKind,
+			ParamType:    ArtifactHubType,
+		}
+		got, err := resolveCatalogName(params, conf)
+		if err != nil {
+			t.Fatalf("unexpected error resolving explicit StepAction catalog: %v", err)
+		}
+		if want := "custom-stepactions"; got != want {
+			t.Errorf("expected catalog %q but got %q", want, got)
+		}
+	})
+
+	t.Run("task remains compatible", func(t *testing.T) {
+		params := map[string]string{ParamKind: "task", ParamType: ArtifactHubType}
+		got, err := resolveCatalogName(params, conf)
+		if err != nil {
+			t.Fatalf("unexpected error resolving task catalog: %v", err)
+		}
+		if want := "tekton-catalog-tasks"; got != want {
+			t.Errorf("expected catalog %q but got %q", want, got)
+		}
+	})
 }
 
 func TestResolveDisabled(t *testing.T) {
@@ -641,10 +689,11 @@ func toParams(m map[string]string) []pipelinev1.Param {
 
 func contextWithConfig() context.Context {
 	config := map[string]string{
-		"default-tekton-hub-catalog":            "Tekton",
-		"default-artifact-hub-task-catalog":     "tekton-catalog-tasks",
-		"default-artifact-hub-pipeline-catalog": "tekton-catalog-pipelines",
-		"default-type":                          "artifact",
+		"default-tekton-hub-catalog":              "Tekton",
+		"default-artifact-hub-task-catalog":       "tekton-catalog-tasks",
+		"default-artifact-hub-pipeline-catalog":   "tekton-catalog-pipelines",
+		"default-artifact-hub-stepaction-catalog": "git-clone-stepaction",
+		"default-type": "artifact",
 	}
 
 	return framework.InjectResolverConfigToContext(context.Background(), config)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Add `default-artifact-hub-stepaction-catalog` with the shipped default `git-clone-stepaction`.
- Use that default when Artifact Hub StepAction requests omit `catalog` in both resolver implementations.
- Preserve explicit StepAction catalogs and existing Task defaults for older/custom ConfigMaps without the new key.
- Update Hub Resolver configuration docs and the StepAction example.

Fixes #10419

## Verification

- `go test -race -count=1 ./pkg/resolution/resolver/hub ./pkg/remoteresolution/resolver/hub`
- `make test-unit-verbose-and-race`
- `go vet ./...`
- `golangci-lint run --modules-download-mode=vendor --new-from-rev=origin/main --max-issues-per-linter=0 --max-same-issues=0 --timeout=10m` (`0 issues`)
- `./hack/verify-codegen.sh` (`up to date`)
- `yamllint -c .yamllint config/resolvers/hubresolver-config.yaml`
- `./hack/verify-agent-readiness.sh`

`pre-commit run --all-files` runs all unit tests successfully, but its full-repository lint/private-key hooks are currently blocked by existing `origin/main` findings: the `docs/auth.md` test fixture is detected as a private key and full lint reports 161 issues on both clean `origin/main` and this branch. The change-scoped CI lint above reports no new issues.

## AI assistance

Hermes Agent using OpenAI GPT-5.6 Sol assisted with implementation and test orchestration. OpenAI Codex GPT-5.5 independently reviewed the final diff. The resulting changes were validated with the commands listed above.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed (see baseline note above)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The Hub Resolver now defaults the Artifact Hub catalog to `git-clone-stepaction` when resolving a StepAction without an explicit `catalog` parameter.
```
