### PR TITLE
Prevent matrix combination count int overflow

### DIFF
--- a/pkg/apis/pipeline/v1/matrix_types.go
+++ b/pkg/apis/pipeline/v1/matrix_types.go
@@ -222,7 +222,11 @@ func (m *Matrix) CountCombinations() int {
 	count := m.countGeneratedCombinationsFromParams()
 
 	// Add any additional Combinations generated from Matrix Include Parameters
-	count += m.countNewCombinationsFromInclude()
+	includeCount := m.countNewCombinationsFromInclude()
+	if count > math.MaxInt-includeCount {
+		return math.MaxInt
+	}
+	count += includeCount
 
 	return count
 }
@@ -263,6 +267,9 @@ func (m *Matrix) countNewCombinationsFromInclude() int {
 			if val, exist := matrixParamMap[param.Name]; exist {
 				// If the Matrix Include param values does not exist, a new Combination will be generated
 				if !slices.Contains(val, param.Value.StringVal) {
+					if count == math.MaxInt {
+						return math.MaxInt
+					}
 					count++
 				} else {
 					break

--- a/pkg/apis/pipeline/v1/matrix_types.go
+++ b/pkg/apis/pipeline/v1/matrix_types.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math"
 	"sort"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -234,8 +235,13 @@ func (m *Matrix) countGeneratedCombinationsFromParams() int {
 	}
 	count := 1
 	for _, param := range m.Params {
-		if len(param.Value.ArrayVal) > 0 {
-			count *= len(param.Value.ArrayVal)
+		if l := len(param.Value.ArrayVal); l > 0 {
+			// Cap at math.MaxInt on overflow so validateCombinationsCount
+			// still rejects the matrix instead of accepting a wrapped count.
+			if count > math.MaxInt/l {
+				return math.MaxInt
+			}
+			count *= l
 		}
 	}
 	return count

--- a/pkg/apis/pipeline/v1/matrix_types_test.go
+++ b/pkg/apis/pipeline/v1/matrix_types_test.go
@@ -931,6 +931,16 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 		name:   "combinations count overflows int and is capped at MaxInt",
 		matrix: matrixWithArrayParams(64, 2),
 		want:   math.MaxInt,
+	}, {
+		name: "combinations count with include overflows int and is capped at MaxInt",
+		matrix: func() *v1.Matrix {
+			matrix := matrixWithArrayParams(64, 2)
+			matrix.Include = v1.IncludeParamsList{{Params: v1.Params{{
+				Name: "p0", Value: v1.ParamValue{Type: v1.ParamTypeString, StringVal: "new-value"},
+			}}}}
+			return matrix
+		}(),
+		want: math.MaxInt,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1/matrix_types_test.go
+++ b/pkg/apis/pipeline/v1/matrix_types_test.go
@@ -14,6 +14,8 @@ limitations under the License.
 package v1_test
 
 import (
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -925,6 +927,10 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 				Name: "version", Value: v1.ParamValue{StringVal: "$(tasks.platforms.results.str[*])"}},
 			}},
 		want: 3,
+	}, {
+		name:   "combinations count overflows int and is capped at MaxInt",
+		matrix: matrixWithArrayParams(64, 2),
+		want:   math.MaxInt,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -933,4 +939,22 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 			}
 		})
 	}
+}
+
+// matrixWithArrayParams returns a Matrix with numParams array params, each
+// holding arrayLen distinct values. It is used to build matrices whose true
+// combination count (arrayLen^numParams) overflows a 64-bit int.
+func matrixWithArrayParams(numParams, arrayLen int) *v1.Matrix {
+	params := make(v1.Params, numParams)
+	for i := range params {
+		vals := make([]string, arrayLen)
+		for j := range vals {
+			vals[j] = fmt.Sprintf("v%d-%d", i, j)
+		}
+		params[i] = v1.Param{
+			Name:  fmt.Sprintf("p%d", i),
+			Value: v1.ParamValue{Type: v1.ParamTypeArray, ArrayVal: vals},
+		}
+	}
+	return &v1.Matrix{Params: params}
 }

--- a/pkg/apis/pipeline/v1beta1/matrix_types.go
+++ b/pkg/apis/pipeline/v1beta1/matrix_types.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math"
 	"sort"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -234,7 +235,13 @@ func (m *Matrix) countGeneratedCombinationsFromParams() int {
 	}
 	count := 1
 	for _, param := range m.Params {
-		count *= len(param.Value.ArrayVal)
+		l := len(param.Value.ArrayVal)
+		// Cap at math.MaxInt on overflow so validateCombinationsCount still
+		// rejects the matrix instead of accepting a wrapped count.
+		if l > 0 && count > math.MaxInt/l {
+			return math.MaxInt
+		}
+		count *= l
 	}
 	return count
 }

--- a/pkg/apis/pipeline/v1beta1/matrix_types.go
+++ b/pkg/apis/pipeline/v1beta1/matrix_types.go
@@ -222,7 +222,11 @@ func (m *Matrix) CountCombinations() int {
 	count := m.countGeneratedCombinationsFromParams()
 
 	// Add any additional Combinations generated from Matrix Include Parameters
-	count += m.countNewCombinationsFromInclude()
+	includeCount := m.countNewCombinationsFromInclude()
+	if count > math.MaxInt-includeCount {
+		return math.MaxInt
+	}
+	count += includeCount
 
 	return count
 }
@@ -262,6 +266,9 @@ func (m *Matrix) countNewCombinationsFromInclude() int {
 			if val, exist := matrixParamMap[param.Name]; exist {
 				// If the Matrix Include param values does not exist, a new Combination will be generated
 				if !slices.Contains(val, param.Value.StringVal) {
+					if count == math.MaxInt {
+						return math.MaxInt
+					}
 					count++
 				} else {
 					break

--- a/pkg/apis/pipeline/v1beta1/matrix_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/matrix_types_test.go
@@ -921,6 +921,16 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 		name:   "combinations count overflows int and is capped at MaxInt",
 		matrix: matrixWithArrayParams(64, 2),
 		want:   math.MaxInt,
+	}, {
+		name: "combinations count with include overflows int and is capped at MaxInt",
+		matrix: func() *v1beta1.Matrix {
+			matrix := matrixWithArrayParams(64, 2)
+			matrix.Include = v1beta1.IncludeParamsList{{Params: v1beta1.Params{{
+				Name: "p0", Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeString, StringVal: "new-value"},
+			}}}}
+			return matrix
+		}(),
+		want: math.MaxInt,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/matrix_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/matrix_types_test.go
@@ -14,6 +14,8 @@ limitations under the License.
 package v1beta1_test
 
 import (
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -915,6 +917,10 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 				}},
 			}},
 		want: 7,
+	}, {
+		name:   "combinations count overflows int and is capped at MaxInt",
+		matrix: matrixWithArrayParams(64, 2),
+		want:   math.MaxInt,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -923,4 +929,22 @@ func TestPipelineTask_CountCombinations(t *testing.T) {
 			}
 		})
 	}
+}
+
+// matrixWithArrayParams returns a Matrix with numParams array params, each
+// holding arrayLen distinct values. It is used to build matrices whose true
+// combination count (arrayLen^numParams) overflows a 64-bit int.
+func matrixWithArrayParams(numParams, arrayLen int) *v1beta1.Matrix {
+	params := make(v1beta1.Params, numParams)
+	for i := range params {
+		vals := make([]string, arrayLen)
+		for j := range vals {
+			vals[j] = fmt.Sprintf("v%d-%d", i, j)
+		}
+		params[i] = v1beta1.Param{
+			Name:  fmt.Sprintf("p%d", i),
+			Value: v1beta1.ParamValue{Type: v1beta1.ParamTypeArray, ArrayVal: vals},
+		}
+	}
+	return &v1beta1.Matrix{Params: params}
 }


### PR DESCRIPTION
# Changes

Matrix combination counting could overflow an `int` while multiplying matrix
parameter lengths or while adding combinations generated by `include`. A wrapped
count could bypass `DefaultMaxMatrixCombinationsCount` validation even though
fan-out would still attempt to materialize the full matrix.

Cap both multiplication and addition at `math.MaxInt`, ensuring an overflowing
matrix remains above the configured limit and is rejected. Apply the fix to the
duplicated `v1` and `v1beta1` implementations.

Add regression cases for overflow from matrix parameters and from adding a new
include combination in both API versions.

/kind bug

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label
- [x] Release notes block below has been updated with any user facing changes
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed an integer overflow in matrix combination counting that could let a very
large matrix bypass the max-matrix-combinations validation guard.
```
