### PR TITLE
apis: reject debug.beforeSteps names not present in inline taskSpec

### DIFF
--- a/pkg/apis/pipeline/v1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation.go
@@ -86,7 +86,7 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(ValidateWorkspaceBindings(ctx, ts.Workspaces).ViaField("workspaces"))
 	if ts.Debug != nil {
 		errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "debug", config.AlphaAPIFields).ViaField("debug"))
-		errs = errs.Also(validateDebug(ts.Debug).ViaField("debug"))
+		errs = errs.Also(validateDebug(ts.Debug, ts.TaskSpec).ViaField("debug"))
 	}
 	if ts.StepSpecs != nil {
 		errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "stepSpecs", config.BetaAPIFields).ViaField("stepSpecs"))
@@ -274,7 +274,9 @@ func combineParamSpec(p ParamSpec, paramSpecForValidation map[string]ParamSpec) 
 
 // validateDebug validates the debug section of the TaskRun.
 // if set, onFailure breakpoint must be "enabled"
-func validateDebug(db *TaskRunDebug) (errs *apis.FieldError) {
+// if taskSpec is provided (i.e. it's inline, not a remote taskRef), beforeSteps entries must
+// name an actual step in the task.
+func validateDebug(db *TaskRunDebug, taskSpec *TaskSpec) (errs *apis.FieldError) {
 	if db == nil || db.Breakpoints == nil {
 		return errs
 	}
@@ -286,12 +288,26 @@ func validateDebug(db *TaskRunDebug) (errs *apis.FieldError) {
 	if db.Breakpoints.OnFailure != "" && db.Breakpoints.OnFailure != EnabledOnFailureBreakpoint {
 		errs = errs.Also(apis.ErrInvalidValue(db.Breakpoints.OnFailure+" is not a valid onFailure breakpoint value, onFailure breakpoint is only allowed to be set as enabled", "breakpoints.onFailure"))
 	}
+
+	// Step names can only be validated when the TaskSpec is inline; a remote taskRef isn't
+	// resolved yet at admission time.
+	var stepNames sets.String
+	if taskSpec != nil {
+		stepNames = sets.NewString()
+		for _, step := range taskSpec.Steps {
+			stepNames.Insert(step.Name)
+		}
+	}
+
 	beforeSteps := sets.NewString()
 	for i, step := range db.Breakpoints.BeforeSteps {
 		if beforeSteps.Has(step) {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("before step must be unique, the same step: %s is defined multiple times at", step), fmt.Sprintf("breakpoints.beforeSteps[%d]", i)))
 		}
 		beforeSteps.Insert(step)
+		if stepNames != nil && !stepNames.Has(step) {
+			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("before step %s does not exist in the task", step), fmt.Sprintf("breakpoints.beforeSteps[%d]", i)))
+		}
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -750,6 +750,25 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wantErr: apis.ErrGeneric("before step must be unique, the same step: step-1 is defined multiple times at", "debug.breakpoints.beforeSteps[1]"),
 		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
+		name: "invalid breakpoint before step not in inline taskSpec",
+		spec: v1.TaskRunSpec{
+			TaskSpec: &v1.TaskSpec{
+				Steps: []v1.Step{{
+					Name:    "step-1",
+					Image:   "ubuntu",
+					Command: []string{"echo"},
+				}},
+			},
+			Debug: &v1.TaskRunDebug{
+				Breakpoints: &v1.TaskBreakpoints{
+					BeforeSteps: []string{"nonexistent-step"},
+					OnFailure:   "enabled",
+				},
+			},
+		},
+		wantErr: apis.ErrInvalidValue("before step nonexistent-step does not exist in the task", "debug.breakpoints.beforeSteps[0]"),
+		wc:      cfgtesting.EnableAlphaAPIFields,
+	}, {
 		name: "empty onFailure breakpoint",
 		spec: v1.TaskRunSpec{
 			TaskRef: &v1.TaskRef{

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -86,7 +86,7 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(ValidateWorkspaceBindings(ctx, ts.Workspaces).ViaField("workspaces"))
 	if ts.Debug != nil {
 		errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "debug", config.AlphaAPIFields).ViaField("debug"))
-		errs = errs.Also(validateDebug(ts.Debug).ViaField("debug"))
+		errs = errs.Also(validateDebug(ts.Debug, ts.TaskSpec).ViaField("debug"))
 	}
 	if ts.StepOverrides != nil {
 		errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "stepOverrides", config.BetaAPIFields).ViaField("stepOverrides"))
@@ -275,7 +275,9 @@ func combineParamSpec(p ParamSpec, paramSpecForValidation map[string]ParamSpec) 
 
 // validateDebug validates the debug section of the TaskRun.
 // if set, onFailure breakpoint must be "enabled"
-func validateDebug(db *TaskRunDebug) (errs *apis.FieldError) {
+// if taskSpec is provided (i.e. it's inline, not a remote taskRef), beforeSteps entries must
+// name an actual step in the task.
+func validateDebug(db *TaskRunDebug, taskSpec *TaskSpec) (errs *apis.FieldError) {
 	if db == nil || db.Breakpoints == nil {
 		return errs
 	}
@@ -287,12 +289,26 @@ func validateDebug(db *TaskRunDebug) (errs *apis.FieldError) {
 	if db.Breakpoints.OnFailure != "" && db.Breakpoints.OnFailure != EnabledOnFailureBreakpoint {
 		errs = errs.Also(apis.ErrInvalidValue(db.Breakpoints.OnFailure+" is not a valid onFailure breakpoint value, onFailure breakpoint is only allowed to be set as enabled", "breakpoints.onFailure"))
 	}
+
+	// Step names can only be validated when the TaskSpec is inline; a remote taskRef isn't
+	// resolved yet at admission time.
+	var stepNames sets.String
+	if taskSpec != nil {
+		stepNames = sets.NewString()
+		for _, step := range taskSpec.Steps {
+			stepNames.Insert(step.Name)
+		}
+	}
+
 	beforeSteps := sets.NewString()
 	for i, step := range db.Breakpoints.BeforeSteps {
 		if beforeSteps.Has(step) {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("before step must be unique, the same step: %s is defined multiple times at", step), fmt.Sprintf("breakpoints.beforeSteps[%d]", i)))
 		}
 		beforeSteps.Insert(step)
+		if stepNames != nil && !stepNames.Has(step) {
+			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("before step %s does not exist in the task", step), fmt.Sprintf("breakpoints.beforeSteps[%d]", i)))
+		}
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -745,6 +745,25 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wantErr: apis.ErrGeneric("before step must be unique, the same step: step-1 is defined multiple times at", "debug.breakpoints.beforeSteps[1]"),
 		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
+		name: "invalid breakpoint before step not in inline taskSpec",
+		spec: v1beta1.TaskRunSpec{
+			TaskSpec: &v1beta1.TaskSpec{
+				Steps: []v1beta1.Step{{
+					Name:    "step-1",
+					Image:   "ubuntu",
+					Command: []string{"echo"},
+				}},
+			},
+			Debug: &v1beta1.TaskRunDebug{
+				Breakpoints: &v1beta1.TaskBreakpoints{
+					BeforeSteps: []string{"nonexistent-step"},
+					OnFailure:   "enabled",
+				},
+			},
+		},
+		wantErr: apis.ErrInvalidValue("before step nonexistent-step does not exist in the task", "debug.breakpoints.beforeSteps[0]"),
+		wc:      cfgtesting.EnableAlphaAPIFields,
+	}, {
 		name: "empty onFailure breakpoint",
 		spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{


### PR DESCRIPTION
Motivation:
`validateDebug` in pkg/apis/pipeline/{v1,v1beta1}/taskrun_validation.go
checked debug.breakpoints.beforeSteps for duplicate entries but never
verified that the named steps actually exist. A TaskRun with a typo'd
step name (e.g. "nonexistant-step") passed webhook validation silently.
At runtime, NeedsDebugBeforeStep compares beforeSteps against the pod's
container names, finds no match, and the breakpoint simply never fires
- with no error or warning surfaced to the user.

Approach:
Thread the TaskRunSpec's inline TaskSpec into validateDebug and reject
any beforeSteps entry that doesn't match a step name declared in that
TaskSpec. When TaskSpec is nil (the TaskRun uses a taskRef, including
remote resolution), the check is skipped, since the webhook cannot see
the resolved Task's steps at admission time - this matches the caveat
called out in the issue itself. v1 and v1beta1 are updated in lockstep
so behavior stays consistent across both API versions.

Since the runtime only ever matches beforeSteps against step container
names (never sidecars), the new validation only considers TaskSpec.Steps,
which mirrors actual runtime semantics.

User-visible behavior is unchanged for TaskRuns that use a taskRef, or
that already reference valid step names. The only change is that a
TaskRun with an inline taskSpec and a typo'd beforeSteps entry is now
rejected at admission with a clear error, instead of being silently
accepted with a breakpoint that never fires.

Validation:
- go build ./...
- go test ./pkg/apis/pipeline/v1/... ./pkg/apis/pipeline/v1beta1/...
  (all existing tests pass; added one new table-driven case per API
  version covering a beforeSteps entry that doesn't match any inline
  step)

/kind bug

```release-note
**TaskRun**: `debug.breakpoints.beforeSteps` entries are now validated
against the inline `taskSpec`'s step names at admission time. A
`beforeSteps` entry that does not match any step in an inline `taskSpec`
is now rejected with a clear error, instead of silently producing a
TaskRun whose breakpoint never fires. Unchanged for TaskRuns using a
`taskRef` (including remote resolution), where the admission webhook
cannot see the resolved step names.
```

Fixes #9720

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>