### PR TITLE
fix(ci): bump codeql-action/analyze to match init

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -99,4 +99,4 @@ jobs:
         make -j 4 all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3


### PR DESCRIPTION
# Changes

`Analyze (go)` has failed on every pull request since https://github.com/tektoncd/pipeline/commit/a4441e34b25b690b72297c4ead4722c40382034d, with:

```
##[error]Loaded a configuration file for version '4.37.3', but running version '4.37.0'
##[error]analyze post-action step failed: Loaded a configuration file for version '4.37.3', but running version '4.37.0'
```

That bump moved `github/codeql-action/init` to v4.37.3 and left `github/codeql-action/analyze` in the same workflow on v4.37.0, so `analyze` reads a configuration file written by a newer `init` than itself and refuses it. Dependabot tracks each action path as its own dependency, so the two are not kept in step automatically.

This moves `analyze` onto the commit `init` already points at.

## Verifying the digest

The new digest is `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`, which is what `v4.37.3` resolves to:

- the release: https://github.com/github/codeql-action/releases/tag/v4.37.3
- the commit it tags: https://github.com/github/codeql-action/commit/e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 - its own message is `Merge pull request #4031 from github/update-v4.37.3-72f6a9da0`
- resolving the tag through the API gives the same answer:

  ```console
  $ gh api repos/github/codeql-action/commits/v4.37.3 --jq .sha
  e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
  ```

It is also the digest `init` is already pinned to on `main`, one step above the line this changes: https://github.com/tektoncd/pipeline/blob/db251bd37727606489ea2b4038df384f526ad747/.github/workflows/codeql-analysis.yml#L68

## Verifying that this is the cause

The failure is repository wide rather than specific to any one change:

- it reproduces on unrelated pull requests, e.g. #10511: https://github.com/tektoncd/pipeline/actions/runs/30640963131/job/91190490945
- pull requests whose last run predates the bump still have a green `Analyze (go)`, e.g. #10508: https://github.com/tektoncd/pipeline/actions/runs/30632099515/job/91160664249

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
