### PR TITLE
Ignore otel major/minor updates in dependabot

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -39,6 +39,10 @@ ecosystems:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+      - dependency-name: "go.opentelemetry.io/*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
     groups:
       kubernetes:
         patterns:
@@ -67,6 +71,10 @@ ecosystems:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+      - dependency-name: "go.opentelemetry.io/*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
     groups:
       kubernetes:
         patterns:
@@ -92,6 +100,10 @@ ecosystems:
       - kind/misc
     ignore:
       - dependency-name: "k8s.io/*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+      - dependency-name: "go.opentelemetry.io/*"
         update-types:
           - version-update:semver-major
           - version-update:semver-minor

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
       groups:
         kubernetes:
             patterns:
@@ -49,6 +53,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
       groups:
         kubernetes:
             patterns:
@@ -74,6 +82,10 @@ updates:
         - kind/misc
       ignore:
         - dependency-name: k8s.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
@@ -149,6 +161,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
         - dependency-name: '*'
           update-types:
             - version-update:semver-major
@@ -184,6 +200,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
         - dependency-name: '*'
           update-types:
             - version-update:semver-major
@@ -216,6 +236,10 @@ updates:
         - kind/misc
       ignore:
         - dependency-name: k8s.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
@@ -319,6 +343,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
         - dependency-name: '*'
           update-types:
             - version-update:semver-major
@@ -354,6 +382,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
         - dependency-name: '*'
           update-types:
             - version-update:semver-major
@@ -386,6 +418,10 @@ updates:
         - kind/misc
       ignore:
         - dependency-name: k8s.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
@@ -489,6 +525,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
         - dependency-name: '*'
           update-types:
             - version-update:semver-major
@@ -524,6 +564,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
         - dependency-name: '*'
           update-types:
             - version-update:semver-major
@@ -556,6 +600,10 @@ updates:
         - kind/misc
       ignore:
         - dependency-name: k8s.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
@@ -659,6 +707,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
         - dependency-name: '*'
           update-types:
             - version-update:semver-major
@@ -694,6 +746,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
         - dependency-name: '*'
           update-types:
             - version-update:semver-major
@@ -726,6 +782,10 @@ updates:
         - kind/misc
       ignore:
         - dependency-name: k8s.io/*
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+        - dependency-name: go.opentelemetry.io/*
           update-types:
             - version-update:semver-major
             - version-update:semver-minor


### PR DESCRIPTION
Otel deps must move with knative/pkg; independent bumps are unmergeable.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
