### PR TITLE
fix(pipelinerun): skip PodEvicted live GET when TaskRun cannot retry

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -449,8 +449,11 @@ func (c *Reconciler) resolvePipelineState(
 			// premature PipelineRun failure. Pod eviction is the only transient failure
 			// that can recover (pod gets rescheduled); all other failure reasons
 			// (Failed, Cancelled, TimedOut, etc.) are deterministic and cannot recover.
+			// A failed TaskRun only moves back to a non-terminal state on retry, so the
+			// live GET is skipped when the TaskRun has no retries left — it cannot
+			// change the recovery decision and would only add API server load.
 			if cond := tr.Status.GetCondition(apis.ConditionSucceeded); cond != nil && cond.IsFalse() &&
-				cond.Reason == v1.TaskRunReasonPodEvicted.String() {
+				cond.Reason == v1.TaskRunReasonPodEvicted.String() && tr.IsRetriable() {
 				freshTR, freshErr := c.PipelineClientSet.TektonV1().TaskRuns(pr.Namespace).Get(ctx, name, metav1.GetOptions{})
 				if freshErr != nil {
 					// Eviction recovery never deletes the TaskRun — the controller

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -19262,6 +19262,8 @@ func TestReconcile_DeferFailureWhenTaskRunRecoveredInAPIServer(t *testing.T) {
 			Reason:  v1.TaskRunReasonPodEvicted.String(),
 			Message: "pod eviction",
 		})}
+	// TaskRun still has a retry available so the live GET verification path is exercised.
+	trs[0].Spec.Retries = 1
 
 	// PipelineRun is Running
 	prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
@@ -19343,6 +19345,8 @@ func TestReconcile_ConfirmFailureWhenTaskRunFailedInAPIServer(t *testing.T) {
 			Reason:  v1.TaskRunReasonPodEvicted.String(),
 			Message: "pod eviction",
 		})}
+	// TaskRun still has a retry available so the live GET verification path is exercised.
+	trs[0].Spec.Retries = 1
 
 	// PipelineRun is Running
 	prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
@@ -19411,6 +19415,8 @@ func TestReconcile_APIServerErrorReturnsError(t *testing.T) {
 			Reason:  v1.TaskRunReasonPodEvicted.String(),
 			Message: "pod eviction",
 		})}
+	// TaskRun still has a retry available so the live GET verification path is exercised.
+	trs[0].Spec.Retries = 1
 
 	// PipelineRun is Running
 	prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
@@ -19486,6 +19492,8 @@ func TestReconcile_TaskRunNotFoundFallsBackToCache(t *testing.T) {
 			Reason:  v1.TaskRunReasonPodEvicted.String(),
 			Message: "pod eviction",
 		})}
+	// TaskRun still has a retry available so the live GET verification path is exercised.
+	trs[0].Spec.Retries = 1
 
 	// PipelineRun is Running
 	prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
@@ -19753,5 +19761,173 @@ status:
 	}
 	if !condition.IsFalse() {
 		t.Errorf("Expected PipelineRun to be marked Failed for generic failed TaskRun, got status %s reason %s", condition.Status, condition.Reason)
+	}
+}
+
+// TestReconcile_PodEvictedWithoutRetriesSkipsAPIVerification tests that when a TaskRun
+// fails with PodEvicted but has no retries configured, no API server verification is
+// performed — the live GET cannot change the recovery decision since the TaskRun can
+// never move back to a non-terminal state without a retry available.
+func TestReconcile_PodEvictedWithoutRetriesSkipsAPIVerification(t *testing.T) {
+	names.TestingSeed()
+
+	namespace := "foo"
+	prName := "test-pipeline-run-podevicted-no-retries"
+	trName := "test-pipeline-run-podevicted-no-retries-hello-world-1"
+
+	// TaskRun is Failed due to pod eviction in informer cache, with no retries configured.
+	trs := []*v1.TaskRun{createHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
+		prName, "test-pipeline", "", "hello-world-1",
+		apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  v1.TaskRunReasonPodEvicted.String(),
+			Message: "pod eviction",
+		})}
+
+	// PipelineRun is Running
+	prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineRef:
+    name: test-pipeline
+  taskRunTemplate:
+    serviceAccountName: test-sa
+status:
+  conditions:
+  - type: Succeeded
+    status: Unknown
+    reason: Running
+  startTime: "2022-01-01T00:00:00Z"
+  childReferences:
+  - apiVersion: tekton.dev/v1
+    kind: TaskRun
+    name: %s
+    pipelineTaskName: hello-world-1
+`, prName, namespace, trName))}
+
+	ps := []*v1.Pipeline{simpleHelloWorldPipeline}
+	ts := []*v1.Task{simpleHelloWorldTask}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+		TaskRuns:     trs,
+	}
+	prt := newPipelineRunTest(t, d)
+	defer prt.Cancel()
+
+	// No reactor needed — a PodEvicted TaskRun without retries should NOT trigger
+	// API server verification. The PipelineRun should be marked Failed using the
+	// cached status directly.
+	reconciledRun, clients := prt.reconcileRun(namespace, prName, nil, false)
+
+	// Verify no GET was issued for the TaskRun via the Pipeline clientset
+	for _, action := range clients.Pipeline.Actions() {
+		if action.GetVerb() == "get" && action.GetResource().Resource == "taskruns" {
+			t.Errorf("Expected no API server GET for PodEvicted TaskRun without retries, but got one")
+		}
+	}
+
+	// PipelineRun should be marked Failed — recovery is not possible without a retry
+	condition := reconciledRun.Status.GetCondition(apis.ConditionSucceeded)
+	if condition == nil {
+		t.Fatal("Expected condition on PipelineRun, got nil")
+	}
+	if !condition.IsFalse() {
+		t.Errorf("Expected PipelineRun to be marked Failed for PodEvicted TaskRun without retries, got status %s reason %s", condition.Status, condition.Reason)
+	}
+}
+
+// TestReconcile_PodEvictedRetriesExhaustedSkipsAPIVerification tests that when a TaskRun
+// fails with PodEvicted and its configured retries are already exhausted, no API server
+// verification is performed — the TaskRun cannot retry again, so the live GET cannot
+// change the recovery decision.
+func TestReconcile_PodEvictedRetriesExhaustedSkipsAPIVerification(t *testing.T) {
+	names.TestingSeed()
+
+	namespace := "foo"
+	prName := "test-pipeline-run-podevicted-retries-exhausted"
+	trName := "test-pipeline-run-podevicted-retries-exhausted-hello-world-1"
+
+	// TaskRun is Failed due to pod eviction in informer cache, with its one configured
+	// retry already recorded in RetriesStatus.
+	trs := []*v1.TaskRun{createHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
+		prName, "test-pipeline", "", "hello-world-1",
+		apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  v1.TaskRunReasonPodEvicted.String(),
+			Message: "pod eviction",
+		})}
+	trs[0].Spec.Retries = 1
+	trs[0].Status.RetriesStatus = []v1.TaskRunStatus{{
+		Status: duckv1.Status{
+			Conditions: []apis.Condition{{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionFalse,
+				Reason:  v1.TaskRunReasonPodEvicted.String(),
+				Message: "pod eviction",
+			}},
+		},
+	}}
+
+	// PipelineRun is Running
+	prs := []*v1.PipelineRun{parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  pipelineRef:
+    name: test-pipeline
+  taskRunTemplate:
+    serviceAccountName: test-sa
+status:
+  conditions:
+  - type: Succeeded
+    status: Unknown
+    reason: Running
+  startTime: "2022-01-01T00:00:00Z"
+  childReferences:
+  - apiVersion: tekton.dev/v1
+    kind: TaskRun
+    name: %s
+    pipelineTaskName: hello-world-1
+`, prName, namespace, trName))}
+
+	ps := []*v1.Pipeline{simpleHelloWorldPipeline}
+	ts := []*v1.Task{simpleHelloWorldTask}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+		TaskRuns:     trs,
+	}
+	prt := newPipelineRunTest(t, d)
+	defer prt.Cancel()
+
+	// No reactor needed — a PodEvicted TaskRun with retries exhausted should NOT
+	// trigger API server verification. The PipelineRun should be marked Failed using
+	// the cached status directly.
+	reconciledRun, clients := prt.reconcileRun(namespace, prName, nil, false)
+
+	// Verify no GET was issued for the TaskRun via the Pipeline clientset
+	for _, action := range clients.Pipeline.Actions() {
+		if action.GetVerb() == "get" && action.GetResource().Resource == "taskruns" {
+			t.Errorf("Expected no API server GET for PodEvicted TaskRun with retries exhausted, but got one")
+		}
+	}
+
+	// PipelineRun should be marked Failed — recovery is not possible with retries exhausted
+	condition := reconciledRun.Status.GetCondition(apis.ConditionSucceeded)
+	if condition == nil {
+		t.Fatal("Expected condition on PipelineRun, got nil")
+	}
+	if !condition.IsFalse() {
+		t.Errorf("Expected PipelineRun to be marked Failed for PodEvicted TaskRun with retries exhausted, got status %s reason %s", condition.Status, condition.Reason)
 	}
 }


### PR DESCRIPTION
# Changes

Follow-up to #9640. That change added a live `GET taskruns.tekton.dev`
call whenever the PipelineRun informer cache shows a child TaskRun as
Failed with reason PodEvicted, to guard against stale-cache data
causing premature PipelineRun failure while the TaskRun is still
recovering from eviction.

On current main, a Failed TaskRun can only move back to a non-terminal
state through a retry (see the identical `tr.IsRetriable()` gate used
in pkg/reconciler/taskrun/taskrun.go to decide whether a failed
TaskRun is retried). For a PodEvicted TaskRun with no retries
configured, or with its retries already exhausted, the live GET
cannot change the recovery decision — the final PipelineRun status is
the same Failed outcome either way. The extra GET only adds
API-server load and makes that reconcile depend on API-server
availability for no benefit.

To be precise about impact: this is not a correctness fix. The
PipelineRun's final status for retry-exhausted/non-retriable
PodEvicted TaskRuns is unchanged before and after this change — both
end up Failed. The benefit is narrower: fewer unnecessary API-server
GET calls and no unnecessary availability dependency on that path.

This PR adds a `tr.IsRetriable()` check alongside the existing
PodEvicted condition check in `getTaskRunFunc`, so the live GET
verification only runs when the cached TaskRun still has a retry
available. It updates the four existing recovery tests to set
`Spec.Retries = 1` so they continue to exercise the live-GET path
intentionally, and adds two new tests covering the skip path:
PodEvicted with no retries configured, and PodEvicted with retries
already exhausted.

Validation:

```
go build ./...
go test ./pkg/reconciler/pipelinerun -run 'TestReconcile_(DeferFailureWhenTaskRunRecoveredInAPIServer|ConfirmFailureWhenTaskRunFailedInAPIServer|APIServerErrorReturnsError|TaskRunNotFoundFallsBackToCache|PodEvictedWithoutRetriesSkipsAPIVerification|PodEvictedRetriesExhaustedSkipsAPIVerification|GenericFailedTaskRunSkipsAPIVerification)' -count=1
go test ./pkg/reconciler/pipelinerun/... -count=1
```

All pass.

/kind bug

Fixes #10102

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed the PipelineRun controller performing an unnecessary live
TaskRun GET against the API server when a cached child TaskRun has
failed with reason `PodEvicted` but has no retries left. The
verification GET (added in a prior fix for stale-cache data) is now
only issued when the TaskRun still has a retry available, since that
is the only way a failed TaskRun can recover.
```
