### PR TITLE
Allow one-word shell command substitution in pipeline task params

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -876,12 +876,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		for _, param := range task.Params {
 			if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
 				for _, expression := range expressions {
-					prefix := strings.SplitN(expression, ".", 2)[0]
-					if !validPrefixes.Has(prefix) {
-						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-							"value",
-						).ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
+					if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+						errs = errs.Also(err.ViaField("value").ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
 					}
 				}
 			}
@@ -889,12 +885,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		for i, we := range task.When {
 			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
 				for _, expression := range expressions {
-					prefix := strings.SplitN(expression, ".", 2)[0]
-					if !validPrefixes.Has(prefix) {
-						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-							"",
-						).ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
+					if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+						errs = errs.Also(err.ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
 					}
 				}
 			}
@@ -903,12 +895,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 			for _, param := range task.Matrix.Params {
 				if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
 					for _, expression := range expressions {
-						prefix := strings.SplitN(expression, ".", 2)[0]
-						if !validPrefixes.Has(prefix) {
-							errs = errs.Also(apis.ErrInvalidValue(
-								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-								"value",
-							).ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
+						if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+							errs = errs.Also(err.ViaField("value").ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
 						}
 					}
 				}
@@ -917,12 +905,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 				for _, param := range include.Params {
 					if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
 						for _, expression := range expressions {
-							prefix := strings.SplitN(expression, ".", 2)[0]
-							if !validPrefixes.Has(prefix) {
-								errs = errs.Also(apis.ErrInvalidValue(
-									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-									"value",
-								).ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
+							if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+								errs = errs.Also(err.ViaField("value").ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
 							}
 						}
 					}
@@ -931,6 +915,24 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		}
 	}
 	return errs
+}
+
+// validateVarSubstitutionPrefix returns an error if expression looks like a Tekton
+// variable reference (contains ".") but does not start with a known prefix.
+// Expressions without a "." such as "$(ls)" are treated as shell command
+// substitution and are allowed.
+func validateVarSubstitutionPrefix(expression string, validPrefixes sets.String) *apis.FieldError {
+	if !strings.Contains(expression, ".") {
+		return nil
+	}
+	prefix := strings.SplitN(expression, ".", 2)[0]
+	if validPrefixes.Has(prefix) {
+		return nil
+	}
+	return apis.ErrInvalidValue(
+		fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+		"",
+	)
 }
 
 // findAndValidateResultRefsForMatrix checks that any result references to Matrixed PipelineTasks if consumed

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -877,14 +877,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		for _, param := range task.Params {
 			if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
 				for _, expression := range expressions {
-					fields := strings.SplitN(expression, ".", 3)
-					if !validPrefixes.Has(fields[0]) &&
-						!(len(fields) > 1 && validPrefixes.Has(fields[0]+"."+fields[1]) &&
-							(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
-						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-							"value",
-						).ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
+					if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+						errs = errs.Also(err.ViaField("value").ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
 					}
 				}
 			}
@@ -892,14 +886,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		for i, we := range task.When {
 			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
 				for _, expression := range expressions {
-					fields := strings.SplitN(expression, ".", 3)
-					if !validPrefixes.Has(fields[0]) &&
-						!(len(fields) > 1 && validPrefixes.Has(fields[0]+"."+fields[1]) &&
-							(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
-						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-							"",
-						).ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
+					if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+						errs = errs.Also(err.ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
 					}
 				}
 			}
@@ -908,15 +896,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 			for _, param := range task.Matrix.Params {
 				if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
 					for _, expression := range expressions {
-						fields := strings.SplitN(expression, ".", 3)
-						if !validPrefixes.Has(fields[0]) &&
-							!(len(fields) > 1 &&
-								validPrefixes.Has(fields[0]+"."+fields[1]) &&
-								(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
-							errs = errs.Also(apis.ErrInvalidValue(
-								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-								"value",
-							).ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
+						if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+							errs = errs.Also(err.ViaField("value").ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
 						}
 					}
 				}
@@ -925,15 +906,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 				for _, param := range include.Params {
 					if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
 						for _, expression := range expressions {
-							fields := strings.SplitN(expression, ".", 3)
-							if !validPrefixes.Has(fields[0]) &&
-								!(len(fields) > 1 &&
-									validPrefixes.Has(fields[0]+"."+fields[1]) &&
-									(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
-								errs = errs.Also(apis.ErrInvalidValue(
-									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-									"value",
-								).ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
+							if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+								errs = errs.Also(err.ViaField("value").ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
 							}
 						}
 					}
@@ -942,6 +916,26 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		}
 	}
 	return errs
+}
+
+// validateVarSubstitutionPrefix returns an error if expression looks like a Tekton
+// variable reference (contains ".") but does not start with a known prefix.
+// Expressions without a "." such as "$(ls)" are treated as shell command
+// substitution and are allowed.
+func validateVarSubstitutionPrefix(expression string, validPrefixes sets.String) *apis.FieldError {
+	if !strings.Contains(expression, ".") {
+		return nil
+	}
+	fields := strings.SplitN(expression, ".", 3)
+	if validPrefixes.Has(fields[0]) ||
+		(len(fields) > 1 && validPrefixes.Has(fields[0]+"."+fields[1]) &&
+			(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
+		return nil
+	}
+	return apis.ErrInvalidValue(
+		fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+		"",
+	)
 }
 
 // findAndValidateResultRefsForMatrix checks that any result references to Matrixed PipelineTasks if consumed

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -349,6 +349,34 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "one-word shell command substitution in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo files: $(ls)"},
+					}},
+				}},
+			},
+		},
+	}, {
+		name: "undotted shell-like expression in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env_value_set_from_yq)"},
+					}},
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -708,7 +736,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			Paths:   []string{""},
 		},
 	}, {
-		name: "invalid variable reference in pipeline task param",
+		name: "invalid dotted variable reference in pipeline task param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -716,17 +744,17 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 					Name:    "foo",
 					TaskRef: &TaskRef{Name: "foo-task"},
 					Params: Params{{
-						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env_value_set_from_yq)"},
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env.value_set_from_yq)"},
 					}},
 				}},
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(env.value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
 		},
 	}, {
-		name: "invalid variable reference in matrix param",
+		name: "invalid dotted variable reference in matrix param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -735,18 +763,18 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 					TaskRef: &TaskRef{Name: "foo-task"},
 					Matrix: &Matrix{
 						Params: Params{{
-							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(invalid_ref)", "image2"}},
+							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(invalid.ref)", "image2"}},
 						}},
 					},
 				}},
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid.ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.params[IMAGE].value"},
 		},
 	}, {
-		name: "invalid variable reference in matrix include param",
+		name: "invalid dotted variable reference in matrix include param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -757,7 +785,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 						Include: IncludeParamsList{{
 							Name: "build-1",
 							Params: Params{{
-								Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(invalid_ref)"},
+								Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(invalid.ref)"},
 							}},
 						}},
 					},
@@ -765,7 +793,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid.ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.include[0].params[IMAGE].value"},
 		},
 	}}

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -379,6 +379,34 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "one-word shell command substitution in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo files: $(ls)"},
+					}},
+				}},
+			},
+		},
+	}, {
+		name: "undotted shell-like expression in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env_value_set_from_yq)"},
+					}},
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -738,7 +766,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			Paths:   []string{""},
 		},
 	}, {
-		name: "invalid variable reference in pipeline task param",
+		name: "invalid dotted variable reference in pipeline task param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -746,13 +774,13 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 					Name:    "foo",
 					TaskRef: &TaskRef{Name: "foo-task"},
 					Params: Params{{
-						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env_value_set_from_yq)"},
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env.value_set_from_yq)"},
 					}},
 				}},
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(env.value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
 		},
 	}, {
@@ -810,7 +838,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
 		},
 	}, {
-		name: "invalid variable reference in matrix param",
+		name: "invalid dotted variable reference in matrix param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -819,18 +847,18 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 					TaskRef: &TaskRef{Name: "foo-task"},
 					Matrix: &Matrix{
 						Params: Params{{
-							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(invalid_ref)", "image2"}},
+							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(invalid.ref)", "image2"}},
 						}},
 					},
 				}},
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid.ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.params[IMAGE].value"},
 		},
 	}, {
-		name: "invalid variable reference in matrix include param",
+		name: "invalid dotted variable reference in matrix include param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -841,7 +869,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 						Include: IncludeParamsList{{
 							Name: "build-1",
 							Params: Params{{
-								Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(invalid_ref)"},
+								Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(invalid.ref)"},
 							}},
 						}},
 					},
@@ -849,7 +877,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid.ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.include[0].params[IMAGE].value"},
 		},
 	}, {
@@ -861,7 +889,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 					Name:    "foo",
 					TaskRef: &TaskRef{Name: "foo-task"},
 					When: WhenExpressions{{
-						Input:    "$(invalid_ref)",
+						Input:    "$(invalid.ref)",
 						Operator: selection.In,
 						Values:   []string{"bar"},
 					}},
@@ -869,7 +897,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid.ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].when[0]"},
 		},
 	}}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -859,14 +859,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		for _, param := range task.Params {
 			if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
 				for _, expression := range expressions {
-					fields := strings.SplitN(expression, ".", 3)
-					if !validPrefixes.Has(fields[0]) &&
-						!(len(fields) > 1 && validPrefixes.Has(fields[0]+"."+fields[1]) &&
-							(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
-						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-							"value",
-						).ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
+					if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+						errs = errs.Also(err.ViaField("value").ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
 					}
 				}
 			}
@@ -874,14 +868,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		for i, we := range task.WhenExpressions {
 			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
 				for _, expression := range expressions {
-					fields := strings.SplitN(expression, ".", 3)
-					if !validPrefixes.Has(fields[0]) &&
-						!(len(fields) > 1 && validPrefixes.Has(fields[0]+"."+fields[1]) &&
-							(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
-						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-							"",
-						).ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
+					if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+						errs = errs.Also(err.ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
 					}
 				}
 			}
@@ -890,15 +878,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 			for _, param := range task.Matrix.Params {
 				if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
 					for _, expression := range expressions {
-						fields := strings.SplitN(expression, ".", 3)
-						if !validPrefixes.Has(fields[0]) &&
-							!(len(fields) > 1 &&
-								validPrefixes.Has(fields[0]+"."+fields[1]) &&
-								(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
-							errs = errs.Also(apis.ErrInvalidValue(
-								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-								"value",
-							).ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
+						if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+							errs = errs.Also(err.ViaField("value").ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
 						}
 					}
 				}
@@ -907,15 +888,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 				for _, param := range include.Params {
 					if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
 						for _, expression := range expressions {
-							fields := strings.SplitN(expression, ".", 3)
-							if !validPrefixes.Has(fields[0]) &&
-								!(len(fields) > 1 &&
-									validPrefixes.Has(fields[0]+"."+fields[1]) &&
-									(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
-								errs = errs.Also(apis.ErrInvalidValue(
-									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-									"value",
-								).ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
+							if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+								errs = errs.Also(err.ViaField("value").ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
 							}
 						}
 					}
@@ -924,6 +898,26 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		}
 	}
 	return errs
+}
+
+// validateVarSubstitutionPrefix returns an error if expression looks like a Tekton
+// variable reference (contains ".") but does not start with a known prefix.
+// Expressions without a "." such as "$(ls)" are treated as shell command
+// substitution and are allowed.
+func validateVarSubstitutionPrefix(expression string, validPrefixes sets.String) *apis.FieldError {
+	if !strings.Contains(expression, ".") {
+		return nil
+	}
+	fields := strings.SplitN(expression, ".", 3)
+	if validPrefixes.Has(fields[0]) ||
+		(len(fields) > 1 && validPrefixes.Has(fields[0]+"."+fields[1]) &&
+			(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
+		return nil
+	}
+	return apis.ErrInvalidValue(
+		fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+		"",
+	)
 }
 
 // findAndValidateResultRefsForMatrix checks that any result references to Matrixed PipelineTasks if consumed

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -858,12 +858,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		for _, param := range task.Params {
 			if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
 				for _, expression := range expressions {
-					prefix := strings.SplitN(expression, ".", 2)[0]
-					if !validPrefixes.Has(prefix) {
-						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-							"value",
-						).ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
+					if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+						errs = errs.Also(err.ViaField("value").ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
 					}
 				}
 			}
@@ -871,12 +867,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		for i, we := range task.WhenExpressions {
 			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
 				for _, expression := range expressions {
-					prefix := strings.SplitN(expression, ".", 2)[0]
-					if !validPrefixes.Has(prefix) {
-						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-							"",
-						).ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
+					if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+						errs = errs.Also(err.ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
 					}
 				}
 			}
@@ -885,12 +877,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 			for _, param := range task.Matrix.Params {
 				if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
 					for _, expression := range expressions {
-						prefix := strings.SplitN(expression, ".", 2)[0]
-						if !validPrefixes.Has(prefix) {
-							errs = errs.Also(apis.ErrInvalidValue(
-								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-								"value",
-							).ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
+						if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+							errs = errs.Also(err.ViaField("value").ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
 						}
 					}
 				}
@@ -899,12 +887,8 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 				for _, param := range include.Params {
 					if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
 						for _, expression := range expressions {
-							prefix := strings.SplitN(expression, ".", 2)[0]
-							if !validPrefixes.Has(prefix) {
-								errs = errs.Also(apis.ErrInvalidValue(
-									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
-									"value",
-								).ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
+							if err := validateVarSubstitutionPrefix(expression, validPrefixes); err != nil {
+								errs = errs.Also(err.ViaField("value").ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
 							}
 						}
 					}
@@ -913,6 +897,24 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		}
 	}
 	return errs
+}
+
+// validateVarSubstitutionPrefix returns an error if expression looks like a Tekton
+// variable reference (contains ".") but does not start with a known prefix.
+// Expressions without a "." such as "$(ls)" are treated as shell command
+// substitution and are allowed.
+func validateVarSubstitutionPrefix(expression string, validPrefixes sets.String) *apis.FieldError {
+	if !strings.Contains(expression, ".") {
+		return nil
+	}
+	prefix := strings.SplitN(expression, ".", 2)[0]
+	if validPrefixes.Has(prefix) {
+		return nil
+	}
+	return apis.ErrInvalidValue(
+		fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+		"",
+	)
 }
 
 // findAndValidateResultRefsForMatrix checks that any result references to Matrixed PipelineTasks if consumed

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -276,6 +276,34 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "one-word shell command substitution in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo files: $(ls)"},
+					}},
+				}},
+			},
+		},
+	}, {
+		name: "undotted shell-like expression in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env_value_set_from_yq)"},
+					}},
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -635,7 +663,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			Paths:   []string{""},
 		},
 	}, {
-		name: "invalid variable reference in pipeline task param",
+		name: "invalid dotted variable reference in pipeline task param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -643,17 +671,17 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 					Name:    "foo",
 					TaskRef: &TaskRef{Name: "foo-task"},
 					Params: Params{{
-						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env_value_set_from_yq)"},
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env.value_set_from_yq)"},
 					}},
 				}},
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(env.value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
 		},
 	}, {
-		name: "invalid variable reference in matrix param",
+		name: "invalid dotted variable reference in matrix param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -662,18 +690,18 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 					TaskRef: &TaskRef{Name: "foo-task"},
 					Matrix: &Matrix{
 						Params: Params{{
-							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(invalid_ref)", "image2"}},
+							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(invalid.ref)", "image2"}},
 						}},
 					},
 				}},
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid.ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.params[IMAGE].value"},
 		},
 	}, {
-		name: "invalid variable reference in matrix include param",
+		name: "invalid dotted variable reference in matrix include param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -684,7 +712,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 						Include: IncludeParamsList{{
 							Name: "build-1",
 							Params: Params{{
-								Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(invalid_ref)"},
+								Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(invalid.ref)"},
 							}},
 						}},
 					},
@@ -692,7 +720,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid.ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.include[0].params[IMAGE].value"},
 		},
 	}}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -306,6 +306,34 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "one-word shell command substitution in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo files: $(ls)"},
+					}},
+				}},
+			},
+		},
+	}, {
+		name: "undotted shell-like expression in pipeline task param",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env_value_set_from_yq)"},
+					}},
+				}},
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -665,7 +693,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			Paths:   []string{""},
 		},
 	}, {
-		name: "invalid variable reference in pipeline task param",
+		name: "invalid dotted variable reference in pipeline task param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -673,13 +701,13 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 					Name:    "foo",
 					TaskRef: &TaskRef{Name: "foo-task"},
 					Params: Params{{
-						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env_value_set_from_yq)"},
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(env.value_set_from_yq)"},
 					}},
 				}},
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(env.value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
 		},
 	}, {
@@ -737,7 +765,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
 		},
 	}, {
-		name: "invalid variable reference in matrix param",
+		name: "invalid dotted variable reference in matrix param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -746,18 +774,18 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 					TaskRef: &TaskRef{Name: "foo-task"},
 					Matrix: &Matrix{
 						Params: Params{{
-							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(invalid_ref)", "image2"}},
+							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(invalid.ref)", "image2"}},
 						}},
 					},
 				}},
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid.ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.params[IMAGE].value"},
 		},
 	}, {
-		name: "invalid variable reference in matrix include param",
+		name: "invalid dotted variable reference in matrix include param",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
@@ -768,7 +796,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 						Include: IncludeParamsList{{
 							Name: "build-1",
 							Params: Params{{
-								Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(invalid_ref)"},
+								Name: "IMAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(invalid.ref)"},
 							}},
 						}},
 					},
@@ -776,7 +804,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid.ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.include[0].params[IMAGE].value"},
 		},
 	}, {
@@ -788,7 +816,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 					Name:    "foo",
 					TaskRef: &TaskRef{Name: "foo-task"},
 					WhenExpressions: WhenExpressions{{
-						Input:    "$(invalid_ref)",
+						Input:    "$(invalid.ref)",
 						Operator: selection.In,
 						Values:   []string{"bar"},
 					}},
@@ -796,7 +824,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid.ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].when[0]"},
 		},
 	}}


### PR DESCRIPTION
# Changes

Pipeline validation (`validateVarSubstitutionExpressions`) rejected any `$(...)` expression whose first segment was not a known Tekton prefix. That incorrectly failed legitimate one-word shell command substitutions such as `$(ls)` in pipeline task parameter values.

Tekton variable references always use dotted notation (`params.foo`, `results.bar.path`, etc.). This change:
- Allows undotted `$(...)` expressions as shell command substitution
- Continues to reject dotted expressions with unknown prefixes (e.g. `$(invalid.ref)`)
- Keeps `results` as a valid prefix (from #10443)

Applies to both `v1` and `v1beta1`.

Fixes #10444

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix pipeline validation rejecting one-word shell command substitutions like $(ls) in task parameter values
```