### PR TITLE
fix(resolvers): honor leader-election bucket ownership

### DIFF
--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -93,8 +93,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return controller.NewPermanentError(err)
 	}
 
+	// Resolver controllers use controller.NewContext directly rather than a
+	// generated reconciler, so they must enforce bucket ownership here.
 	if !r.IsLeaderFor(types.NamespacedName{Namespace: namespace, Name: name}) {
-		return nil
+		return controller.NewSkipKey(key)
 	}
 
 	rr, err := r.resolutionRequestLister.ResolutionRequests(namespace).Get(name)

--- a/pkg/remoteresolution/resolver/framework/reconciler.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler.go
@@ -93,6 +93,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return controller.NewPermanentError(err)
 	}
 
+	if !r.IsLeaderFor(types.NamespacedName{Namespace: namespace, Name: name}) {
+		return nil
+	}
+
 	rr, err := r.resolutionRequestLister.ResolutionRequests(namespace).Get(name)
 	if err != nil {
 		err := &resolutioncommon.GetResourceError{ResolverName: "resolutionrequest", Key: key, Original: err}

--- a/pkg/remoteresolution/resolver/framework/reconciler_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_test.go
@@ -522,6 +522,9 @@ func TestReconcile(t *testing.T) {
 			}
 
 			err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(tc.inputRequest))
+			if tc.notLeader && !controller.IsSkipKey(err) {
+				t.Fatalf("expected non-leader reconciliation to be skipped, got %v", err)
+			}
 			if tc.expectedErr != nil {
 				if err == nil {
 					t.Fatalf("expected to get error %v, but got nothing", tc.expectedErr)
@@ -534,7 +537,7 @@ func TestReconcile(t *testing.T) {
 				}
 			} else {
 				if err != nil {
-					if ok, _ := controller.IsRequeueKey(err); !ok {
+					if ok, _ := controller.IsRequeueKey(err); !ok && !(tc.notLeader && controller.IsSkipKey(err)) {
 						t.Fatalf("did not expect an error, but got %v", err)
 					}
 				}

--- a/pkg/remoteresolution/resolver/framework/reconciler_test.go
+++ b/pkg/remoteresolution/resolver/framework/reconciler_test.go
@@ -67,6 +67,7 @@ func TestReconcile(t *testing.T) {
 		expectedStatus    *v1beta1.ResolutionRequestStatus
 		expectedErr       error
 		transient         bool
+		notLeader         bool
 	}{
 		{
 			name: "known value",
@@ -423,6 +424,22 @@ func TestReconcile(t *testing.T) {
 			expectedErr:       errors.New("context deadline exceeded"),
 			transient:         true,
 		}, {
+			name: "non-leader skips resolution",
+			inputRequest: &v1beta1.ResolutionRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "rr", Namespace: "foo"},
+				Spec: v1beta1.ResolutionRequestSpec{
+					Params: []pipelinev1.Param{{
+						Name:  resolutionframework.FakeParamName,
+						Value: *pipelinev1.NewStructuredValues("bar"),
+					}},
+				},
+			},
+			paramMap: map[string]*resolutionframework.FakeResolvedResource{
+				"bar": {ErrorWith: "resolver should not have been called"},
+			},
+			expectedStatus: &v1beta1.ResolutionRequestStatus{},
+			notLeader:      true,
+		}, {
 			name: "resolved but not yet done should skip re-resolution",
 			inputRequest: &v1beta1.ResolutionRequest{
 				TypeMeta: metav1.TypeMeta{
@@ -499,6 +516,10 @@ func TestReconcile(t *testing.T) {
 			ctx, _ := ttesting.SetupFakeContext(t)
 			testAssets, cancel := getResolverFrameworkController(ctx, t, d, fakeResolver, setClockOnReconciler)
 			defer cancel()
+
+			if tc.notLeader {
+				testAssets.Controller.Reconciler.(pkgreconciler.LeaderAware).Demote(pkgreconciler.UniversalBucket())
+			}
 
 			err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(tc.inputRequest))
 			if tc.expectedErr != nil {

--- a/pkg/resolution/resolver/framework/reconciler.go
+++ b/pkg/resolution/resolver/framework/reconciler.go
@@ -96,6 +96,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return controller.NewPermanentError(err)
 	}
 
+	if !r.IsLeaderFor(types.NamespacedName{Namespace: namespace, Name: name}) {
+		return nil
+	}
+
 	rr, err := r.resolutionRequestLister.ResolutionRequests(namespace).Get(name)
 	if err != nil {
 		err := &resolutioncommon.GetResourceError{ResolverName: "resolutionrequest", Key: key, Original: err}

--- a/pkg/resolution/resolver/framework/reconciler.go
+++ b/pkg/resolution/resolver/framework/reconciler.go
@@ -96,8 +96,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return controller.NewPermanentError(err)
 	}
 
+	// Resolver controllers use controller.NewContext directly rather than a
+	// generated reconciler, so they must enforce bucket ownership here.
 	if !r.IsLeaderFor(types.NamespacedName{Namespace: namespace, Name: name}) {
-		return nil
+		return controller.NewSkipKey(key)
 	}
 
 	rr, err := r.resolutionRequestLister.ResolutionRequests(namespace).Get(name)

--- a/pkg/resolution/resolver/framework/reconciler_test.go
+++ b/pkg/resolution/resolver/framework/reconciler_test.go
@@ -65,6 +65,7 @@ func TestReconcile(t *testing.T) {
 		reconcilerTimeout time.Duration
 		expectedStatus    *v1beta1.ResolutionRequestStatus
 		expectedErr       error
+		notLeader         bool
 	}{
 		{
 			name: "unknown value",
@@ -210,6 +211,22 @@ func TestReconcile(t *testing.T) {
 			reconcilerTimeout: 1 * time.Second,
 			expectedErr:       errors.New("context deadline exceeded"),
 		}, {
+			name: "non-leader skips resolution",
+			inputRequest: &v1beta1.ResolutionRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "rr", Namespace: "foo"},
+				Spec: v1beta1.ResolutionRequestSpec{
+					Params: []pipelinev1.Param{{
+						Name:  framework.FakeParamName,
+						Value: *pipelinev1.NewStructuredValues("bar"),
+					}},
+				},
+			},
+			paramMap: map[string]*framework.FakeResolvedResource{
+				"bar": {ErrorWith: "resolver should not have been called"},
+			},
+			expectedStatus: &v1beta1.ResolutionRequestStatus{},
+			notLeader:      true,
+		}, {
 			name: "resolved but not yet done should skip re-resolution",
 			inputRequest: &v1beta1.ResolutionRequest{
 				TypeMeta: metav1.TypeMeta{
@@ -279,6 +296,10 @@ func TestReconcile(t *testing.T) {
 			ctx, _ := ttesting.SetupFakeContext(t)
 			testAssets, cancel := getResolverFrameworkController(ctx, t, d, fakeResolver, setClockOnReconciler)
 			defer cancel()
+
+			if tc.notLeader {
+				testAssets.Controller.Reconciler.(pkgreconciler.LeaderAware).Demote(pkgreconciler.UniversalBucket())
+			}
 
 			err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(tc.inputRequest))
 			if tc.expectedErr != nil {

--- a/pkg/resolution/resolver/framework/reconciler_test.go
+++ b/pkg/resolution/resolver/framework/reconciler_test.go
@@ -302,6 +302,9 @@ func TestReconcile(t *testing.T) {
 			}
 
 			err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(tc.inputRequest))
+			if tc.notLeader && !controller.IsSkipKey(err) {
+				t.Fatalf("expected non-leader reconciliation to be skipped, got %v", err)
+			}
 			if tc.expectedErr != nil {
 				if err == nil {
 					t.Fatalf("expected to get error %v, but got nothing", tc.expectedErr)
@@ -311,7 +314,7 @@ func TestReconcile(t *testing.T) {
 				}
 			} else {
 				if err != nil {
-					if ok, _ := controller.IsRequeueKey(err); !ok {
+					if ok, _ := controller.IsRequeueKey(err); !ok && !(tc.notLeader && controller.IsSkipKey(err)) {
 						t.Fatalf("did not expect an error, but got %v", err)
 					}
 				}

--- a/test/resolver_cache_test.go
+++ b/test/resolver_cache_test.go
@@ -84,7 +84,7 @@ func TestBundleResolverCache(t *testing.T) {
 }
 
 // @test:execution=serial
-// @test:reason=scales the shared resolver deployment to 4 replicas, causing concurrent cache tests to see 4 registry fetches instead of the expected 1
+// @test:reason=scales the shared resolver deployment to 4 replicas to verify leader election prevents duplicate registry fetches
 // @test:tags=resolver,cache,replicas
 func TestBundleResolverCacheWithFourResolverReplicas(t *testing.T) {
 	ctx := t.Context()
@@ -95,7 +95,8 @@ func TestBundleResolverCacheWithFourResolverReplicas(t *testing.T) {
 	// GIVEN
 	replicas := 4
 	taskRunCount := 80
-	expectedRequests := replicas
+	// Only the replica that owns the ResolutionRequest bucket should populate its cache.
+	expectedRequests := 1
 	task := newHelloWorldTask(t, helpers.ObjectNameForTest(t), namespace)
 	repoName := "test-" + task.Name
 	repo := getRegistryServiceIP(ctx, t, c, namespace) + ":5000/" + repoName


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Resolver controllers embed Knative leader-aware state, but their handwritten reconcile loops did not check whether the current replica owned the request's bucket. Because each replica receives informer events, non-owner replicas could resolve and patch the same `ResolutionRequest`.

- Check `IsLeaderFor` before lister lookup and resolution in both resolver framework implementations.
- Return Knative's skip-key signal for non-owner work.
- Add regression coverage proving a non-owner does not invoke the resolver or modify request status.
- Update multi-replica cache coverage to expect only the owning replica to fetch from the registry.

This complements #10114, which prevents re-resolution after request data becomes visible.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix resolver replicas processing ResolutionRequests outside their leader-election bucket.
```
