### PR TITLE
Use larger GitHub-hosted runners for CI and E2E

### DIFF
--- a/.github/e2e-matrix-draft.json
+++ b/.github/e2e-matrix-draft.json
@@ -1,5 +1,5 @@
 {
-  "os": ["ubuntu-latest-16-cores"],
+  "os": ["ubuntu-latest-8-cores"],
   "k8s-name": ["k8s-latest"],
   "feature-flags": ["stable"],
   "include": [

--- a/.github/e2e-matrix-draft.json
+++ b/.github/e2e-matrix-draft.json
@@ -1,5 +1,5 @@
 {
-  "os": ["ubuntu-latest"],
+  "os": ["ubuntu-latest-16-cores"],
   "k8s-name": ["k8s-latest"],
   "feature-flags": ["stable"],
   "include": [

--- a/.github/e2e-matrix-full.json
+++ b/.github/e2e-matrix-full.json
@@ -1,5 +1,5 @@
 {
-  "os": ["ubuntu-latest", "ubuntu-24.04-arm"],
+  "os": ["ubuntu-latest-16-cores", "ubuntu-24.04-arm"],
   "k8s-name": ["k8s-oldest", "k8s-latest"],
   "feature-flags": ["stable", "beta", "alpha"],
   "include": [

--- a/.github/e2e-matrix-full.json
+++ b/.github/e2e-matrix-full.json
@@ -1,5 +1,5 @@
 {
-  "os": ["ubuntu-latest-16-cores", "ubuntu-24.04-arm"],
+  "os": ["ubuntu-latest-8-cores", "ubuntu-24.04-arm"],
   "k8s-name": ["k8s-oldest", "k8s-latest"],
   "feature-flags": ["stable", "beta", "alpha"],
   "include": [

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
 
   build:
     name: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     needs: [changes]
     if: ${{ needs.changes.outputs.non-docs == 'true' }}
     steps:
@@ -80,7 +80,7 @@ jobs:
         go build -v ./...
   buildFips:
     name: buildFips
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     needs: [changes]
     if: ${{ needs.changes.outputs.non-docs == 'true' }}
     steps:
@@ -96,7 +96,7 @@ jobs:
         echo "Build finished with exit code: $?"
   linting:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
       checks: write # Used by golangci-lint to annotate code in the PR
@@ -137,7 +137,7 @@ jobs:
   tests:
     needs: [build]
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
@@ -151,7 +151,7 @@ jobs:
   generated:
     needs: [build]
     name: Check generated code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
@@ -165,7 +165,7 @@ jobs:
   multi-arch-build:
     needs: [build]
     name: Multi-arch build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     env:
       KOCACHE: /tmp/ko-cache
     steps:

--- a/.github/workflows/e2e-matrix-extras.yaml
+++ b/.github/workflows/e2e-matrix-extras.yaml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-latest-16-cores
+        - ubuntu-latest-8-cores
         k8s-name:
         - k8s-latest-minus-five  # 1.29
         - k8s-latest-minus-four  # 1.30

--- a/.github/workflows/e2e-matrix-extras.yaml
+++ b/.github/workflows/e2e-matrix-extras.yaml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-latest
+        - ubuntu-latest-16-cores
         k8s-name:
         - k8s-latest-minus-five  # 1.29
         - k8s-latest-minus-four  # 1.30

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -24,7 +24,7 @@ defaults:
 jobs:
   go-coverage:
     name: Go coverage
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -30,7 +30,7 @@ env:
 jobs:
   build:
     name: Nightly Build (K8s ${{ inputs.kubernetes_version || 'v1.33.x' }})
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-8-cores
     if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
 
     permissions:

--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -30,7 +30,7 @@ env:
 jobs:
   build:
     name: Nightly Build (K8s ${{ inputs.kubernetes_version || 'v1.33.x' }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
 
     permissions:


### PR DESCRIPTION
# Changes

Switch to the org's **Default Larger Runners** group for CPU-intensive GitHub Actions jobs:

- **E2E tests** (matrix, extras, nightly): `ubuntu-latest` → `ubuntu-latest-16-cores` (16 vCPUs, 64 GB RAM, 300 GB SSD)
- **CI jobs** (build, buildFips, lint, test, codegen, multi-arch, coverage): `ubuntu-latest` → `ubuntu-latest-8-cores` (8 vCPUs, 32 GB RAM, 300 GB SSD)

Lightweight jobs (change detection, CI summary, labels, scorecard, woke, zizmor, etc.) remain on `ubuntu-latest`. ARM runner remains on `ubuntu-24.04-arm`.

**Prerequisites:** The **Default Larger Runners** group needs `tektoncd/pipeline` added to its selected repositories with "Allow public repositories" enabled in org settings.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```