### PR TITLE
Add configuration for custom git resolver backoff

### DIFF
--- a/config/resolvers/git-resolver-config.yaml
+++ b/config/resolvers/git-resolver-config.yaml
@@ -46,3 +46,10 @@ data:
   # "never"  - Never cache resolved resources
   # "auto"   - Only cache when revision is a commit hash
   # default-cache-mode: "auto"
+  # Optional: Backoff configuration for retrying failed git resolution requests.
+  # These settings control the exponential backoff behavior when transient errors occur.
+  # backoff-duration: "2s"
+  # backoff-factor: "2.0"
+  # backoff-jitter: "0.1"
+  # backoff-steps: "2"  # total number of resolution attempts (must be >= 1)
+  # backoff-cap: "10s"

--- a/docs/git-resolver.md
+++ b/docs/git-resolver.md
@@ -55,6 +55,11 @@ for the name, namespace and defaults that the resolver ships with.
 | `api-token-secret-key`       | The key within the token secret containing the actual secret. Required if using the authenticated API with `org` and `repo`.                                  | `oauth`, `token`                                                 |
 | `api-token-secret-namespace` | The namespace containing the token secret, if not `default`.                                                                                                  | `other-namespace`                                                |
 | `default-org`                | The default organization to look for repositories under when using the authenticated API, if not specified in the resolver parameters. Optional.              | `tektoncd`, `kubernetes`                                         |
+| `backoff-duration`           | The initial duration for a backoff when a resolution request fails. Default: `2s`.                                                                            | `500ms`, `2s`                                                    |
+| `backoff-factor`             | The factor by which the sleep duration increases every step. Default: `2.0`.                                                                                  | `2.5`, `4.0`                                                     |
+| `backoff-jitter`             | A random amount of additional sleep between 0 and duration * jitter. Default: `0.1`.                                                                          | `0.1`, `0.5`                                                     |
+| `backoff-steps`              | The total number of resolution attempts. Set to `1` to disable retries. Default: `2`.                                                                         | `3`, `7`                                                         |
+| `backoff-cap`                | The maximum backoff duration. If reached, remaining steps are zeroed. Default: `10s`.                                                                         | `10s`, `20s`                                                     |
 
 ### Caching Options
 

--- a/pkg/remoteresolution/resolver/git/resolver.go
+++ b/pkg/remoteresolution/resolver/git/resolver.go
@@ -190,9 +190,10 @@ func (r *Resolver) resolveViaGit(ctx context.Context, params map[string]string) 
 		Params:     params,
 	}
 
-	if params[git.UrlParam] != "" {
-		return g.ResolveGitClone(ctx)
-	}
-
-	return g.ResolveAPIGit(ctx, r.clientFunc)
+	return git.ResolveWithRetry(ctx, func() (resolutionframework.ResolvedResource, error) {
+		if params[git.UrlParam] != "" {
+			return g.ResolveGitClone(ctx)
+		}
+		return g.ResolveAPIGit(ctx, r.clientFunc)
+	})
 }

--- a/pkg/resolution/resolver/git/config.go
+++ b/pkg/resolution/resolver/git/config.go
@@ -20,9 +20,13 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/logging"
 )
 
 const (
@@ -51,6 +55,28 @@ const (
 	APISecretKeyKey = "api-token-secret-key"
 	// APISecretNamespaceKey is the config map key for the token secret's namespace
 	APISecretNamespaceKey = "api-token-secret-namespace"
+
+	// ConfigBackoffDuration is the configuration field name for controlling
+	// the initial duration of a backoff when a git resolution fails
+	ConfigBackoffDuration  = "backoff-duration"
+	DefaultBackoffDuration = 2 * time.Second
+	// ConfigBackoffFactor is the configuration field name for controlling
+	// the factor by which successive backoffs will increase when a git
+	// resolution fails
+	ConfigBackoffFactor  = "backoff-factor"
+	DefaultBackoffFactor = 2.0
+	// ConfigBackoffJitter is the configuration field name for controlling
+	// the randomness applied to backoff durations when a git resolution fails
+	ConfigBackoffJitter  = "backoff-jitter"
+	DefaultBackoffJitter = 0.1
+	// ConfigBackoffSteps is the configuration field name for controlling
+	// the total number of resolution attempts when a git resolution fails
+	ConfigBackoffSteps  = "backoff-steps"
+	DefaultBackoffSteps = 2
+	// ConfigBackoffCap is the configuration field name for controlling
+	// the maximum duration to try when backing off
+	ConfigBackoffCap  = "backoff-cap"
+	DefaultBackoffCap = 10 * time.Second
 )
 
 type GitResolverConfig map[string]ScmConfig
@@ -66,6 +92,81 @@ type ScmConfig struct {
 	APISecretName      string `json:"api-token-secret-name"`
 	APISecretKey       string `json:"api-token-secret-key"`
 	APISecretNamespace string `json:"api-token-secret-namespace"`
+}
+
+// GetGitResolverBackoff returns a wait.Backoff to be used when retrying
+// git resolution requests. This can be configured with the backoff-duration,
+// backoff-factor, backoff-jitter, backoff-steps, and backoff-cap fields in
+// the git-resolver-config ConfigMap. Invalid values are logged as warnings
+// and replaced with their defaults so that retry behavior is preserved.
+func GetGitResolverBackoff(ctx context.Context) wait.Backoff {
+	logger := logging.FromContext(ctx)
+	conf := framework.GetResolverConfigFromContext(ctx)
+
+	backoff := wait.Backoff{
+		Duration: DefaultBackoffDuration,
+		Factor:   DefaultBackoffFactor,
+		Jitter:   DefaultBackoffJitter,
+		Steps:    DefaultBackoffSteps,
+		Cap:      DefaultBackoffCap,
+	}
+	if v, ok := conf[ConfigBackoffDuration]; ok {
+		duration, err := time.ParseDuration(v)
+		switch {
+		case err != nil:
+			logger.Warnf("invalid %s value %q, using default %v: %v", ConfigBackoffDuration, v, DefaultBackoffDuration, err)
+		case duration < 0:
+			logger.Warnf("invalid %s value %q: must not be negative, using default %v", ConfigBackoffDuration, v, DefaultBackoffDuration)
+		default:
+			backoff.Duration = duration
+		}
+	}
+	if v, ok := conf[ConfigBackoffFactor]; ok {
+		factor, err := strconv.ParseFloat(v, 64)
+		switch {
+		case err != nil:
+			logger.Warnf("invalid %s value %q, using default %v: %v", ConfigBackoffFactor, v, DefaultBackoffFactor, err)
+		case factor < 0:
+			logger.Warnf("invalid %s value %q: must not be negative, using default %v", ConfigBackoffFactor, v, DefaultBackoffFactor)
+		default:
+			backoff.Factor = factor
+		}
+	}
+	if v, ok := conf[ConfigBackoffJitter]; ok {
+		jitter, err := strconv.ParseFloat(v, 64)
+		switch {
+		case err != nil:
+			logger.Warnf("invalid %s value %q, using default %v: %v", ConfigBackoffJitter, v, DefaultBackoffJitter, err)
+		case jitter < 0:
+			logger.Warnf("invalid %s value %q: must not be negative, using default %v", ConfigBackoffJitter, v, DefaultBackoffJitter)
+		default:
+			backoff.Jitter = jitter
+		}
+	}
+	if v, ok := conf[ConfigBackoffSteps]; ok {
+		steps, err := strconv.Atoi(v)
+		switch {
+		case err != nil:
+			logger.Warnf("invalid %s value %q, using default %v: %v", ConfigBackoffSteps, v, DefaultBackoffSteps, err)
+		case steps < 1:
+			logger.Warnf("invalid %s value %q: must be at least 1, using default %v", ConfigBackoffSteps, v, DefaultBackoffSteps)
+		default:
+			backoff.Steps = steps
+		}
+	}
+	if v, ok := conf[ConfigBackoffCap]; ok {
+		cap, err := time.ParseDuration(v)
+		switch {
+		case err != nil:
+			logger.Warnf("invalid %s value %q, using default %v: %v", ConfigBackoffCap, v, DefaultBackoffCap, err)
+		case cap < 0:
+			logger.Warnf("invalid %s value %q: must not be negative, using default %v", ConfigBackoffCap, v, DefaultBackoffCap)
+		default:
+			backoff.Cap = cap
+		}
+	}
+
+	return backoff
 }
 
 func GetGitResolverConfig(ctx context.Context) (GitResolverConfig, error) {

--- a/pkg/resolution/resolver/git/config_test.go
+++ b/pkg/resolution/resolver/git/config_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package git
 
 import (
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	resolutionframework "github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
@@ -140,6 +142,133 @@ func TestGetGitResolverConfig(t *testing.T) {
 			}
 			if d := cmp.Diff(tc.expectedConfig, gitResolverConfig); d != "" {
 				t.Errorf("expected config: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestGetGitResolverBackoffDefaults(t *testing.T) {
+	ctx := resolutionframework.InjectResolverConfigToContext(t.Context(), map[string]string{})
+	backoff := GetGitResolverBackoff(ctx)
+	if backoff.Duration != DefaultBackoffDuration {
+		t.Fatalf("expected default duration %v, got %v", DefaultBackoffDuration, backoff.Duration)
+	}
+	if backoff.Factor != DefaultBackoffFactor {
+		t.Fatalf("expected default factor %v, got %v", DefaultBackoffFactor, backoff.Factor)
+	}
+	if backoff.Jitter != DefaultBackoffJitter {
+		t.Fatalf("expected default jitter %v, got %v", DefaultBackoffJitter, backoff.Jitter)
+	}
+	if backoff.Steps != DefaultBackoffSteps {
+		t.Fatalf("expected default steps %v, got %v", DefaultBackoffSteps, backoff.Steps)
+	}
+	if backoff.Cap != DefaultBackoffCap {
+		t.Fatalf("expected default cap %v, got %v", DefaultBackoffCap, backoff.Cap)
+	}
+}
+
+func TestGetGitResolverBackoffCustom(t *testing.T) {
+	configBackoffDuration := 7 * time.Second
+	configBackoffFactor := 7.0
+	configBackoffJitter := 0.5
+	configBackoffSteps := 3
+	configBackoffCap := 20 * time.Second
+	config := map[string]string{
+		ConfigBackoffDuration: configBackoffDuration.String(),
+		ConfigBackoffFactor:   strconv.FormatFloat(configBackoffFactor, 'f', -1, 64),
+		ConfigBackoffJitter:   strconv.FormatFloat(configBackoffJitter, 'f', -1, 64),
+		ConfigBackoffSteps:    strconv.Itoa(configBackoffSteps),
+		ConfigBackoffCap:      configBackoffCap.String(),
+	}
+	ctx := resolutionframework.InjectResolverConfigToContext(t.Context(), config)
+	backoff := GetGitResolverBackoff(ctx)
+	if backoff.Duration != configBackoffDuration {
+		t.Fatalf("expected duration %v, got %v", configBackoffDuration, backoff.Duration)
+	}
+	if backoff.Factor != configBackoffFactor {
+		t.Fatalf("expected factor %v, got %v", configBackoffFactor, backoff.Factor)
+	}
+	if backoff.Jitter != configBackoffJitter {
+		t.Fatalf("expected jitter %v, got %v", configBackoffJitter, backoff.Jitter)
+	}
+	if backoff.Steps != configBackoffSteps {
+		t.Fatalf("expected steps %v, got %v", configBackoffSteps, backoff.Steps)
+	}
+	if backoff.Cap != configBackoffCap {
+		t.Fatalf("expected cap %v, got %v", configBackoffCap, backoff.Cap)
+	}
+}
+
+func TestGetGitResolverBackoffInvalidValuesFallBackToDefaults(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]string
+	}{
+		{
+			name: "unparseable values",
+			config: map[string]string{
+				ConfigBackoffDuration: "not-a-duration",
+				ConfigBackoffFactor:   "not-a-float",
+				ConfigBackoffJitter:   "not-a-float",
+				ConfigBackoffSteps:    "not-an-int",
+				ConfigBackoffCap:      "not-a-duration",
+			},
+		},
+		{
+			name: "negative duration",
+			config: map[string]string{
+				ConfigBackoffDuration: "-1s",
+			},
+		},
+		{
+			name: "negative factor",
+			config: map[string]string{
+				ConfigBackoffFactor: "-1.0",
+			},
+		},
+		{
+			name: "negative jitter",
+			config: map[string]string{
+				ConfigBackoffJitter: "-0.5",
+			},
+		},
+		{
+			name: "zero steps",
+			config: map[string]string{
+				ConfigBackoffSteps: "0",
+			},
+		},
+		{
+			name: "negative steps",
+			config: map[string]string{
+				ConfigBackoffSteps: "-1",
+			},
+		},
+		{
+			name: "negative cap",
+			config: map[string]string{
+				ConfigBackoffCap: "-5s",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := resolutionframework.InjectResolverConfigToContext(t.Context(), tc.config)
+			backoff := GetGitResolverBackoff(ctx)
+			if backoff.Duration != DefaultBackoffDuration {
+				t.Errorf("expected default duration %v, got %v", DefaultBackoffDuration, backoff.Duration)
+			}
+			if backoff.Factor != DefaultBackoffFactor {
+				t.Errorf("expected default factor %v, got %v", DefaultBackoffFactor, backoff.Factor)
+			}
+			if backoff.Jitter != DefaultBackoffJitter {
+				t.Errorf("expected default jitter %v, got %v", DefaultBackoffJitter, backoff.Jitter)
+			}
+			if backoff.Steps != DefaultBackoffSteps {
+				t.Errorf("expected default steps %v, got %v", DefaultBackoffSteps, backoff.Steps)
+			}
+			if backoff.Cap != DefaultBackoffCap {
+				t.Errorf("expected default cap %v, got %v", DefaultBackoffCap, backoff.Cap)
 			}
 		})
 	}

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -36,6 +36,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/cache"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
@@ -131,11 +132,37 @@ func (r *Resolver) Resolve(ctx context.Context, origParams []pipelinev1.Param) (
 		KubeClient: r.kubeClient,
 	}
 
-	if params[UrlParam] != "" {
-		return g.ResolveGitClone(ctx)
-	}
+	return ResolveWithRetry(ctx, func() (framework.ResolvedResource, error) {
+		if params[UrlParam] != "" {
+			return g.ResolveGitClone(ctx)
+		}
+		return g.ResolveAPIGit(ctx, r.clientFunc)
+	})
+}
 
-	return g.ResolveAPIGit(ctx, r.clientFunc)
+// ResolveWithRetry wraps a resolution function with exponential backoff retry
+// logic. The backoff parameters are read from the git-resolver-config ConfigMap.
+// Invalid configuration values are logged and replaced with defaults so that
+// retry behavior is always preserved.
+func ResolveWithRetry(ctx context.Context, fn func() (framework.ResolvedResource, error)) (framework.ResolvedResource, error) {
+	backoff := GetGitResolverBackoff(ctx)
+
+	var result framework.ResolvedResource
+	var lastErr error
+	retryErr := wait.ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
+		result, lastErr = fn()
+		return lastErr == nil, nil
+	})
+	if retryErr != nil {
+		if errors.Is(retryErr, context.Canceled) || errors.Is(retryErr, context.DeadlineExceeded) {
+			return nil, retryErr
+		}
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, retryErr
+	}
+	return result, nil
 }
 
 func ValidateParams(ctx context.Context, params []pipelinev1.Param) error {

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -1228,3 +1228,134 @@ func TestGetScmConfigForParamConfigKey(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveWithRetrySucceedsAfterTransientFailure(t *testing.T) {
+	config := map[string]string{
+		ConfigBackoffDuration: "1ms",
+		ConfigBackoffFactor:   "1.0",
+		ConfigBackoffJitter:   "0",
+		ConfigBackoffSteps:    "3",
+		ConfigBackoffCap:      "10ms",
+	}
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
+
+	callCount := 0
+	expected := &resolvedGitResource{
+		Content:  []byte("hello"),
+		Revision: "abc123",
+	}
+
+	result, err := ResolveWithRetry(ctx, func() (framework.ResolvedResource, error) {
+		callCount++
+		if callCount < 3 {
+			return nil, errors.New("transient error")
+		}
+		return expected, nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got error: %v", err)
+	}
+	if callCount != 3 {
+		t.Fatalf("expected 3 attempts, got %d", callCount)
+	}
+	if string(result.Data()) != string(expected.Data()) {
+		t.Fatalf("expected data %q, got %q", expected.Data(), result.Data())
+	}
+}
+
+func TestResolveWithRetryExhaustsRetries(t *testing.T) {
+	config := map[string]string{
+		ConfigBackoffDuration: "1ms",
+		ConfigBackoffFactor:   "1.0",
+		ConfigBackoffJitter:   "0",
+		ConfigBackoffSteps:    "2",
+		ConfigBackoffCap:      "10ms",
+	}
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
+
+	callCount := 0
+	_, err := ResolveWithRetry(ctx, func() (framework.ResolvedResource, error) {
+		callCount++
+		return nil, errors.New("persistent error")
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 attempts (matching steps), got %d", callCount)
+	}
+}
+
+func TestResolveWithRetryContextCancelled(t *testing.T) {
+	config := map[string]string{
+		ConfigBackoffSteps: "3",
+	}
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	_, err := ResolveWithRetry(ctx, func() (framework.ResolvedResource, error) {
+		t.Fatal("fn should not be called with cancelled context")
+		return nil, errors.New("unreachable")
+	})
+	if err == nil {
+		t.Fatal("expected error with cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+func TestResolveWithRetryContextCancelledMidBackoff(t *testing.T) {
+	config := map[string]string{
+		ConfigBackoffDuration: "50ms",
+		ConfigBackoffFactor:   "1.0",
+		ConfigBackoffJitter:   "0",
+		ConfigBackoffSteps:    "5",
+		ConfigBackoffCap:      "1s",
+	}
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
+	ctx, cancel := context.WithCancel(ctx)
+
+	callCount := 0
+	_, err := ResolveWithRetry(ctx, func() (framework.ResolvedResource, error) {
+		callCount++
+		if callCount == 1 {
+			cancel()
+		}
+		return nil, errors.New("transient error")
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+func TestResolveWithRetrySucceedsFirstAttempt(t *testing.T) {
+	config := map[string]string{
+		ConfigBackoffSteps: "3",
+	}
+	ctx := framework.InjectResolverConfigToContext(t.Context(), config)
+
+	callCount := 0
+	expected := &resolvedGitResource{
+		Content:  []byte("hello"),
+		Revision: "abc123",
+	}
+
+	result, err := ResolveWithRetry(ctx, func() (framework.ResolvedResource, error) {
+		callCount++
+		return expected, nil
+	})
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected 1 attempt, got %d", callCount)
+	}
+	if string(result.Data()) != string(expected.Data()) {
+		t.Fatalf("expected data %q, got %q", expected.Data(), result.Data())
+	}
+}


### PR DESCRIPTION
# Changes

The git resolver is susceptible to flakes in network communication, both for git clone operations and SCM API calls. In order to increase reliability, this PR adds configurable exponential backoff retries to mitigate transient issues, following the same pattern as the bundle resolver backoff added in #8574.

The backoff parameters (`backoff-duration`, `backoff-factor`, `backoff-jitter`, `backoff-steps`, `backoff-cap`) can be configured via the `git-resolver-config` ConfigMap. Both the deprecated and active (remoteresolution) resolver paths benefit from retry logic through a shared `ResolveWithRetry` helper.

Partially addresses #8571

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has Docs if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has Tests included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some [examples of good release notes](https://github.com/tektoncd/community/blob/main/standards.md#release-notes).

# Release Notes

```release-note
Enables the configuration of backoffs for git resolver requests.
```