### PR TITLE
[release-v1.6.x] Fix PipelineRun stuck in ResolvingTaskRef when RR enqueue is missed

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -152,6 +153,12 @@ const (
 	taskRun     = pipeline.TaskRunControllerName
 	customRun   = pipeline.CustomRunControllerName
 	pipelineRun = pipeline.PipelineRunControllerName
+
+	// remoteResolutionRequeueAfter is how long to wait before re-reconciling a
+	// PipelineRun that is awaiting an in-progress ResolutionRequest. Periodic
+	// requeue ensures progress even if the ResolutionRequest completion event
+	// is missed or cannot be mapped back via owner references (see #10414).
+	remoteResolutionRequeueAfter = time.Second
 )
 
 // Reconciler implements controller.Reconciler for Configuration resources.
@@ -473,7 +480,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("PipelineRun %s/%s awaiting remote resource", pr.Namespace, pr.Name)
 		pr.Status.MarkRunning(v1.PipelineRunReasonResolvingPipelineRef.String(), message)
-		return nil
+		return controller.NewRequeueAfter(remoteResolutionRequeueAfter)
 	case errors.Is(err, apiserver.ErrReferencedObjectValidationFailed), errors.Is(err, apiserver.ErrCouldntValidateObjectPermanent):
 		logger.Errorf("Failed dryRunValidation for PipelineRun %s: %v", pr.Name, err)
 		pr.Status.MarkFailed(v1.PipelineRunReasonFailedValidation.String(),
@@ -660,7 +667,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("PipelineRun %s/%s awaiting remote resource", pr.Namespace, pr.Name)
 		pr.Status.MarkRunning(v1.TaskRunReasonResolvingTaskRef, message)
-		return nil
+		return controller.NewRequeueAfter(remoteResolutionRequeueAfter)
 	case err != nil:
 		return err
 	default:
@@ -672,7 +679,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("PipelineRun %s/%s awaiting remote resource", pr.Namespace, pr.Name)
 		pr.Status.MarkRunning(v1.TaskRunReasonResolvingTaskRef, message)
-		return nil
+		return controller.NewRequeueAfter(remoteResolutionRequeueAfter)
 	case err != nil:
 		return err
 	default:

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -9180,8 +9180,16 @@ spec:
 	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
-	wantEvents := []string(nil)
-	pipelinerun, _ := prt.reconcileRun(pr.Namespace, pr.Name, wantEvents, false)
+	reconcileError := prt.TestAssets.Controller.Reconciler.Reconcile(prt.TestAssets.Ctx, pr.Namespace+"/"+pr.Name)
+	if ok, duration := controller.IsRequeueKey(reconcileError); !ok {
+		t.Fatalf("expected requeue while awaiting remote PipelineRef resolution, got: %v", reconcileError)
+	} else if duration != remoteResolutionRequeueAfter {
+		t.Fatalf("expected requeue after %v, got %v", remoteResolutionRequeueAfter, duration)
+	}
+	pipelinerun, err := prt.TestAssets.Clients.Pipeline.TektonV1().PipelineRuns(pr.Namespace).Get(prt.TestAssets.Ctx, pr.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting reconciled PipelineRun: %v", err)
+	}
 	th.CheckPipelineRunConditionStatusAndReason(t, pipelinerun.Status, corev1.ConditionUnknown, v1.PipelineRunReasonResolvingPipelineRef.String())
 
 	client := prt.TestAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests("default")
@@ -9467,8 +9475,16 @@ spec:
 	prt := newPipelineRunTest(t, d)
 	defer prt.Cancel()
 
-	wantEvents := []string(nil)
-	pipelinerun, _ := prt.reconcileRun(pr.Namespace, pr.Name, wantEvents, false)
+	reconcileError := prt.TestAssets.Controller.Reconciler.Reconcile(prt.TestAssets.Ctx, pr.Namespace+"/"+pr.Name)
+	if ok, duration := controller.IsRequeueKey(reconcileError); !ok {
+		t.Fatalf("expected requeue while awaiting remote TaskRef resolution, got: %v", reconcileError)
+	} else if duration != remoteResolutionRequeueAfter {
+		t.Fatalf("expected requeue after %v, got %v", remoteResolutionRequeueAfter, duration)
+	}
+	pipelinerun, err := prt.TestAssets.Clients.Pipeline.TektonV1().PipelineRuns(pr.Namespace).Get(prt.TestAssets.Ctx, pr.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting reconciled PipelineRun: %v", err)
+	}
 	th.CheckPipelineRunConditionStatusAndReason(t, pipelinerun.Status, corev1.ConditionUnknown, v1.TaskRunReasonResolvingTaskRef)
 
 	client := prt.TestAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests("default")

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -99,6 +99,14 @@ type Reconciler struct {
 
 const ImagePullBackOff = "ImagePullBackOff"
 
+const (
+	// remoteResolutionRequeueAfter is how long to wait before re-reconciling a
+	// TaskRun that is awaiting an in-progress ResolutionRequest. Periodic
+	// requeue ensures progress even if the ResolutionRequest completion event
+	// is missed or cannot be mapped back via owner references (see #10414).
+	remoteResolutionRequeueAfter = time.Second
+)
+
 var (
 	// Check that our Reconciler implements taskrunreconciler.Interface
 	_ taskrunreconciler.Interface = (*Reconciler)(nil)
@@ -423,7 +431,7 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1.TaskRun) (*v1.TaskSpec,
 	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("TaskRun %s/%s awaiting remote resource", tr.Namespace, tr.Name)
 		tr.Status.MarkResourceOngoing(v1.TaskRunReasonResolvingTaskRef, message)
-		return nil, nil, err
+		return nil, nil, controller.NewRequeueAfter(remoteResolutionRequeueAfter)
 	case errors.Is(err, apiserver.ErrReferencedObjectValidationFailed), errors.Is(err, apiserver.ErrCouldntValidateObjectPermanent):
 		tr.Status.MarkResourceFailed(v1.TaskRunReasonTaskFailedValidation, err)
 		return nil, nil, controller.NewPermanentError(err)
@@ -448,7 +456,7 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1.TaskRun) (*v1.TaskSpec,
 	case errors.Is(err, remote.ErrRequestInProgress):
 		message := fmt.Sprintf("TaskRun %s/%s awaiting remote StepAction", tr.Namespace, tr.Name)
 		tr.Status.MarkResourceOngoing(v1.TaskRunReasonResolvingStepActionRef, message)
-		return nil, nil, err
+		return nil, nil, controller.NewRequeueAfter(remoteResolutionRequeueAfter)
 	case errors.Is(err, apiserver.ErrReferencedObjectValidationFailed), errors.Is(err, apiserver.ErrCouldntValidateObjectPermanent):
 		tr.Status.MarkResourceFailed(v1.TaskRunReasonTaskFailedValidation, err)
 		return nil, nil, controller.NewPermanentError(err)


### PR DESCRIPTION
Manual cherry-pick of #10429 to `release-v1.6.x` (automatic cherry-pick failed due to conflicts in `pkg/reconciler/taskrun/taskrun.go`).

Returns `controller.NewRequeueAfter(1s)` while awaiting remote resolution so a missed enqueue is non-terminal.

```release-note
Fix PipelineRun remaining stuck in ResolvingTaskRef when a ResolutionRequest completion event is missed by periodically requeueing while remote resolution is in progress
```