### PR TITLE
fix(resolutionrequest): preserve resolver-written status fields

### DIFF
--- a/pkg/reconciler/resolutionrequest/controller.go
+++ b/pkg/reconciler/resolutionrequest/controller.go
@@ -42,11 +42,11 @@ func NewController(clock clock.PassiveClock) func(ctx context.Context, cmw confi
 			client: resolutionclient.Get(ctx),
 			clock:  clock,
 		}
-		// ResolutionRequest status is shared with resolver controllers, so avoid
-		// generated whole-status updates.
 		impl := resolutionrequestreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
 			return controller.Options{
-				ConfigStore:       configStore,
+				ConfigStore: configStore,
+				// ResolutionRequest status is shared with resolver controllers, so avoid
+				// generated whole-status updates.
 				SkipStatusUpdates: true,
 			}
 		})

--- a/pkg/reconciler/resolutionrequest/controller.go
+++ b/pkg/reconciler/resolutionrequest/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	resolutionclient "github.com/tektoncd/pipeline/pkg/client/resolution/injection/client"
 	resolutionrequestinformer "github.com/tektoncd/pipeline/pkg/client/resolution/injection/informers/resolution/v1beta1/resolutionrequest"
 	resolutionrequestreconciler "github.com/tektoncd/pipeline/pkg/client/resolution/injection/reconciler/resolution/v1beta1/resolutionrequest"
 	"k8s.io/utils/clock"
@@ -38,11 +39,15 @@ func NewController(clock clock.PassiveClock) func(ctx context.Context, cmw confi
 		configStore.WatchConfigs(cmw)
 
 		r := &Reconciler{
-			clock: clock,
+			client: resolutionclient.Get(ctx),
+			clock:  clock,
 		}
+		// ResolutionRequest status is shared with resolver controllers, so avoid
+		// generated whole-status updates.
 		impl := resolutionrequestreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
 			return controller.Options{
-				ConfigStore: configStore,
+				ConfigStore:       configStore,
+				SkipStatusUpdates: true,
 			}
 		})
 

--- a/pkg/reconciler/resolutionrequest/resolutionrequest.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest.go
@@ -18,15 +18,21 @@ package resolutionrequest
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
+	resolutionclientset "github.com/tektoncd/pipeline/pkg/client/resolution/clientset/versioned"
 	rrreconciler "github.com/tektoncd/pipeline/pkg/client/resolution/injection/reconciler/resolution/v1beta1/resolutionrequest"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
 )
@@ -34,7 +40,8 @@ import (
 // Reconciler is a knative reconciler for processing ResolutionRequest
 // objects
 type Reconciler struct {
-	clock clock.PassiveClock
+	client resolutionclientset.Interface
+	clock  clock.PassiveClock
 }
 
 var _ rrreconciler.Interface = (*Reconciler)(nil)
@@ -46,6 +53,21 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, rr *v1beta1.ResolutionRe
 		return nil
 	}
 
+	original := rr.DeepCopy()
+	reconciler.PreProcessReconcile(ctx, rr)
+	event := r.reconcile(ctx, rr)
+	reconciler.PostProcessReconcile(ctx, rr, original)
+
+	if equality.Semantic.DeepEqual(lifecycleStatus(original), lifecycleStatus(rr)) {
+		return event
+	}
+	if err := r.patchLifecycleStatus(ctx, rr); err != nil {
+		return err
+	}
+	return event
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, rr *v1beta1.ResolutionRequest) reconciler.Event {
 	if rr.IsDone() {
 		return nil
 	}
@@ -66,6 +88,32 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, rr *v1beta1.ResolutionRe
 	}
 
 	return nil
+}
+
+// lifecycleStatusPatch intentionally excludes resolver-owned payload fields and annotations.
+type lifecycleStatusPatch struct {
+	Metadata map[string]string `json:"metadata"`
+	Status   duckv1.Status     `json:"status"`
+}
+
+func lifecycleStatus(rr *v1beta1.ResolutionRequest) duckv1.Status {
+	return duckv1.Status{
+		ObservedGeneration: rr.Status.ObservedGeneration,
+		Conditions:         rr.Status.Conditions,
+	}
+}
+
+func (r *Reconciler) patchLifecycleStatus(ctx context.Context, rr *v1beta1.ResolutionRequest) error {
+	patchBytes, err := json.Marshal(lifecycleStatusPatch{
+		Metadata: map[string]string{"resourceVersion": rr.ResourceVersion},
+		Status:   lifecycleStatus(rr),
+	})
+	if err != nil {
+		return err
+	}
+	_, err = r.client.ResolutionV1beta1().ResolutionRequests(rr.Namespace).Patch(
+		ctx, rr.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+	return err
 }
 
 // requestDuration returns the amount of time that has passed since a

--- a/pkg/reconciler/resolutionrequest/resolutionrequest.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest.go
@@ -28,6 +28,7 @@ import (
 	rrreconciler "github.com/tektoncd/pipeline/pkg/client/resolution/injection/reconciler/resolution/v1beta1/resolutionrequest"
 	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock"
@@ -62,6 +63,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, rr *v1beta1.ResolutionRe
 		return event
 	}
 	if err := r.patchLifecycleStatus(ctx, rr); err != nil {
+		if apierrors.IsConflict(err) {
+			return controller.NewRequeueAfter(0)
+		}
 		return err
 	}
 	return event

--- a/pkg/reconciler/resolutionrequest/resolutionrequest.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest.go
@@ -38,9 +38,11 @@ import (
 	"knative.dev/pkg/reconciler"
 )
 
-// Reconciler is a knative reconciler for processing ResolutionRequest
-// objects
+// Reconciler is a knative reconciler for processing ResolutionRequest objects.
+// It patches lifecycle-owned status fields itself and must be configured with
+// SkipStatusUpdates so generated updates do not overwrite resolver-owned fields.
 type Reconciler struct {
+	// client applies lifecycle-only status patches.
 	client resolutionclientset.Interface
 	clock  clock.PassiveClock
 }
@@ -64,9 +66,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, rr *v1beta1.ResolutionRe
 	}
 	if err := r.patchLifecycleStatus(ctx, rr); err != nil {
 		if apierrors.IsConflict(err) {
+			// RetryUpdateConflicts would replay lifecycle status derived from this
+			// stale object. Requeue so lifecycle status is recomputed from fresh state.
 			return controller.NewRequeueAfter(0)
 		}
-		return err
+		return fmt.Errorf("failed to update resource lifecycle status: %w", err)
 	}
 	return event
 }

--- a/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
@@ -232,8 +232,8 @@ func TestReconcilePreservesResolverStatusOnConflict(t *testing.T) {
 	})
 
 	err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input))
-	if !apierrors.IsConflict(err) {
-		t.Fatalf("first reconcile error = %v, want conflict", err)
+	if ok, delay := controller.IsRequeueKey(err); !ok || delay != 0 {
+		t.Fatalf("first reconcile result = %v, want immediate requeue", err)
 	}
 
 	latest, err := testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
@@ -282,8 +282,8 @@ func TestReconcilePreservesResolverFailureOnConflict(t *testing.T) {
 	})
 
 	err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input))
-	if !apierrors.IsConflict(err) {
-		t.Fatalf("first reconcile error = %v, want conflict", err)
+	if ok, delay := controller.IsRequeueKey(err); !ok || delay != 0 {
+		t.Fatalf("first reconcile result = %v, want immediate requeue", err)
 	}
 	latest, err := testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
@@ -199,14 +199,12 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func TestReconcilePreservesResolverStatusOnConflict(t *testing.T) {
+func TestReconcileWrapsLifecycleStatusError(t *testing.T) {
 	input := &v1beta1.ResolutionRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "rr",
 			Namespace:         "foo",
 			CreationTimestamp: metav1.Now(),
-			Generation:        1,
-			ResourceVersion:   "1",
 		},
 	}
 	d := test.Data{
@@ -216,6 +214,15 @@ func TestReconcilePreservesResolverStatusOnConflict(t *testing.T) {
 	testAssets, cancel := getResolutionRequestController(t, d)
 	defer cancel()
 
+	testAssets.Clients.ResolutionRequests.PrependReactor("patch", "resolutionrequests", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("write failed")
+	})
+	if err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input)); err == nil || err.Error() != "failed to update resource lifecycle status: write failed" {
+		t.Fatalf("Reconcile() error = %v, want wrapped lifecycle status error", err)
+	}
+}
+
+func TestReconcilePreservesResolverStatusOnConflict(t *testing.T) {
 	wantFields := v1beta1.ResolutionRequestStatusFields{
 		Data: "resolved data",
 		Source: &pipelinev1.RefSource{
@@ -226,82 +233,82 @@ func TestReconcilePreservesResolverStatusOnConflict(t *testing.T) {
 		},
 	}
 	wantAnnotations := map[string]string{"resolver.example/cache": "hit"}
-	prependConcurrentStatusUpdate(t, testAssets, input, func(latest *v1beta1.ResolutionRequest) {
-		latest.Status.ResolutionRequestStatusFields = wantFields
-		latest.Status.Annotations = wantAnnotations
-	})
-
-	err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input))
-	if ok, delay := controller.IsRequeueKey(err); !ok || delay != 0 {
-		t.Fatalf("first reconcile result = %v, want immediate requeue", err)
-	}
-
-	latest, err := testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("get ResolutionRequest after conflict: %v", err)
-	}
-	assertResolverStatus(t, latest, wantFields, wantAnnotations)
-	if err := testAssets.Informers.ResolutionRequest.Informer().GetIndexer().Update(latest.DeepCopy()); err != nil {
-		t.Fatalf("update ResolutionRequest informer: %v", err)
-	}
-
-	if err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input)); err != nil {
-		t.Fatalf("second reconcile: %v", err)
-	}
-	latest, err = testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("get reconciled ResolutionRequest: %v", err)
-	}
-	assertResolverStatus(t, latest, wantFields, wantAnnotations)
-	if condition := latest.Status.GetCondition(apis.ConditionSucceeded); condition == nil || condition.Status != corev1.ConditionTrue {
-		t.Fatalf("Succeeded condition = %#v, want True", condition)
-	}
-}
-
-func TestReconcilePreservesResolverFailureOnConflict(t *testing.T) {
-	input := &v1beta1.ResolutionRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "rr",
-			Namespace:         "foo",
-			CreationTimestamp: metav1.Now(),
-			Generation:        1,
-			ResourceVersion:   "1",
+	testCases := []struct {
+		name                string
+		concurrentUpdate    func(*v1beta1.ResolutionRequest)
+		assertPreserved     func(*testing.T, *v1beta1.ResolutionRequest)
+		wantConditionStatus corev1.ConditionStatus
+	}{
+		{
+			name: "resolver payload",
+			concurrentUpdate: func(latest *v1beta1.ResolutionRequest) {
+				latest.Status.ResolutionRequestStatusFields = wantFields
+				latest.Status.Annotations = wantAnnotations
+			},
+			assertPreserved: func(t *testing.T, latest *v1beta1.ResolutionRequest) {
+				t.Helper()
+				assertResolverStatus(t, latest, wantFields, wantAnnotations)
+			},
+			wantConditionStatus: corev1.ConditionTrue,
+		},
+		{
+			name: "resolver failure",
+			concurrentUpdate: func(latest *v1beta1.ResolutionRequest) {
+				latest.Status.ObservedGeneration = latest.Generation
+				latest.Status.InitializeConditions()
+				latest.Status.MarkFailed("ResolverFailed", "resolver failed")
+			},
+			assertPreserved:     assertResolverFailure,
+			wantConditionStatus: corev1.ConditionFalse,
 		},
 	}
-	d := test.Data{
-		ResolutionRequests: []*v1beta1.ResolutionRequest{input},
-		ConfigMaps:         th.NewDefaultsCofigMapInSlice(),
-	}
-	testAssets, cancel := getResolutionRequestController(t, d)
-	defer cancel()
 
-	prependConcurrentStatusUpdate(t, testAssets, input, func(latest *v1beta1.ResolutionRequest) {
-		latest.Status.ObservedGeneration = latest.Generation
-		latest.Status.InitializeConditions()
-		latest.Status.MarkFailed("ResolverFailed", "resolver failed")
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := &v1beta1.ResolutionRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "rr",
+					Namespace:         "foo",
+					CreationTimestamp: metav1.Now(),
+					Generation:        1,
+					ResourceVersion:   "1",
+				},
+			}
+			d := test.Data{
+				ResolutionRequests: []*v1beta1.ResolutionRequest{input},
+				ConfigMaps:         th.NewDefaultsCofigMapInSlice(),
+			}
+			testAssets, cancel := getResolutionRequestController(t, d)
+			defer cancel()
 
-	err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input))
-	if ok, delay := controller.IsRequeueKey(err); !ok || delay != 0 {
-		t.Fatalf("first reconcile result = %v, want immediate requeue", err)
-	}
-	latest, err := testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("get ResolutionRequest after conflict: %v", err)
-	}
-	assertResolverFailure(t, latest)
-	if err := testAssets.Informers.ResolutionRequest.Informer().GetIndexer().Update(latest.DeepCopy()); err != nil {
-		t.Fatalf("update ResolutionRequest informer: %v", err)
-	}
+			prependConcurrentStatusUpdate(t, testAssets, input, tc.concurrentUpdate)
+			err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input))
+			if ok, delay := controller.IsRequeueKey(err); !ok || delay != 0 {
+				t.Fatalf("first reconcile result = %v, want immediate requeue", err)
+			}
 
-	if err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input)); err != nil {
-		t.Fatalf("second reconcile: %v", err)
+			latest, err := testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get ResolutionRequest after conflict: %v", err)
+			}
+			tc.assertPreserved(t, latest)
+			if err := testAssets.Informers.ResolutionRequest.Informer().GetIndexer().Update(latest.DeepCopy()); err != nil {
+				t.Fatalf("update ResolutionRequest informer: %v", err)
+			}
+
+			if err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input)); err != nil {
+				t.Fatalf("second reconcile: %v", err)
+			}
+			latest, err = testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get reconciled ResolutionRequest: %v", err)
+			}
+			tc.assertPreserved(t, latest)
+			if condition := latest.Status.GetCondition(apis.ConditionSucceeded); condition == nil || condition.Status != tc.wantConditionStatus {
+				t.Fatalf("Succeeded condition = %#v, want %s", condition, tc.wantConditionStatus)
+			}
+		})
 	}
-	latest, err = testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("get reconciled ResolutionRequest: %v", err)
-	}
-	assertResolverFailure(t, latest)
 }
 
 func prependConcurrentStatusUpdate(t *testing.T, testAssets test.Assets, input *v1beta1.ResolutionRequest, update func(*v1beta1.ResolutionRequest)) {

--- a/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
@@ -18,6 +18,8 @@ package resolutionrequest
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -25,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
 	th "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
@@ -33,8 +36,11 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 	"knative.dev/pkg/apis"
@@ -190,6 +196,182 @@ func TestReconcile(t *testing.T) {
 				t.Errorf("ResolutionRequest status doesn't match %s", diff.PrintWantGot(d))
 			}
 		})
+	}
+}
+
+func TestReconcilePreservesResolverStatusOnConflict(t *testing.T) {
+	input := &v1beta1.ResolutionRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "rr",
+			Namespace:         "foo",
+			CreationTimestamp: metav1.Now(),
+			Generation:        1,
+			ResourceVersion:   "1",
+		},
+	}
+	d := test.Data{
+		ResolutionRequests: []*v1beta1.ResolutionRequest{input},
+		ConfigMaps:         th.NewDefaultsCofigMapInSlice(),
+	}
+	testAssets, cancel := getResolutionRequestController(t, d)
+	defer cancel()
+
+	wantFields := v1beta1.ResolutionRequestStatusFields{
+		Data: "resolved data",
+		Source: &pipelinev1.RefSource{
+			URI: "source",
+		},
+		RefSource: &pipelinev1.RefSource{
+			URI: "ref-source",
+		},
+	}
+	wantAnnotations := map[string]string{"resolver.example/cache": "hit"}
+	prependConcurrentStatusUpdate(t, testAssets, input, func(latest *v1beta1.ResolutionRequest) {
+		latest.Status.ResolutionRequestStatusFields = wantFields
+		latest.Status.Annotations = wantAnnotations
+	})
+
+	err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input))
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("first reconcile error = %v, want conflict", err)
+	}
+
+	latest, err := testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ResolutionRequest after conflict: %v", err)
+	}
+	assertResolverStatus(t, latest, wantFields, wantAnnotations)
+	if err := testAssets.Informers.ResolutionRequest.Informer().GetIndexer().Update(latest.DeepCopy()); err != nil {
+		t.Fatalf("update ResolutionRequest informer: %v", err)
+	}
+
+	if err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input)); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	latest, err = testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get reconciled ResolutionRequest: %v", err)
+	}
+	assertResolverStatus(t, latest, wantFields, wantAnnotations)
+	if condition := latest.Status.GetCondition(apis.ConditionSucceeded); condition == nil || condition.Status != corev1.ConditionTrue {
+		t.Fatalf("Succeeded condition = %#v, want True", condition)
+	}
+}
+
+func TestReconcilePreservesResolverFailureOnConflict(t *testing.T) {
+	input := &v1beta1.ResolutionRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "rr",
+			Namespace:         "foo",
+			CreationTimestamp: metav1.Now(),
+			Generation:        1,
+			ResourceVersion:   "1",
+		},
+	}
+	d := test.Data{
+		ResolutionRequests: []*v1beta1.ResolutionRequest{input},
+		ConfigMaps:         th.NewDefaultsCofigMapInSlice(),
+	}
+	testAssets, cancel := getResolutionRequestController(t, d)
+	defer cancel()
+
+	prependConcurrentStatusUpdate(t, testAssets, input, func(latest *v1beta1.ResolutionRequest) {
+		latest.Status.ObservedGeneration = latest.Generation
+		latest.Status.InitializeConditions()
+		latest.Status.MarkFailed("ResolverFailed", "resolver failed")
+	})
+
+	err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input))
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("first reconcile error = %v, want conflict", err)
+	}
+	latest, err := testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ResolutionRequest after conflict: %v", err)
+	}
+	assertResolverFailure(t, latest)
+	if err := testAssets.Informers.ResolutionRequest.Informer().GetIndexer().Update(latest.DeepCopy()); err != nil {
+		t.Fatalf("update ResolutionRequest informer: %v", err)
+	}
+
+	if err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRequestName(input)); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	latest, err = testAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(input.Namespace).Get(testAssets.Ctx, input.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get reconciled ResolutionRequest: %v", err)
+	}
+	assertResolverFailure(t, latest)
+}
+
+func prependConcurrentStatusUpdate(t *testing.T, testAssets test.Assets, input *v1beta1.ResolutionRequest, update func(*v1beta1.ResolutionRequest)) {
+	t.Helper()
+	gvr := v1beta1.SchemeGroupVersion.WithResource("resolutionrequests")
+	injected := false
+	testAssets.Clients.ResolutionRequests.PrependReactor("patch", "resolutionrequests", func(action ktesting.Action) (bool, runtime.Object, error) {
+		patchAction := action.(ktesting.PatchAction)
+		if got := patchAction.GetSubresource(); got != "status" {
+			t.Fatalf("patch subresource = %q, want status", got)
+		}
+
+		var patch struct {
+			Metadata map[string]json.RawMessage `json:"metadata"`
+			Status   map[string]json.RawMessage `json:"status"`
+		}
+		if err := json.Unmarshal(patchAction.GetPatch(), &patch); err != nil {
+			t.Fatalf("unmarshal status patch: %v", err)
+		}
+		if len(patch.Metadata) != 1 || patch.Metadata["resourceVersion"] == nil {
+			t.Fatalf("metadata patch = %s, want only resourceVersion", patchAction.GetPatch())
+		}
+		if len(patch.Status) != 2 || patch.Status["conditions"] == nil || patch.Status["observedGeneration"] == nil {
+			t.Fatalf("status patch = %s, want only conditions and observedGeneration", patchAction.GetPatch())
+		}
+		var patchResourceVersion string
+		if err := json.Unmarshal(patch.Metadata["resourceVersion"], &patchResourceVersion); err != nil {
+			t.Fatalf("unmarshal patch resourceVersion: %v", err)
+		}
+
+		if !injected {
+			injected = true
+			obj, err := testAssets.Clients.ResolutionRequests.Tracker().Get(gvr, input.Namespace, input.Name)
+			if err != nil {
+				t.Fatalf("get tracked ResolutionRequest: %v", err)
+			}
+			latest := obj.(*v1beta1.ResolutionRequest).DeepCopy()
+			latest.ResourceVersion = "2"
+			update(latest)
+			if err := testAssets.Clients.ResolutionRequests.Tracker().Update(gvr, latest, input.Namespace); err != nil {
+				t.Fatalf("inject resolver status: %v", err)
+			}
+		}
+
+		obj, err := testAssets.Clients.ResolutionRequests.Tracker().Get(gvr, input.Namespace, input.Name)
+		if err != nil {
+			t.Fatalf("get current ResolutionRequest: %v", err)
+		}
+		if currentResourceVersion := obj.(*v1beta1.ResolutionRequest).ResourceVersion; patchResourceVersion != currentResourceVersion {
+			return true, nil, apierrors.NewConflict(gvr.GroupResource(), input.Name, errors.New("resourceVersion changed"))
+		}
+		return false, nil, nil
+	})
+}
+
+func assertResolverFailure(t *testing.T, rr *v1beta1.ResolutionRequest) {
+	t.Helper()
+	condition := rr.Status.GetCondition(apis.ConditionSucceeded)
+	if condition == nil || condition.Status != corev1.ConditionFalse || condition.Reason != "ResolverFailed" || condition.Message != "resolver failed" {
+		t.Errorf("Succeeded condition = %#v, want resolver failure", condition)
+	}
+}
+
+func assertResolverStatus(t *testing.T, rr *v1beta1.ResolutionRequest, wantFields v1beta1.ResolutionRequestStatusFields, wantAnnotations map[string]string) {
+	t.Helper()
+	if d := cmp.Diff(wantFields, rr.Status.ResolutionRequestStatusFields); d != "" {
+		t.Errorf("resolver status fields changed (-want, +got): %s", d)
+	}
+	if d := cmp.Diff(wantAnnotations, rr.Status.Annotations); d != "" {
+		t.Errorf("resolver status annotations changed (-want, +got): %s", d)
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The ResolutionRequest lifecycle controller and resolver controllers share the status subresource. When a lifecycle status update conflicts with a resolver update, the generated conflict retry can fetch the latest object and then replace its status with an older desired status, removing resolver-written data, source fields, and annotations.

- Disable generated whole-status updates for the ResolutionRequest lifecycle controller.
- Patch only lifecycle-owned conditions and observed generation, guarded by the reconciled resource version.
- Requeue conflicts for a fresh reconciliation without reporting them as internal errors.
- Preserve Knative condition initialization, transition-time, and observed-generation processing.
- Add deterministic conflict tests covering resolved payload fields, status annotations, and terminal resolver failures.

This complements #10114 and #10480 by preventing lifecycle status updates from removing data after resolution.

Validated with:

- `go test -count=20 ./pkg/reconciler/resolutionrequest`
- `go test ./pkg/reconciler/resolutionrequest ./pkg/resolution/resolver/framework ./pkg/remoteresolution/resolver/framework`
- `go test -race ./pkg/reconciler/resolutionrequest ./pkg/resolution/resolver/framework ./pkg/remoteresolution/resolver/framework`
- `go test -tags=e2e ./test -run '^$'`
- 500-run cluster A/B: data clears fell from 239 to 0; all PipelineRuns and ResolutionRequests succeeded; ResolutionRequest conflict errors/events remained at 0

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Prevent ResolutionRequest lifecycle updates from overwriting resolver-written status fields.
```