### PR TITLE
Reject TaskRun taskRef with custom task kind but no apiVersion

### DIFF
--- a/examples/v1/taskruns/beta/emit-array-results.yaml
+++ b/examples/v1/taskruns/beta/emit-array-results.yaml
@@ -36,4 +36,4 @@ metadata:
 spec:
   taskRef:
     name: write-array
-    kind: task
+    kind: Task

--- a/pkg/apis/pipeline/v1/taskref_validation.go
+++ b/pkg/apis/pipeline/v1/taskref_validation.go
@@ -28,5 +28,13 @@ func (ref *TaskRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if ref == nil {
 		return errs
 	}
-	return validateRef(ctx, ref.Name, ref.Resolver, ref.Params)
+	// A non-default Kind is only meaningful for a Custom Task reference, which
+	// requires APIVersion to be set as well (see TaskRef.IsCustomTask). Without
+	// APIVersion the kind is silently ignored at resolution: the ref resolves
+	// as an ordinary namespaced Task when one exists, or fails with a
+	// confusing not-found error.
+	if ref.Kind != "" && ref.Kind != NamespacedTaskKind && ref.APIVersion == "" {
+		errs = errs.Also(apis.ErrInvalidValue("custom task ref must specify apiVersion", "apiVersion"))
+	}
+	return errs.Also(validateRef(ctx, ref.Name, ref.Resolver, ref.Params))
 }

--- a/pkg/apis/pipeline/v1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskref_validation_test.go
@@ -38,6 +38,12 @@ func TestTaskRef_Valid(t *testing.T) {
 		name:    "simple taskref",
 		taskRef: &v1.TaskRef{Name: "taskrefname"},
 	}, {
+		name:    "explicit default kind without apiversion",
+		taskRef: &v1.TaskRef{Name: "taskrefname", Kind: v1.NamespacedTaskKind},
+	}, {
+		name:    "custom task with kind and apiversion",
+		taskRef: &v1.TaskRef{Name: "taskrefname", Kind: "Example", APIVersion: "example.dev/v1"},
+	}, {
 		name:    "beta feature: valid resolver",
 		taskRef: &v1.TaskRef{ResolverRef: v1.ResolverRef{Resolver: "git"}},
 		wc:      cfgtesting.EnableBetaAPIFields,
@@ -85,6 +91,10 @@ func TestTaskRef_Invalid(t *testing.T) {
 		name:    "missing taskref name",
 		taskRef: &v1.TaskRef{},
 		wantErr: apis.ErrMissingField("name"),
+	}, {
+		name:    "custom task kind without apiversion",
+		taskRef: &v1.TaskRef{Name: "foo", Kind: "Example"},
+		wantErr: apis.ErrInvalidValue("custom task ref must specify apiVersion", "apiVersion"),
 	}, {
 		name:    "invalid taskref name",
 		taskRef: &v1.TaskRef{Name: "_foo"},

--- a/pkg/apis/pipeline/v1beta1/taskref_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation.go
@@ -35,6 +35,14 @@ func (ref *TaskRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if apis.IsInCreate(ctx) && ref.Bundle != "" {
 		errs = errs.Also(apis.ErrDisallowedFields("bundle"))
 	}
+	// A non-default Kind is only meaningful for a Custom Task reference, which
+	// requires APIVersion to be set as well (see TaskRef.IsCustomTask). Without
+	// APIVersion the kind is silently ignored at resolution: the ref resolves
+	// as an ordinary namespaced Task when one exists, or fails with a
+	// confusing not-found error.
+	if ref.Kind != "" && ref.Kind != NamespacedTaskKind && ref.APIVersion == "" {
+		errs = errs.Also(apis.ErrInvalidValue("custom task ref must specify apiVersion", "apiVersion"))
+	}
 	switch {
 	case ref.Resolver != "" || ref.Params != nil:
 		if ref.Params != nil {

--- a/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
@@ -38,6 +38,12 @@ func TestTaskRef_Valid(t *testing.T) {
 		name:    "simple taskref",
 		taskRef: &v1beta1.TaskRef{Name: "taskrefname"},
 	}, {
+		name:    "explicit default kind without apiversion",
+		taskRef: &v1beta1.TaskRef{Name: "taskrefname", Kind: v1beta1.NamespacedTaskKind},
+	}, {
+		name:    "custom task with kind and apiversion",
+		taskRef: &v1beta1.TaskRef{Name: "taskrefname", Kind: "Example", APIVersion: "example.dev/v1"},
+	}, {
 		name:    "beta feature: valid resolver",
 		taskRef: &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}},
 		wc:      cfgtesting.EnableBetaAPIFields,
@@ -84,6 +90,10 @@ func TestTaskRef_Invalid(t *testing.T) {
 		name:    "missing taskref name",
 		taskRef: &v1beta1.TaskRef{},
 		wantErr: apis.ErrMissingField("name"),
+	}, {
+		name:    "custom task kind without apiversion",
+		taskRef: &v1beta1.TaskRef{Name: "foo", Kind: "Example"},
+		wantErr: apis.ErrInvalidValue("custom task ref must specify apiVersion", "apiVersion"),
 	}, {
 		name: "taskRef with resolver and k8s style name",
 		taskRef: &v1beta1.TaskRef{


### PR DESCRIPTION
# Changes

Setting `taskRef.kind` to a non-default value without `taskRef.apiVersion` currently passes admission validation. `TaskRef.IsCustomTask()` requires both fields to be set, so such a ref is not treated as a Custom Task, and the resolver ignores the kind entirely: the TaskRun runs an ordinary namespaced Task when one with that name exists, or fails at resolution with a confusing `tasks.tekton.dev "foo" not found` error. #6505 added the Pipeline-level checks for this (pipeline task `taskRef` and embedded `taskSpec`); the issue notes the standalone TaskRun `taskRef` case was left open.

This adds the pairing check to `TaskRef.Validate` in v1 and v1beta1, reusing the pre-existing "custom task ref must specify apiVersion" error from the Pipeline-level custom task validation. The Pipeline path is unaffected: `PipelineTask.Validate` routes non-default kinds to `validateCustomTask` before `TaskRef.Validate` is reached, so no duplicate errors. An explicit `kind: Task` without apiVersion stays valid, since the defaulting webhook writes `kind: Task` into every non-resolver taskRef. The reverse case (apiVersion set, kind empty) is deliberately not rejected: such refs resolve as namespaced Tasks today and rejecting them would break working configs. Also corrects `examples/v1/taskruns/beta/emit-array-results.yaml`, which set `kind: task` (lowercase) on an ordinary task reference and would have been rejected by the new check.

`docs/taskruns.md` documents only `taskRef.name` for TaskRuns, `taskRef.kind` is not documented there, so no doc change is included.

Fixes #6557

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixes a bug which let a TaskRun taskRef set kind to a value other than "Task" without an apiVersion. The kind was silently ignored: the TaskRun ran a namespaced Task with the same name when one existed, or failed at resolution with a confusing not-found error. After this change, creating such a TaskRun fails admission in v1 and v1beta1 with "custom task ref must specify apiVersion", the same validation already applied to taskRefs inside pipelineTasks.
Action Required: TaskRun manifests that set kind: ClusterTask (removed in v1.0) or a wrong-case value such as kind: task will now be rejected. Remove kind or set it to "Task" for ordinary task references, and set apiVersion for Custom Task references.
```
