### PR TITLE
fix(nightlies): restart webhook after CEL feature-flag patch

### DIFF
--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -95,7 +95,12 @@ jobs:
           kubectl patch configmap feature-flags -n tekton-pipelines --patch='
           data:
             enable-cel-in-whenexpression: "true"
-          ' || true
+          '
+
+          # Restart the webhook so it picks up the feature-flag change before
+          # we apply the pipeline (which uses CEL in when expressions).
+          kubectl rollout restart deployment/tekton-pipelines-webhook -n tekton-pipelines
+          kubectl rollout status deployment/tekton-pipelines-webhook -n tekton-pipelines --timeout=60s
 
       - name: Apply Build Pipeline Definition
         run: |


### PR DESCRIPTION
# Changes

Tekton v1.14.1 validates `cel:` expressions in `when` blocks at PipelineRun admission time in addition to Pipeline creation. The admission webhook caches ConfigMap values in memory. In the nightly workflow, only ~1.35 seconds elapsed between `kubectl patch configmap feature-flags` (enabling CEL) and `tkn pipeline start`, so the webhook still had the old cached value and rejected the PipelineRun with `Error: EOF`.

Fix: force a `kubectl rollout restart` of the webhook deployment after patching the feature flag, then wait for it to be ready with `kubectl rollout status--timeout=60s`. This guarantees the new pod loads the updated flag before
validating incoming resources.

Also removes `|| true` from the patch command, a failure to enable the feature flag should be visible, not silently swallowed.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind bug