### PR TITLE
ci(.github/workflows): enable Codecov coverage reporting

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -26,6 +26,8 @@ jobs:
     name: Go coverage
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
+      actions: read
       pull-requests: write
 
     steps:
@@ -48,21 +50,54 @@ jobs:
       - name: Generate coverage
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/pipeline
         run: |
-          go test -cover -coverprofile=coverage.txt ./... || true
+          go test -coverprofile=coverage.out -covermode=atomic ./... || true
           echo "Generated coverage profile"
 
       - name: Archive coverage results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: code-coverage
-          path: ${{ github.workspace }}/src/github.com/tektoncd/pipeline/coverage.txt
+          path: ${{ github.workspace }}/src/github.com/tektoncd/pipeline/coverage.out
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
         uses: fgrosse/go-coverage-report@cbeb2ab2e32591d690337146ba02a911cc566f3f # v1.3.0
         continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
-        env:
-          GITHUB_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
         with:
           coverage-artifact-name: "code-coverage"
-          coverage-file-name: "coverage.txt"
+          coverage-file-name: "coverage.out"
+
+  codecov-upload:
+    name: Upload coverage to Codecov
+    if: github.event_name != 'pull_request'
+    needs: go-coverage
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: code-coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6.0.2
+        continue-on-error: true
+        with:
+          files: coverage.out
+          flags: unit-tests
+          use_oidc: true
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default: false
+
 ignore:
 - "pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go"
 - "pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go"
+- "**/fake/**"
+- "hack/**"
+- "test/**"
+- "pkg/client/**"
+- "vendor/**"


### PR DESCRIPTION
Edit codecov.yml with coverage thresholds and an ignore list for non-source directories, following the same change made in tekton pruner. Upload coverage to Codecov via OIDC alongside the existing artifact upload and PR-comment step.

Assisted-by: Claude Sonnet 5 (via Claude Code)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

/kind misc

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
