### PR TITLE
Add PR template reminder to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ If you're an agent working in this repo, start here. This file is meant to orien
 ## Before changing code
 
 - Read `CONTRIBUTING.md`, `DEVELOPMENT.md`, `test/README.md`, and the docs for the area you are touching.
+- When opening PRs, follow the repo's PR template in `.github/pull_request_template.md`.
 - For API changes, read `api_compatibility_policy.md` first and expect codegen/OpenAPI updates.
 - For reconciler changes, add or update package tests with fake clients before reaching for e2e tests.
 - For e2e changes, follow the annotations and categories in `test/README.md`.


### PR DESCRIPTION
# Changes

Add a note in the "Before changing code" section of `AGENTS.md` pointing agents at `.github/pull_request_template.md`, so PRs opened by AI assistants follow the repo's standard format.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

Made with [Cursor](https://cursor.com)