### PR TITLE
Add "results"  as a valid prefix to Pipeline task params

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -871,7 +871,7 @@ func validateMatrix(ctx context.Context, tasks []PipelineTask) (errs *apis.Field
 }
 
 func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) (errs *apis.FieldError) {
-	validPrefixes := sets.NewString("params", "tasks", "finally", "context", "workspaces")
+	validPrefixes := sets.NewString("params", "tasks", "finally", "context", "workspaces", "results")
 	for idx, task := range tasks {
 		for _, param := range task.Params {
 			if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
@@ -879,7 +879,7 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 					prefix := strings.SplitN(expression, ".", 2)[0]
 					if !validPrefixes.Has(prefix) {
 						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 							"value",
 						).ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
 					}
@@ -892,7 +892,7 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 					prefix := strings.SplitN(expression, ".", 2)[0]
 					if !validPrefixes.Has(prefix) {
 						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 							"",
 						).ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
 					}
@@ -906,7 +906,7 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 						prefix := strings.SplitN(expression, ".", 2)[0]
 						if !validPrefixes.Has(prefix) {
 							errs = errs.Also(apis.ErrInvalidValue(
-								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 								"value",
 							).ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
 						}
@@ -920,7 +920,7 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 							prefix := strings.SplitN(expression, ".", 2)[0]
 							if !validPrefixes.Has(prefix) {
 								errs = errs.Also(apis.ErrInvalidValue(
-									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 									"value",
 								).ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
 							}

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -335,6 +335,20 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "results variable reference in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo hello > $(results.output-result.path)"},
+					}},
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -708,7 +722,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
 		},
 	}, {
@@ -728,7 +742,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.params[IMAGE].value"},
 		},
 	}, {
@@ -751,7 +765,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.include[0].params[IMAGE].value"},
 		},
 	}}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -853,7 +853,7 @@ func validateMatrix(ctx context.Context, tasks []PipelineTask) (errs *apis.Field
 }
 
 func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) (errs *apis.FieldError) {
-	validPrefixes := sets.NewString("params", "tasks", "finally", "context", "workspaces")
+	validPrefixes := sets.NewString("params", "tasks", "finally", "context", "workspaces", "results")
 	for idx, task := range tasks {
 		for _, param := range task.Params {
 			if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
@@ -861,7 +861,7 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 					prefix := strings.SplitN(expression, ".", 2)[0]
 					if !validPrefixes.Has(prefix) {
 						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 							"value",
 						).ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
 					}
@@ -874,7 +874,7 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 					prefix := strings.SplitN(expression, ".", 2)[0]
 					if !validPrefixes.Has(prefix) {
 						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 							"",
 						).ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
 					}
@@ -888,7 +888,7 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 						prefix := strings.SplitN(expression, ".", 2)[0]
 						if !validPrefixes.Has(prefix) {
 							errs = errs.Also(apis.ErrInvalidValue(
-								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 								"value",
 							).ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
 						}
@@ -902,7 +902,7 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 							prefix := strings.SplitN(expression, ".", 2)[0]
 							if !validPrefixes.Has(prefix) {
 								errs = errs.Also(apis.ErrInvalidValue(
-									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 									"value",
 								).ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
 							}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -262,6 +262,20 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "results variable reference in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo hello > $(results.output-result.path)"},
+					}},
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -635,7 +649,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
 		},
 	}, {
@@ -655,7 +669,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.params[IMAGE].value"},
 		},
 	}, {
@@ -678,7 +692,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, or workspaces; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.include[0].params[IMAGE].value"},
 		},
 	}}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

# Changes

Pipeline validation (`validateVarSubstitutionExpressions`) rejects any `$(results.*)` 
expression in pipeline task parameters since results  is not in the hardcoded allowlist- 
causing the admission webhook to reject Pipelines that pass scripts containing `$(results.output-result.path)` as 
parameters — even though those expressions are valid and meant to be resolved at 
the Task level.

This adds `results` to the valid prefix set in both `v1` and `v1beta1` validation, 
and adds a test case confirming that `$(results.*.path)` references in pipeline 
task params are accepted.


# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind bug`
- [x] Release notes block below has been updated with any user facing changes

# Release Notes

```release-note
Fix pipeline validation rejecting $(results.*) variable references in pipeline task parameters
```
