### PR TITLE
feat(tracing): add semantic span attributes to reconciler child spans

### DIFF
--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -76,7 +76,7 @@ func init() {
 func cancelCustomRun(ctx context.Context, runName string, namespace string, clientSet clientset.Interface) error {
 	ctx, span := tracerFromContext(ctx).Start(ctx, "cancelCustomRun")
 	defer span.End()
-	span.SetAttributes(attribute.String("customrun", runName), attribute.String("namespace", namespace))
+	span.SetAttributes(attribute.String("tekton.custom_run.name", runName), attribute.String("k8s.namespace.name", namespace))
 
 	_, err := clientSet.TektonV1beta1().CustomRuns(namespace).Patch(ctx, runName, types.JSONPatchType, cancelCustomRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
@@ -91,7 +91,7 @@ func cancelCustomRun(ctx context.Context, runName string, namespace string, clie
 func cancelTaskRun(ctx context.Context, taskRunName string, namespace string, clientSet clientset.Interface) error {
 	ctx, span := tracerFromContext(ctx).Start(ctx, "cancelTaskRun")
 	defer span.End()
-	span.SetAttributes(attribute.String("taskrun", taskRunName), attribute.String("namespace", namespace))
+	span.SetAttributes(attribute.String("tekton.task_run.name", taskRunName), attribute.String("k8s.namespace.name", namespace))
 
 	_, err := clientSet.TektonV1().TaskRuns(namespace).Patch(ctx, taskRunName, types.JSONPatchType, cancelTaskRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
@@ -112,8 +112,8 @@ func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.Pi
 	ctx, span := tracerFromContext(ctx).Start(ctx, "cancelPipelineRun")
 	defer span.End()
 	span.SetAttributes(
-		attribute.String("pipelinerun", pr.Name),
-		attribute.String("namespace", pr.Namespace),
+		attribute.String("tekton.pipeline_run.name", pr.Name),
+		attribute.String("k8s.namespace.name", pr.Namespace),
 	)
 
 	errs := cancelPipelineTaskRuns(ctx, logger, pr, clientSet)
@@ -213,8 +213,8 @@ func gracefullyCancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger,
 	ctx, span := tracerFromContext(ctx).Start(ctx, "gracefullyCancelPipelineRun")
 	defer span.End()
 	span.SetAttributes(
-		attribute.String("pipelinerun", pr.Name),
-		attribute.String("namespace", pr.Namespace),
+		attribute.String("tekton.pipeline_run.name", pr.Name),
+		attribute.String("k8s.namespace.name", pr.Namespace),
 	)
 
 	errs := cancelPipelineTaskRuns(ctx, logger, pr, clientSet)

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -189,7 +189,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1.PipelineRun) pkgr
 	defer span.End()
 
 	span.SetAttributes(
-		attribute.String("pipelinerun", pr.Name), attribute.String("namespace", pr.Namespace),
+		attribute.String("tekton.pipeline_run.name", pr.Name),
+		attribute.String("k8s.namespace.name", pr.Namespace),
 	)
 	if spanCtx := span.SpanContext(); spanCtx.IsValid() {
 		logger = logger.With(zap.String("traceID", spanCtx.TraceID().String()), zap.String("spanID", spanCtx.SpanID().String()))
@@ -395,6 +396,10 @@ func (c *Reconciler) resolvePipelineState(
 ) (resources.PipelineRunState, error) {
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "resolvePipelineState")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("tekton.pipeline_run.name", pr.Name),
+		attribute.Int("tekton.pipeline.task_count", len(pipelineTasks)),
+	)
 
 	// List VerificationPolicies once per reconcile for trusted resources (used by all pipeline tasks).
 	vp, err := c.verificationPolicyLister.VerificationPolicies(pr.Namespace).List(labels.Everything())
@@ -544,6 +549,10 @@ func (c *Reconciler) resolvePipelineState(
 func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipelineFunc rprp.GetPipeline) error {
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "reconcile")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("tekton.pipeline_run.name", pr.Name),
+		attribute.String("k8s.namespace.name", pr.Namespace),
+	)
 	logger := logging.FromContext(ctx)
 	pr.SetDefaults(ctx)
 
@@ -988,6 +997,9 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1.PipelineRun, pipelineRunFacts *resources.PipelineRunFacts) error {
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "runNextSchedulableTask")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("tekton.pipeline_run.name", pr.Name),
+	)
 
 	logger := logging.FromContext(ctx)
 	recorder := controller.GetEventRecorder(ctx)
@@ -1314,6 +1326,10 @@ func (c *Reconciler) detectPipelineRefCycle(pr *v1.PipelineRun, targetPipelineNa
 func (c *Reconciler) createTaskRuns(ctx context.Context, rpt *resources.ResolvedPipelineTask, pr *v1.PipelineRun, facts *resources.PipelineRunFacts) ([]*v1.TaskRun, error) {
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createTaskRuns")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("tekton.pipeline_run.name", pr.Name),
+		attribute.String("tekton.pipeline_task.name", rpt.PipelineTask.Name),
+	)
 
 	var matrixCombinations []v1.Params
 	if rpt.PipelineTask.IsMatrixed() {

--- a/pkg/reconciler/pipelinerun/timeout.go
+++ b/pkg/reconciler/pipelinerun/timeout.go
@@ -75,8 +75,8 @@ func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.P
 	ctx, span := tracerFromContext(ctx).Start(ctx, "timeoutPipelineRun")
 	defer span.End()
 	span.SetAttributes(
-		attribute.String("pipelinerun", pr.Name),
-		attribute.String("namespace", pr.Namespace),
+		attribute.String("tekton.pipeline_run.name", pr.Name),
+		attribute.String("k8s.namespace.name", pr.Namespace),
 	)
 
 	errs := timeoutPipelineTasks(ctx, logger, pr, clientSet)
@@ -105,7 +105,7 @@ func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1.P
 func timeoutCustomRun(ctx context.Context, customRunName string, namespace string, clientSet clientset.Interface) error {
 	ctx, span := tracerFromContext(ctx).Start(ctx, "timeoutCustomRun")
 	defer span.End()
-	span.SetAttributes(attribute.String("customrun", customRunName), attribute.String("namespace", namespace))
+	span.SetAttributes(attribute.String("tekton.custom_run.name", customRunName), attribute.String("k8s.namespace.name", namespace))
 
 	_, err := clientSet.TektonV1beta1().CustomRuns(namespace).Patch(ctx, customRunName, types.JSONPatchType, timeoutCustomRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {
@@ -118,7 +118,7 @@ func timeoutCustomRun(ctx context.Context, customRunName string, namespace strin
 func timeoutTaskRun(ctx context.Context, taskRunName string, namespace string, clientSet clientset.Interface) error {
 	ctx, span := tracerFromContext(ctx).Start(ctx, "timeoutTaskRun")
 	defer span.End()
-	span.SetAttributes(attribute.String("taskrun", taskRunName), attribute.String("namespace", namespace))
+	span.SetAttributes(attribute.String("tekton.task_run.name", taskRunName), attribute.String("k8s.namespace.name", namespace))
 
 	_, err := clientSet.TektonV1().TaskRuns(namespace).Patch(ctx, taskRunName, types.JSONPatchType, timeoutTaskRunPatchBytes, metav1.PatchOptions{}, "")
 	if errors.IsNotFound(err) {

--- a/pkg/reconciler/pipelinerun/tracing.go
+++ b/pkg/reconciler/pipelinerun/tracing.go
@@ -66,7 +66,10 @@ func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, pr *v
 	// Create a new root span since there was no parent spanContext provided through annotations
 	ctxWithTrace, span := tracerProvider.Tracer(TracerName).Start(ctx, "PipelineRun:Reconciler")
 	defer span.End()
-	span.SetAttributes(attribute.String("pipelinerun", pr.Name), attribute.String("namespace", pr.Namespace))
+	span.SetAttributes(
+		attribute.String("tekton.pipeline_run.name", pr.Name),
+		attribute.String("k8s.namespace.name", pr.Namespace),
+	)
 
 	pro.Inject(ctxWithTrace, propagation.MapCarrier(spanContext))
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -135,7 +135,10 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) pkgrecon
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "TaskRun:ReconcileKind")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("taskrun", tr.Name), attribute.String("namespace", tr.Namespace))
+	span.SetAttributes(
+		attribute.String("tekton.task_run.name", tr.Name),
+		attribute.String("k8s.namespace.name", tr.Namespace),
+	)
 	if spanCtx := span.SpanContext(); spanCtx.IsValid() {
 		logger = logger.With(zap.String("traceID", spanCtx.TraceID().String()), zap.String("spanID", spanCtx.SpanID().String()))
 		ctx = logging.WithLogger(ctx, logger)
@@ -414,6 +417,9 @@ func newNativeSidecarFromCluster(client kubernetes.Interface, log *zap.SugaredLo
 func (c *Reconciler) stopSidecars(ctx context.Context, tr *v1.TaskRun) error {
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "stopSidecars")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("tekton.task_run.name", tr.Name),
+	)
 	logger := logging.FromContext(ctx)
 	// do not continue without knowing the associated pod
 	if tr.Status.PodName == "" {
@@ -694,6 +700,10 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1.TaskRun) (*v1.TaskSpec,
 func (c *Reconciler) reconcile(ctx context.Context, tr *v1.TaskRun, rtr *resources.ResolvedTask) error {
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "reconcile")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("tekton.task_run.name", tr.Name),
+		attribute.String("k8s.namespace.name", tr.Namespace),
+	)
 
 	logger := logging.FromContext(ctx)
 	recorder := controller.GetEventRecorder(ctx)
@@ -914,6 +924,10 @@ func (c *Reconciler) handlePodCreationError(tr *v1.TaskRun, err error) error {
 func (c *Reconciler) failTaskRun(ctx context.Context, tr *v1.TaskRun, reason v1.TaskRunReason, message string) error {
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "failTaskRun")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("tekton.task_run.name", tr.Name),
+		attribute.String("tekton.task_run.reason", string(reason)),
+	)
 	logger := logging.FromContext(ctx)
 
 	logger.Warnf("stopping task run %q because of %q", tr.Name, reason)
@@ -1041,6 +1055,9 @@ func terminateStepsInPod(tr *v1.TaskRun, taskRunReason v1.TaskRunReason) {
 func (c *Reconciler) createPod(ctx context.Context, ts *v1.TaskSpec, tr *v1.TaskRun, rtr *resources.ResolvedTask, workspaceVolumes map[string]corev1.Volume) (_ *corev1.Pod, err error) {
 	ctx, span := c.tracerProvider.Tracer(TracerName).Start(ctx, "createPod")
 	defer span.End()
+	span.SetAttributes(
+		attribute.String("tekton.task_run.name", tr.Name),
+	)
 	defer func() {
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())

--- a/pkg/reconciler/taskrun/tracing.go
+++ b/pkg/reconciler/taskrun/tracing.go
@@ -62,7 +62,10 @@ func initTracing(ctx context.Context, tracerProvider trace.TracerProvider, tr *v
 	// Create a new root span since there was no parent spanContext provided through annotations
 	ctxWithTrace, span := tracerProvider.Tracer(TracerName).Start(ctx, "TaskRun:Reconciler")
 	defer span.End()
-	span.SetAttributes(attribute.String("taskrun", tr.Name), attribute.String("namespace", tr.Namespace))
+	span.SetAttributes(
+		attribute.String("tekton.task_run.name", tr.Name),
+		attribute.String("k8s.namespace.name", tr.Namespace),
+	)
 
 	pro.Inject(ctxWithTrace, propagation.MapCarrier(spanContext))
 


### PR DESCRIPTION
## Summary

22 of 26 child spans in the PipelineRun/TaskRun reconcilers carried zero attributes — they were unqueryable timers. This PR adds semantic attributes to all key spans so operators can filter and search traces by outcome, task name, namespace, etc. in Jaeger/Tempo.

Closes #9785

```release-note
Added OTel semantic attributes to PipelineRun and TaskRun reconciler spans for improved trace queryability.
```

## Changes

### Attribute keys (OTel semconv-aligned)
- `tekton.pipeline_run.name` / `tekton.task_run.name` — replaces ad-hoc `pipelinerun`/`taskrun`
- `k8s.namespace.name` — replaces ad-hoc `namespace`
- `tekton.pipeline.task_count` — number of tasks in pipeline
- `tekton.pipeline_task.name` — pipeline task name in createTaskRuns
- `tekton.task_run.reason` — failure reason in failTaskRun

### Spans instrumented

**PipelineRun reconciler** (`pkg/reconciler/pipelinerun/`):
- `ReconcileKind` — pipeline_run.name, k8s.namespace.name
- `reconcile` — pipeline_run.name, k8s.namespace.name
- `resolvePipelineState` — pipeline_run.name, task_count
- `runNextSchedulableTask` — pipeline_run.name
- `createTaskRuns` — pipeline_run.name, pipeline_task.name
- `cancelPipelineRun`, `gracefullyCancelPipelineRun`, `timeoutPipelineRun` — updated to semconv keys
- `cancelTaskRun`, `cancelCustomRun`, `timeoutTaskRun`, `timeoutCustomRun` — updated

**TaskRun reconciler** (`pkg/reconciler/taskrun/`):
- `ReconcileKind` — task_run.name, k8s.namespace.name
- `reconcile` — task_run.name, k8s.namespace.name
- `stopSidecars` — task_run.name
- `failTaskRun` — task_run.name, task_run.reason
- `createPod` — task_run.name

## Test Plan

- `go build ./pkg/reconciler/pipelinerun/...` ✅
- `go build ./pkg/reconciler/taskrun/...` ✅
- `go test ./pkg/reconciler/pipelinerun/...` ✅
- `go test ./pkg/reconciler/taskrun/...` ✅
