### PR TITLE
Bump plumbing ref for github_release_oci task

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -559,7 +559,7 @@ spec:
           - name: url
             value: https://github.com/tektoncd/plumbing
           - name: revision
-            value: 7abffd25eb2e578e6698a9ff13470d04906f79e6
+            value: ddcbc8eb56fe4b340ec4c0930f78e68b6a56783e
           - name: pathInRepo
             value: tekton/resources/release/base/github_release_oci.yaml
       params:


### PR DESCRIPTION
# Changes

Bump the `tektoncd/plumbing` revision for the `github_release_oci` task in the release pipeline to pick up two fixes:

- **tektoncd/plumbing#3476**: fix release-note rendering — markdown list formatting and dropped first character in release notes
- **tektoncd/plumbing#3519**: clean up GitHub release title and add optional draft param

The previous pin (`7abffd25`, April 21) predates both fixes (merged July 1 and July 21 respectively).

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind misc`.
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```