### PR TITLE
fix(pipelinerun): stop the tasks timeout from running through the finally phase

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -99,4 +99,4 @@ jobs:
         make -j 4 all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/pkg/apis/pipeline/v1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types.go
@@ -221,7 +221,22 @@ func (pr *PipelineRun) HaveTasksTimedOut(ctx context.Context, c clock.PassiveClo
 		if timeout.Duration == config.NoTimeoutDuration {
 			return false
 		}
+		// The tasks timeout only budgets the DAG phase. status.FinallyStartTime marks the end
+		// of that phase, so once it is set the elapsed time is frozen there instead of growing
+		// while finally tasks run - otherwise a DAG that finished within its budget would still
+		// be reported as timed out just because the finally phase crossed the deadline.
+		// Both markers are metav1.Time, which serialises with second granularity, so their
+		// difference under-reports the real DAG runtime by up to a second; take the upper end
+		// of that interval, or a DAG that this very timeout cut off would read back as having
+		// finished exactly on the deadline and stop being reported as timed out.
+		// The frozen value is only ever used when it is shorter than the live one, so a marker
+		// written by a clock ahead of ours can never make this stricter than plain wall clock.
 		runtime := c.Since(startTime.Time)
+		if finallyStartTime := pr.Status.FinallyStartTime; finallyStartTime != nil && !finallyStartTime.IsZero() {
+			if dagRuntime := finallyStartTime.Sub(startTime.Time) + time.Second; dagRuntime < runtime {
+				runtime = dagRuntime
+			}
+		}
 		if runtime > timeout.Duration {
 			return true
 		}

--- a/pkg/apis/pipeline/v1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_types_test.go
@@ -435,6 +435,81 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 	}
 }
 
+func TestPipelineRunHaveTasksTimedOutWithFinallyStarted(t *testing.T) {
+	// Once the finally phase starts the DAG is done, so the tasks timeout must be measured
+	// against status.FinallyStartTime rather than against the current time.
+	tcs := []struct {
+		name             string
+		tasksTimeout     time.Duration
+		startTime        time.Time
+		finallyStartTime time.Time
+		expected         bool
+	}{{
+		name:             "dag finished within the tasks timeout, finally running past it",
+		tasksTimeout:     time.Minute,
+		startTime:        now.Add(-90 * time.Second),
+		finallyStartTime: now.Add(-50 * time.Second),
+		expected:         false,
+	}, {
+		name:             "dag overran the tasks timeout before finally started",
+		tasksTimeout:     time.Minute,
+		startTime:        now.Add(-90 * time.Second),
+		finallyStartTime: now.Add(-20 * time.Second),
+		expected:         true,
+	}, {
+		// Both markers are metav1.Time, which serialises with second granularity, so the span
+		// between them is a whole number of seconds that under-reports the real DAG runtime by
+		// up to a second. A DAG that the tasks timeout itself cut off therefore reads back as
+		// having finished exactly on the deadline, and must still count as timed out.
+		name:             "dag cut off by the tasks timeout reads back as finishing exactly on it",
+		tasksTimeout:     20 * time.Second,
+		startTime:        now.Add(-25 * time.Second),
+		finallyStartTime: now.Add(-5 * time.Second),
+		expected:         true,
+	}, {
+		// One second below the deadline is the largest span the truncation can produce for a DAG
+		// that stayed inside its budget, so this pins the other side of that boundary.
+		name:             "dag finished a second inside the tasks timeout",
+		tasksTimeout:     20 * time.Second,
+		startTime:        now.Add(-25 * time.Second),
+		finallyStartTime: now.Add(-6 * time.Second),
+		expected:         false,
+	}, {
+		name:             "no tasks timeout specified",
+		tasksTimeout:     0,
+		startTime:        now.Add(-24 * time.Hour),
+		finallyStartTime: now.Add(-1 * time.Hour),
+		expected:         false,
+	}, {
+		// A marker written by a clock running ahead of ours must not time out a DAG that plain
+		// wall clock says is still inside its budget.
+		name:             "marker is in the future, wall clock still within the tasks timeout",
+		tasksTimeout:     2 * time.Minute,
+		startTime:        now.Add(-90 * time.Second),
+		finallyStartTime: now.Add(60 * time.Second),
+		expected:         false,
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1.PipelineRunSpec{
+					Timeouts: &v1.TimeoutFields{Tasks: &metav1.Duration{Duration: tc.tasksTimeout}},
+				},
+				Status: v1.PipelineRunStatus{PipelineRunStatusFields: v1.PipelineRunStatusFields{
+					StartTime:        &metav1.Time{Time: tc.startTime},
+					FinallyStartTime: &metav1.Time{Time: tc.finallyStartTime},
+				}},
+			}
+
+			if pr.HaveTasksTimedOut(t.Context(), testClock) != tc.expected {
+				t.Errorf("Expected HaveTasksTimedOut to be %t", tc.expected)
+			}
+		})
+	}
+}
+
 func TestPipelineRunTimeouts(t *testing.T) {
 	tcs := []struct {
 		name                   string

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -218,7 +218,22 @@ func (pr *PipelineRun) HaveTasksTimedOut(ctx context.Context, c clock.PassiveClo
 		if timeout.Duration == config.NoTimeoutDuration {
 			return false
 		}
+		// The tasks timeout only budgets the DAG phase. status.FinallyStartTime marks the end
+		// of that phase, so once it is set the elapsed time is frozen there instead of growing
+		// while finally tasks run - otherwise a DAG that finished within its budget would still
+		// be reported as timed out just because the finally phase crossed the deadline.
+		// Both markers are metav1.Time, which serialises with second granularity, so their
+		// difference under-reports the real DAG runtime by up to a second; take the upper end
+		// of that interval, or a DAG that this very timeout cut off would read back as having
+		// finished exactly on the deadline and stop being reported as timed out.
+		// The frozen value is only ever used when it is shorter than the live one, so a marker
+		// written by a clock ahead of ours can never make this stricter than plain wall clock.
 		runtime := c.Since(startTime.Time)
+		if finallyStartTime := pr.Status.FinallyStartTime; finallyStartTime != nil && !finallyStartTime.IsZero() {
+			if dagRuntime := finallyStartTime.Sub(startTime.Time) + time.Second; dagRuntime < runtime {
+				runtime = dagRuntime
+			}
+		}
 		if runtime > timeout.Duration {
 			return true
 		}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -479,6 +479,81 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 	}
 }
 
+func TestPipelineRunHaveTasksTimedOutWithFinallyStarted(t *testing.T) {
+	// Once the finally phase starts the DAG is done, so the tasks timeout must be measured
+	// against status.FinallyStartTime rather than against the current time.
+	tcs := []struct {
+		name             string
+		tasksTimeout     time.Duration
+		startTime        time.Time
+		finallyStartTime time.Time
+		expected         bool
+	}{{
+		name:             "dag finished within the tasks timeout, finally running past it",
+		tasksTimeout:     time.Minute,
+		startTime:        now.Add(-90 * time.Second),
+		finallyStartTime: now.Add(-50 * time.Second),
+		expected:         false,
+	}, {
+		name:             "dag overran the tasks timeout before finally started",
+		tasksTimeout:     time.Minute,
+		startTime:        now.Add(-90 * time.Second),
+		finallyStartTime: now.Add(-20 * time.Second),
+		expected:         true,
+	}, {
+		// Both markers are metav1.Time, which serialises with second granularity, so the span
+		// between them is a whole number of seconds that under-reports the real DAG runtime by
+		// up to a second. A DAG that the tasks timeout itself cut off therefore reads back as
+		// having finished exactly on the deadline, and must still count as timed out.
+		name:             "dag cut off by the tasks timeout reads back as finishing exactly on it",
+		tasksTimeout:     20 * time.Second,
+		startTime:        now.Add(-25 * time.Second),
+		finallyStartTime: now.Add(-5 * time.Second),
+		expected:         true,
+	}, {
+		// One second below the deadline is the largest span the truncation can produce for a DAG
+		// that stayed inside its budget, so this pins the other side of that boundary.
+		name:             "dag finished a second inside the tasks timeout",
+		tasksTimeout:     20 * time.Second,
+		startTime:        now.Add(-25 * time.Second),
+		finallyStartTime: now.Add(-6 * time.Second),
+		expected:         false,
+	}, {
+		name:             "no tasks timeout specified",
+		tasksTimeout:     0,
+		startTime:        now.Add(-24 * time.Hour),
+		finallyStartTime: now.Add(-1 * time.Hour),
+		expected:         false,
+	}, {
+		// A marker written by a clock running ahead of ours must not time out a DAG that plain
+		// wall clock says is still inside its budget.
+		name:             "marker is in the future, wall clock still within the tasks timeout",
+		tasksTimeout:     2 * time.Minute,
+		startTime:        now.Add(-90 * time.Second),
+		finallyStartTime: now.Add(60 * time.Second),
+		expected:         false,
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1beta1.PipelineRunSpec{
+					Timeouts: &v1beta1.TimeoutFields{Tasks: &metav1.Duration{Duration: tc.tasksTimeout}},
+				},
+				Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime:        &metav1.Time{Time: tc.startTime},
+					FinallyStartTime: &metav1.Time{Time: tc.finallyStartTime},
+				}},
+			}
+
+			if pr.HaveTasksTimedOut(t.Context(), testClock) != tc.expected {
+				t.Errorf("Expected HaveTasksTimedOut to be %t", tc.expected)
+			}
+		})
+	}
+}
+
 func TestPipelineRunTimeouts(t *testing.T) {
 	tcs := []struct {
 		name                   string

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2544,6 +2544,184 @@ func TestGetPipelineConditionStatus_TasksTimedOutExplicitWithFinally(t *testing.
 	}
 }
 
+// TestGetPipelineConditionStatus_TasksTimedOutFinallyDone covers the terminal state of a
+// PipelineRun whose DAG the tasks timeout cut off and whose finally task then succeeded: it must
+// still report PipelineRunTimeout. status.StartTime and status.FinallyStartTime are metav1.Time
+// and only survive a round trip through the API server at second granularity, so a DAG stopped by
+// its own deadline reads back as having finished exactly on it - the boundary this pins.
+func TestGetPipelineConditionStatus_TasksTimedOutFinallyDone(t *testing.T) {
+	tasksTimeout := 20 * time.Second
+	startTime := now.Add(-25 * time.Second)
+
+	dagTimedOutFinalDone := PipelineRunState{{
+		TaskRunNames: []string{"task0taskrun"},
+		PipelineTask: &pts[0],
+		TaskRuns:     []*v1.TaskRun{withCancelled(makeFailed(trs[0]))},
+	}, {
+		TaskRunNames: []string{"finaltask"},
+		PipelineTask: &pts[1],
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[1])},
+	}}
+
+	pr := &v1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-tasks-timeout-finally-done"},
+		Spec: v1.PipelineRunSpec{
+			Timeouts: &v1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: 2 * time.Minute},
+				Tasks:    &metav1.Duration{Duration: tasksTimeout},
+			},
+		},
+		Status: v1.PipelineRunStatus{
+			PipelineRunStatusFields: v1.PipelineRunStatusFields{
+				StartTime:        &metav1.Time{Time: startTime},
+				FinallyStartTime: &metav1.Time{Time: startTime.Add(tasksTimeout)},
+			},
+		},
+	}
+
+	d, err := dag.Build(v1.PipelineTaskList([]v1.PipelineTask{pts[0]}), v1.PipelineTaskList([]v1.PipelineTask{pts[0]}).Deps())
+	if err != nil {
+		t.Fatalf("Unexpected error while building graph for DAG tasks: %v", err)
+	}
+	df, err := dag.Build(v1.PipelineTaskList([]v1.PipelineTask{pts[1]}), map[string][]string{})
+	if err != nil {
+		t.Fatalf("Unexpected error while building graph for final tasks: %v", err)
+	}
+
+	finallyStartTime := pr.Status.FinallyStartTime.Time
+	facts := PipelineRunFacts{
+		State:           dagTimedOutFinalDone,
+		TasksGraph:      d,
+		FinalTasksGraph: df,
+		TimeoutsState: PipelineRunTimeoutsState{
+			Clock:            testClock,
+			FinallyStartTime: &finallyStartTime,
+		},
+	}
+	c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
+	if c.Status != corev1.ConditionFalse {
+		t.Errorf("Expected status %s but got %s", corev1.ConditionFalse, c.Status)
+	}
+	if c.Reason != v1.PipelineRunReasonTimedOut.String() {
+		t.Errorf("Expected reason %s but got %s", v1.PipelineRunReasonTimedOut.String(), c.Reason)
+	}
+}
+
+// TestGetPipelineConditionStatus_DAGWithinTasksTimeoutFinallyPastIt covers the case where the DAG
+// finished inside its tasks budget and only the finally phase ran past the tasks deadline. The
+// tasks timeout budgets the DAG phase alone, so it must not fail a PipelineRun whose DAG met it.
+func TestGetPipelineConditionStatus_DAGWithinTasksTimeoutFinallyPastIt(t *testing.T) {
+	dagDoneFinalRunning := PipelineRunState{{
+		TaskRunNames: []string{"task0taskrun"},
+		PipelineTask: &pts[0],
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+	}, {
+		TaskRunNames: []string{"finaltask"},
+		PipelineTask: &pts[1],
+		TaskRuns:     []*v1.TaskRun{makeStarted(trs[1])},
+	}}
+
+	dagDoneFinalDone := PipelineRunState{{
+		TaskRunNames: []string{"task0taskrun"},
+		PipelineTask: &pts[0],
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[0])},
+	}, {
+		TaskRunNames: []string{"finaltask"},
+		PipelineTask: &pts[1],
+		TaskRuns:     []*v1.TaskRun{makeSucceeded(trs[1])},
+	}}
+
+	// Both an explicit tasks timeout and one calculated as pipeline - finally must behave the same.
+	explicitTimeouts := &v1.TimeoutFields{
+		Pipeline: &metav1.Duration{Duration: 2 * time.Minute},
+		Tasks:    &metav1.Duration{Duration: 1 * time.Minute},
+		Finally:  &metav1.Duration{Duration: 1 * time.Minute},
+	}
+	calculatedTimeouts := &v1.TimeoutFields{
+		Pipeline: &metav1.Duration{Duration: 2 * time.Minute},
+		Finally:  &metav1.Duration{Duration: 1 * time.Minute},
+	}
+
+	tcs := []struct {
+		name           string
+		state          PipelineRunState
+		timeouts       *v1.TimeoutFields
+		expectedStatus corev1.ConditionStatus
+		expectedReason string
+	}{{
+		name:           "dag done within tasks timeout, finally still running past it - should keep running",
+		state:          dagDoneFinalRunning,
+		timeouts:       explicitTimeouts,
+		expectedStatus: corev1.ConditionUnknown,
+		expectedReason: v1.PipelineRunReasonRunning.String(),
+	}, {
+		name:           "dag done within tasks timeout, finally completed past it - should succeed",
+		state:          dagDoneFinalDone,
+		timeouts:       explicitTimeouts,
+		expectedStatus: corev1.ConditionTrue,
+		expectedReason: v1.PipelineRunReasonSuccessful.String(),
+	}, {
+		name:           "calculated tasks timeout, dag done within it, finally still running past it - should keep running",
+		state:          dagDoneFinalRunning,
+		timeouts:       calculatedTimeouts,
+		expectedStatus: corev1.ConditionUnknown,
+		expectedReason: v1.PipelineRunReasonRunning.String(),
+	}, {
+		name:           "calculated tasks timeout, dag done within it, finally completed past it - should succeed",
+		state:          dagDoneFinalDone,
+		timeouts:       calculatedTimeouts,
+		expectedStatus: corev1.ConditionTrue,
+		expectedReason: v1.PipelineRunReasonSuccessful.String(),
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			// Started 90s ago with a 1m tasks budget, but the DAG already handed over to finally
+			// at the 40s mark, so the frozen DAG elapsed time (40s) is still within budget.
+			pr := &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-dag-within-tasks-timeout"},
+				Spec: v1.PipelineRunSpec{
+					Timeouts: tc.timeouts,
+				},
+				Status: v1.PipelineRunStatus{
+					PipelineRunStatusFields: v1.PipelineRunStatusFields{
+						StartTime:        &metav1.Time{Time: now.Add(-90 * time.Second)},
+						FinallyStartTime: &metav1.Time{Time: now.Add(-50 * time.Second)},
+					},
+				},
+			}
+			dagTasks := []v1.PipelineTask{pts[0]}
+			finalTasks := []v1.PipelineTask{pts[1]}
+			d, err := dag.Build(v1.PipelineTaskList(dagTasks), v1.PipelineTaskList(dagTasks).Deps())
+			if err != nil {
+				t.Fatalf("Unexpected error while building graph for DAG tasks %v: %v", dagTasks, err)
+			}
+			df, err := dag.Build(v1.PipelineTaskList(finalTasks), map[string][]string{})
+			if err != nil {
+				t.Fatalf("Unexpected error while building graph for final tasks %v: %v", finalTasks, err)
+			}
+			finallyStartTime := pr.Status.FinallyStartTime.Time
+			facts := PipelineRunFacts{
+				State:           tc.state,
+				TasksGraph:      d,
+				FinalTasksGraph: df,
+				TimeoutsState: PipelineRunTimeoutsState{
+					Clock:            testClock,
+					StartTime:        &pr.Status.StartTime.Time,
+					FinallyStartTime: &finallyStartTime,
+				},
+			}
+			c := facts.GetPipelineConditionStatus(t.Context(), pr, zap.NewNop().Sugar(), testClock)
+			if c.Status != tc.expectedStatus {
+				t.Errorf("Expected status %s but got %s for test %s", tc.expectedStatus, c.Status, tc.name)
+			}
+			if c.Reason != tc.expectedReason {
+				t.Errorf("Expected reason %s but got %s for test %s", tc.expectedReason, c.Reason, tc.name)
+			}
+		})
+	}
+}
+
 func TestGetPipelineConditionStatus_OnError(t *testing.T) {
 	var oneFailedStateOnError = PipelineRunState{{
 		PipelineTask: &v1.PipelineTask{


### PR DESCRIPTION
fix #10512

# Changes

`timeouts.tasks` budgets the DAG phase, but `HaveTasksTimedOut` measured plain
wall-clock time from `status.StartTime` and never stopped, so the clock kept
running through the `finally` phase. A PipelineRun whose DAG finished inside its
budget was still failed with `failed due to tasks failed to finish within "..."`
as soon as a `finally` Task pushed the total past the tasks deadline.

`status.FinallyStartTime` already marks the end of the DAG phase, and the
reconciler already uses it as the "still in the DAG phase" guard when cancelling
timed-out DAG Tasks. Reuse it here: freeze the elapsed time at that boundary once
it is set. The frozen value is only taken when it is shorter than the live elapsed
time, so a marker stamped by a clock ahead of ours can never make this check
stricter than the plain wall clock it replaces.

Only the case where the DAG completes within its budget changes behaviour. If the
DAG really overran, cancellation still happens while `FinallyStartTime` is nil,
and the frozen value afterwards is necessarily past the deadline, so the
`PipelineRunTimeoutRunningFinally` handling added in #9709 is unaffected.

The check has been wall-clock based since it was introduced in v0.40.0 and is
unchanged through v1.15.0 and `main`, so every release in that range is affected.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

No docs change is needed: this makes the behaviour match what `docs/pipelineruns.md`
already documents for `timeouts.tasks`.

This change was AI-assisted; I have reviewed, tested and verified it myself.

# Release Notes

```release-note
Fixed `timeouts.tasks` being charged for time spent in the `finally` phase, which failed PipelineRuns whose non-finally Tasks had completed within the tasks timeout.
```

/kind bug
