### PR TITLE
docs: add v1.15.0 release to releases.md

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -41,11 +41,11 @@ Further documentation available:
 
 ## Release
 
-### v1.14
-- **Latest Release**: [v1.14.0][v1.14-0] (2026-06-30) ([docs][v1.14-0-docs], [examples][v1.14-0-examples])
-- **Initial Release**: [v1.14.0][v1.14-0] (2026-06-30)
-- **End of Life**: 2026-07-30
-- **Patch Releases**: [v1.14.0][v1.14-0]
+### v1.15 (LTS)
+- **Latest Release**: [v1.15.0][v1.15-0] (2026-07-31) ([docs][v1.15-0-docs], [examples][v1.15-0-examples])
+- **Initial Release**: [v1.15.0][v1.15-0] (2026-07-31)
+- **End of Life**: 2027-07-31
+- **Patch Releases**: [v1.15.0][v1.15-0]
 
 ### v1.12 (LTS)
 - **Latest Release**: [v1.12.0][v1.12-0] (2026-05-04) ([docs][v1.12-0-docs], [examples][v1.12-0-examples])
@@ -72,6 +72,12 @@ Further documentation available:
 - **Patch Releases**: [v1.3.0][v1.3-0], [v1.3.1][v1.3-1], [v1.3.2][v1.3-2], [v1.3.3][v1.3-3], [v1.3.4][v1.3-4]
 
 ## End of Life Releases
+
+### v1.14
+- **Latest Release**: [v1.14.1][v1.14-1] (2026-07-22) ([docs][v1.14-1-docs], [examples][v1.14-1-examples])
+- **Initial Release**: [v1.14.0][v1.14-0] (2026-06-30)
+- **End of Life**: 2026-07-30
+- **Patch Releases**: [v1.14.0][v1.14-0], [v1.14.1][v1.14-1]
 
 ### v1.13
 - **Latest Release**: [v1.13.0][v1.13-0] (2026-05-29) ([docs][v1.13-0-docs], [examples][v1.13-0-examples])
@@ -352,6 +358,8 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [release-notes-standards]:
     https://github.com/tektoncd/community/blob/main/standards.md#release-notes
 
+[v1.15-0]: https://github.com/tektoncd/pipeline/releases/tag/v1.15.0
+[v1.14-1]: https://github.com/tektoncd/pipeline/releases/tag/v1.14.1
 [v1.14-0]: https://github.com/tektoncd/pipeline/releases/tag/v1.14.0
 [v1.13-0]: https://github.com/tektoncd/pipeline/releases/tag/v1.13.0
 [v1.12-0]: https://github.com/tektoncd/pipeline/releases/tag/v1.12.0
@@ -472,6 +480,8 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [v0-37-5]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.5
 [v0-37-0]: https://github.com/tektoncd/pipeline/releases/tag/v0.37.0
 
+[v1.15-0-docs]: https://github.com/tektoncd/pipeline/tree/v1.15.0/docs#tekton-pipelines
+[v1.14-1-docs]: https://github.com/tektoncd/pipeline/tree/v1.14.1/docs#tekton-pipelines
 [v1.14-0-docs]: https://github.com/tektoncd/pipeline/tree/v1.14.0/docs#tekton-pipelines
 [v1.13-0-docs]: https://github.com/tektoncd/pipeline/tree/v1.13.0/docs#tekton-pipelines
 [v1.12-0-docs]: https://github.com/tektoncd/pipeline/tree/v1.12.0/docs#tekton-pipelines
@@ -535,6 +545,8 @@ Older releases are EOL and available on [GitHub][tekton-pipeline-releases].
 [v0-38-4-docs]: https://github.com/tektoncd/pipeline/tree/v0.38.4/docs#tekton-pipelines
 [v0-37-5-docs]: https://github.com/tektoncd/pipeline/tree/v0.37.5/docs#tekton-pipelines
 
+[v1.15-0-examples]: https://github.com/tektoncd/pipeline/tree/v1.15.0/examples#examples
+[v1.14-1-examples]: https://github.com/tektoncd/pipeline/tree/v1.14.1/examples#examples
 [v1.14-0-examples]: https://github.com/tektoncd/pipeline/tree/v1.14.0/examples#examples
 [v1.13-0-examples]: https://github.com/tektoncd/pipeline/tree/v1.13.0/examples#examples
 [v1.12-0-examples]: https://github.com/tektoncd/pipeline/tree/v1.12.0/examples#examples


### PR DESCRIPTION
# Changes

Add v1.15.0 as the current release entry in `releases.md`. Move v1.14 to End of Life (EOL was 2026-07-30). Also add the v1.14.1 patch release that was missing.

/kind documentation

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. `/kind documentation`
- [x] Release notes block below has been updated with any user facing changes

# Release Notes

```release-note
NONE
```