### PR TITLE
Fix RestrictLength panic on all-symbol input

### DIFF
--- a/pkg/names/generate.go
+++ b/pkg/names/generate.go
@@ -71,7 +71,7 @@ func (simpleNameGenerator) RestrictLength(base string) string {
 		base = base[:maxNameLength]
 	}
 
-	for !alphaNumericRE.MatchString(base[len(base)-1:]) {
+	for len(base) > 0 && !alphaNumericRE.MatchString(base[len(base)-1:]) {
 		base = base[:len(base)-1]
 	}
 	return base

--- a/pkg/names/generate_test.go
+++ b/pkg/names/generate_test.go
@@ -58,6 +58,17 @@ func TestRestrictLength(t *testing.T) {
 		// trimmed until they do.
 		in:   "abcdefg   !@#!$",
 		want: "abcdefg",
+	}, {
+		// Values with no alphanumeric character are trimmed down to
+		// the empty string rather than panicking.
+		in:   "--",
+		want: "",
+	}, {
+		in:   "...",
+		want: "",
+	}, {
+		in:   "!!!",
+		want: "",
 	}} {
 		t.Run(c.in, func(t *testing.T) {
 			got := pkgnames.SimpleNameGenerator.RestrictLength(c.in)

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1816,7 +1816,11 @@ func propagatePipelineNameLabelToPipelineRun(pr *v1.PipelineRun) error {
 		// Use sanitized GenerateName for anonymous pipelines to reduce cardinality while
 		// still allowing categorization
 		if pr.GenerateName != "" {
-			pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = names.SimpleNameGenerator.RestrictLength(pr.GenerateName)
+			pipelineName := names.SimpleNameGenerator.RestrictLength(pr.GenerateName)
+			if pipelineName == "" {
+				pipelineName = pr.Name
+			}
+			pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pipelineName
 		} else {
 			pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pr.Name
 		}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -19143,6 +19143,19 @@ func TestPropagatePipelineNameLabelToPipelineRun_AnonymousPipeline(t *testing.T)
 			wantLabel: "my-pipeline",
 		},
 		{
+			name: "pipelineSpec with all-non-alphanumeric generateName does not panic",
+			pr: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "my-valid-plr",
+					GenerateName: "--",
+				},
+				Spec: v1.PipelineRunSpec{
+					PipelineSpec: &v1.PipelineSpec{},
+				},
+			},
+			wantLabel: "",
+		},
+		{
 			name: "existing pipeline label is preserved and not overwritten",
 			pr: &v1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -19143,7 +19143,7 @@ func TestPropagatePipelineNameLabelToPipelineRun_AnonymousPipeline(t *testing.T)
 			wantLabel: "my-pipeline",
 		},
 		{
-			name: "pipelineSpec with all-non-alphanumeric generateName does not panic",
+			name: "pipelineSpec with all-non-alphanumeric generateName uses pipelinerun name",
 			pr: &v1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:         "my-valid-plr",
@@ -19153,7 +19153,7 @@ func TestPropagatePipelineNameLabelToPipelineRun_AnonymousPipeline(t *testing.T)
 					PipelineSpec: &v1.PipelineSpec{},
 				},
 			},
-			wantLabel: "",
+			wantLabel: "my-valid-plr",
 		},
 		{
 			name: "existing pipeline label is preserved and not overwritten",


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`names.SimpleNameGenerator.RestrictLength` trims trailing non-alphanumeric
characters repeatedly, but it does not guard against the base becoming empty.
When the input has no alphanumeric character at all (for example `--`, `...`,
or `!!!`), the trimming strips it down to `""` and the next iteration evaluates
`base[len("")-1:]`, i.e. `base[-1:]`, panicking with
`slice bounds out of range [-1:]`.

This is reachable from the PipelineRun reconciler.
`propagatePipelineNameLabelToPipelineRun` passes the raw, user-controlled
`pr.GenerateName` to `RestrictLength` when an anonymous `PipelineSpec` is used
(`pkg/reconciler/pipelinerun/pipelinerun.go`). A PipelineRun that sets both
`Name` and `GenerateName: "--"` is accepted by the apiserver (name generation
is skipped because `Name` is already present, so the generated-name validation
that would reject `--` never runs). The object is therefore stored and
reconciled, and the panic takes down the PipelineRun controller goroutine.

This adds a `len(base) > 0` guard to the trimming condition so an all-non-alphanumeric
input returns `""` instead of panicking. The existing trim semantics are
unchanged (`RestrictLength` already returned `""` for inputs like `-`, and the
reconciler already tolerates an empty label value). The change touches only the
leaf utility in `pkg/names`.

Tests:
- `pkg/names/generate_test.go`: extend `TestRestrictLength` with all-symbol
  cases (`--`, `...`, `!!!`) that expect `""`.
- `pkg/reconciler/pipelinerun/pipelinerun_test.go`: add a
  `TestPropagatePipelineNameLabelToPipelineRun_AnonymousPipeline` case with
  `Name` set, `GenerateName: "--"`, and an anonymous `PipelineSpec`, asserting
  the reconciler helper returns an empty label instead of panicking.

Both tests fail before the fix (panic `slice bounds out of range [-1:]`, the
reconciler one failing through the real
`pipelinerun.go -> pkg/names/generate.go` call chain) and pass after it.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed a panic in the PipelineRun controller when a PipelineRun using an embedded (anonymous) pipeline spec sets a `generateName` that contains no alphanumeric characters (for example `--`). Such names no longer crash the reconciler.
```
