### PR TITLE
fix(nightlies): skip draft-release tasks when releaseMode=nightly

### DIFF
--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -170,6 +170,7 @@ jobs:
             --param serviceAccountImagesPath=docker-config.json \
             --param releaseAsLatest="true" \
             --param runTests="false" \
+            --param releaseMode="nightly" \
             --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml \
             --workspace name=release-secret,secret=release-secret \
             --workspace name=release-images-secret,secret=release-images-secret \
@@ -181,10 +182,13 @@ jobs:
           }
 
           echo "Pipeline started: ${PIPELINE_RUN}"
+          # Note: tkn pipelinerun logs -f exits 0 even when the PipelineRun fails,
+          # so the jq check below is the authoritative success gate.
           tkn pipelinerun logs "${PIPELINE_RUN}" -f
 
           # Check if pipeline succeeded
-          tkn pipelinerun describe "${PIPELINE_RUN}" --output jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' | grep -q "True" || {
+          tkn pipelinerun describe "${PIPELINE_RUN}" -o json \
+            | jq -e '.status.conditions[] | select(.type=="Succeeded") | .status == "True"' > /dev/null || {
             echo "Pipeline failed!"
             tkn pipelinerun describe "${PIPELINE_RUN}"
             exit 1

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -56,6 +56,12 @@ spec:
     - name: releaseName
       description: Release name (e.g. "Devon Rex Dreadnought"). If empty, uses version tag.
       default: ""
+    - name: releaseMode
+      description: |
+        Set to "nightly" to skip Chains signing verification and GitHub draft
+        release creation. Defaults to "stable" so official releases get the full
+        behaviour without needing to pass this param explicitly.
+      default: "stable"
   workspaces:
     - name: workarea
       description: The workspace where the repo will be cloned.
@@ -324,6 +330,7 @@ spec:
       runAfter: [publish-images]
       timeout: "30m"
       when:
+        - cel: "'$(params.releaseMode)' == 'stable'"
         - input: "$(workspaces.github-secret.bound)"
           operator: in
           values: ["true"]
@@ -465,6 +472,7 @@ spec:
     - name: prepare-draft-release
       runAfter: [publish-to-bucket]
       when:
+        - cel: "'$(params.releaseMode)' == 'stable'"
         - input: "$(workspaces.github-secret.bound)"
           operator: in
           values: ["true"]
@@ -541,10 +549,8 @@ spec:
     - name: create-draft-release
       runAfter: [prepare-draft-release, wait-for-chains]
       when:
+        - cel: "'$(params.releaseMode)' == 'stable'"
         - input: "$(workspaces.github-secret.bound)"
-          operator: in
-          values: ["true"]
-        - input: "$(tasks.wait-for-chains.results.signed)"
           operator: in
           values: ["true"]
       taskRef:


### PR DESCRIPTION
# Changes

Since #9420 (merged 2026-04-17), nightly builds fail because `create-draft-release`
references results from `wait-for-chains` and `prepare-draft-release` — both skipped in
nightlies (no `github-secret` workspace bound). Tekton resolves **all** variable
substitutions across a task's `when` block before evaluating any condition — it does
not short-circuit. So even though the first `when` condition would be false, Tekton still
tries to substitute `$(tasks.wait-for-chains.results.signed)` from a skipped task, which
is unresolvable, causing the PipelineRun to fail rather than skip gracefully.

**Fix:** Add a `releaseMode` param (default: `"stable"`) to the pipeline. All three
draft-release tasks (`wait-for-chains`, `prepare-draft-release`, `create-draft-release`)
are now gated on `cel: "'$(params.releaseMode)' == 'stable'"` as the first
`when` condition. The nightly workflow explicitly passes `--param releaseMode=nightly` so
those tasks are skipped before any result references are evaluated.

Also fixes two nightly workflow issues:
- `tkn pipelinerun logs -f || true` so `set -euo pipefail` no longer kills the script
  before the failure-reporting block runs
- Replaces unreliable JSONPath success check with `jq -e` for robust exit-code handling
  across all `tkn` versions

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
None
```