### PR TITLE
fix(taskrun): retry native sidecar discovery after transient errors

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -96,11 +96,12 @@ type Reconciler struct {
 	tracerProvider           trace.TracerProvider
 
 	// Native-sidecar detection (ServerVersion + IsNativeSidecarSupport) when EnableKubernetesSidecar
-	// is set is memoized via sync.OnceValues after lazy init guarded by nativeSidecarOnce (#9755).
+	// is set is cached so we do not call Discovery on every resync (#9755). The cache is only
+	// populated on a successful ServerVersion() call so a transient discovery error is retried
+	// on a later reconcile instead of being memoized forever (#10101).
 	// Status.Sidecars cannot be used to skip stopSidecars: injected containers (e.g. Istio)
 	// are not listed there but buildSidecarStopPatch stops them using the live Pod.
-	nativeSidecarOnce        sync.Once
-	nativeSidecarFromCluster func() (useTektonNop bool, err error)
+	nativeSidecarCache nativeSidecarCache
 }
 
 const (
@@ -384,31 +385,40 @@ func (c *Reconciler) durationAndCountMetrics(ctx context.Context, tr *v1.TaskRun
 
 // useTektonSidecarMode returns whether the done path should run stopSidecars (Tekton nop
 // image) vs skipping it for native Kubernetes sidecars. When EnableKubernetesSidecar is enabled,
-// ServerVersion is queried at most once per reconciler; later reconciles reuse the memoized result.
+// ServerVersion is queried at most once per reconciler; later reconciles reuse the cached result,
+// unless the discovery call failed, in which case it is retried on the next reconcile.
 func (c *Reconciler) useTektonSidecarMode(ctx context.Context, logger *zap.SugaredLogger) (bool, error) {
 	if !config.FromContextOrDefaults(ctx).FeatureFlags.EnableKubernetesSidecar {
 		return true, nil
 	}
-	c.nativeSidecarOnce.Do(func() {
-		c.nativeSidecarFromCluster = newNativeSidecarFromCluster(c.KubeClientSet, logger)
-	})
-	return c.nativeSidecarFromCluster()
+	return c.nativeSidecarCache.get(c.KubeClientSet, logger)
 }
 
-// newNativeSidecarFromCluster returns a function that queries ServerVersion at most once and
-// returns whether to use Tekton nop sidecar teardown (true) vs native Kubernetes sidecars (false).
-func newNativeSidecarFromCluster(client kubernetes.Interface, log *zap.SugaredLogger) func() (bool, error) {
-	return sync.OnceValues(func() (bool, error) {
-		sv, err := client.Discovery().ServerVersion()
-		if err != nil {
-			return false, err
-		}
-		if podconvert.IsNativeSidecarSupport(sv) {
-			log.Info("Using Kubernetes Native Sidecars")
-			return false, nil
-		}
-		return true, nil
-	})
+// nativeSidecarCache caches whether to use Tekton nop sidecar teardown (true) vs native
+// Kubernetes sidecars (false), populating the cache only once ServerVersion() succeeds so a
+// transient discovery error does not get memoized forever (#10101).
+type nativeSidecarCache struct {
+	mu        sync.Mutex
+	cached    bool
+	useTekton bool
+}
+
+func (n *nativeSidecarCache) get(client kubernetes.Interface, log *zap.SugaredLogger) (bool, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.cached {
+		return n.useTekton, nil
+	}
+	sv, err := client.Discovery().ServerVersion()
+	if err != nil {
+		return false, err
+	}
+	n.useTekton = !podconvert.IsNativeSidecarSupport(sv)
+	if !n.useTekton {
+		log.Info("Using Kubernetes Native Sidecars")
+	}
+	n.cached = true
+	return n.useTekton, nil
 }
 
 func (c *Reconciler) stopSidecars(ctx context.Context, tr *v1.TaskRun) error {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -8539,7 +8539,7 @@ func TestUseTektonSidecarModeDoesNotCacheDiscoveryErrors(t *testing.T) {
 			return true, nil, errors.New("transient discovery error")
 		}
 		// Signal a successful discovery call (handled=true, no error). The version
-		// FakeDiscovery.ServerVersion() actually returns comes from FakedServerVersion,
+		// that FakeDiscovery.ServerVersion() actually returns comes from FakedServerVersion,
 		// set below, not from this reactor's return value.
 		return true, nil, nil
 	})

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -74,6 +74,8 @@ import (
 	k8sruntimeschema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	apiversion "k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
@@ -8530,12 +8532,17 @@ func TestUseTektonSidecarModeDoesNotCacheDiscoveryErrors(t *testing.T) {
 	kubeClient := fakekubeclientset.NewSimpleClientset()
 
 	discoveryFailed := true
+	discoveryCalls := 0
 	kubeClient.PrependReactor("get", "version", func(action ktesting.Action) (bool, runtime.Object, error) {
+		discoveryCalls++
 		if discoveryFailed {
 			return true, nil, errors.New("transient discovery error")
 		}
-		return false, nil, nil
+		// Explicitly return a version predating native sidecar support (1.29) so the
+		// assertions below don't depend on the fake client's default build version.
+		return true, nil, nil
 	})
+	kubeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &apiversion.Info{Major: "1", Minor: "28"}
 
 	ctx := config.ToContext(context.Background(), &config.Config{
 		FeatureFlags: &config.FeatureFlags{
@@ -8548,6 +8555,9 @@ func TestUseTektonSidecarModeDoesNotCacheDiscoveryErrors(t *testing.T) {
 	if _, err := r.useTektonSidecarMode(ctx, logger); err == nil {
 		t.Fatal("expected the first useTektonSidecarMode call to return the discovery error")
 	}
+	if discoveryCalls != 1 {
+		t.Fatalf("expected discovery to be called once after the first reconcile, got %d calls", discoveryCalls)
+	}
 
 	discoveryFailed = false
 
@@ -8555,7 +8565,17 @@ func TestUseTektonSidecarModeDoesNotCacheDiscoveryErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected useTektonSidecarMode to retry discovery after a transient error and succeed, got err: %v", err)
 	}
+	if discoveryCalls != 2 {
+		t.Fatalf("expected the transient error not to be cached, so discovery is retried on the next reconcile: got %d calls", discoveryCalls)
+	}
 	if !useTektonSidecar {
-		t.Errorf("expected useTektonSidecarMode to return true (fake server version has no native sidecar support), got false")
+		t.Errorf("expected useTektonSidecarMode to return true (server version 1.28 has no native sidecar support), got false")
+	}
+
+	if _, err := r.useTektonSidecarMode(ctx, logger); err != nil {
+		t.Fatalf("unexpected error on third call: %v", err)
+	}
+	if discoveryCalls != 2 {
+		t.Fatalf("expected the successful discovery result to be cached, so a later reconcile does not call discovery again: got %d calls", discoveryCalls)
 	}
 }

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -8538,8 +8538,9 @@ func TestUseTektonSidecarModeDoesNotCacheDiscoveryErrors(t *testing.T) {
 		if discoveryFailed {
 			return true, nil, errors.New("transient discovery error")
 		}
-		// Explicitly return a version predating native sidecar support (1.29) so the
-		// assertions below don't depend on the fake client's default build version.
+		// Signal a successful discovery call (handled=true, no error). The version
+		// FakeDiscovery.ServerVersion() actually returns comes from FakedServerVersion,
+		// set below, not from this reactor's return value.
 		return true, nil, nil
 	})
 	kubeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &apiversion.Info{Major: "1", Minor: "28"}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -85,6 +85,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
+	logtesting "knative.dev/pkg/logging/testing"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
@@ -8519,5 +8520,42 @@ func TestAppendPreviousConditionContext(t *testing.T) {
 				t.Errorf("Expected message to be unchanged %q, got: %s", tc.newMessage, result)
 			}
 		})
+	}
+}
+
+// TestUseTektonSidecarModeDoesNotCacheDiscoveryErrors verifies that a transient
+// Discovery().ServerVersion() error is not cached: it must be returned for the current
+// reconcile but retried (not memoized) on a later reconcile (#10101).
+func TestUseTektonSidecarModeDoesNotCacheDiscoveryErrors(t *testing.T) {
+	kubeClient := fakekubeclientset.NewSimpleClientset()
+
+	discoveryFailed := true
+	kubeClient.PrependReactor("get", "version", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if discoveryFailed {
+			return true, nil, errors.New("transient discovery error")
+		}
+		return false, nil, nil
+	})
+
+	ctx := config.ToContext(context.Background(), &config.Config{
+		FeatureFlags: &config.FeatureFlags{
+			EnableKubernetesSidecar: true,
+		},
+	})
+	logger := logtesting.TestLogger(t)
+	r := &Reconciler{KubeClientSet: kubeClient}
+
+	if _, err := r.useTektonSidecarMode(ctx, logger); err == nil {
+		t.Fatal("expected the first useTektonSidecarMode call to return the discovery error")
+	}
+
+	discoveryFailed = false
+
+	useTektonSidecar, err := r.useTektonSidecarMode(ctx, logger)
+	if err != nil {
+		t.Fatalf("expected useTektonSidecarMode to retry discovery after a transient error and succeed, got err: %v", err)
+	}
+	if !useTektonSidecar {
+		t.Errorf("expected useTektonSidecarMode to return true (fake server version has no native sidecar support), got false")
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

With `enable-kubernetes-sidecar` set, the TaskRun reconciler's done path memoized `client.Discovery().ServerVersion()` with `sync.OnceValues`, which cached both successes and errors forever. A transient discovery failure on the first call meant every later done-path reconcile kept returning that same stale error until the controller restarted, delaying final done-path processing (including sidecar cleanup) for completed TaskRuns.

This replaces that memoization with a mutex-guarded cache that's only populated after a successful discovery call, so a transient error is retried on the next reconcile instead of being cached forever. On the happy path the behavior is unchanged — discovery is still queried at most once per process.

Fixes #10101

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed a bug where, with `enable-kubernetes-sidecar` set, a transient error from the Kubernetes API server during native-sidecar discovery could be cached forever, repeatedly delaying final done-path processing (including sidecar cleanup) for completed TaskRuns instead of being retried once the API server recovered.
```
