### PR TITLE
fix: keep bare step result references as strings

### DIFF
--- a/docs/stepactions.md
+++ b/docs/stepactions.md
@@ -267,6 +267,8 @@ Pipeline supports two new types of results and parameters: array `[]string` and 
 
 **Note:** Whole Array `Results` (using star notation) cannot be referred in `script` and `env`.
 
+**Note:** A reference without array indexing or an object key, `$(steps.<step-name>.results.<result-name>)`, substitutes the raw contents of the result file. A `string` result holding `[]` or `{}` is substituted as that literal text.
+
 The example below shows how you could pass `step results` from a `step` into following steps, in this case, into a `StepAction`.
 
 ```yaml

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -550,12 +550,20 @@ func GetContainerName(name string) string {
 }
 
 // loadStepResult reads the step result file and returns the string, array or object result value.
-func loadStepResult(stepDir string, stepName string, resultName string) (v1.ResultValue, error) {
+// expectedType is the result type the reference asks for. A reference without array indexing or an
+// object key is always a string, so the file contents are used as-is instead of being unmarshalled,
+// otherwise a string result holding "[]" or "{}" would be read back as an array or an object.
+func loadStepResult(stepDir string, stepName string, resultName string, expectedType string) (v1.ResultValue, error) {
 	v := v1.ResultValue{}
 	fp := getStepResultPath(stepDir, GetContainerName(stepName), resultName)
 	fileContents, err := os.ReadFile(fp)
 	if err != nil {
 		return v, err
+	}
+	if expectedType == "string" {
+		v.Type = v1.ParamTypeString
+		v.StringVal = string(fileContents)
+		return v, nil
 	}
 	err = v.UnmarshalJSON(fileContents)
 	if err != nil {
@@ -577,7 +585,7 @@ func findReplacement(stepDir string, s string) (string, []string, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	result, err := loadStepResult(stepDir, pr.ResourceName, pr.ResultName)
+	result, err := loadStepResult(stepDir, pr.ResourceName, pr.ResultName, pr.ResultType)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -877,6 +877,45 @@ func TestApplyStepResultSubstitutions_Env(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "string param that looks like an empty array",
+			stepName:   "foo",
+			resultName: "res",
+			result:     "[]",
+			envValue:   "$(steps.foo.results.res)",
+			want:       "[]",
+			wantErr:    false,
+		},
+		{
+			name:       "string param that looks like an object",
+			stepName:   "foo",
+			resultName: "res",
+			result:     `{"hello":"World"}`,
+			envValue:   "$(steps.foo.results.res)",
+			want:       `{"hello":"World"}`,
+			wantErr:    false,
+		},
+		// A reference without an index or a key substitutes the file contents verbatim.
+		// The two cases below used to be JSON decoded, so they are pinned here to keep
+		// the change deliberate: quotes and escapes are no longer interpreted.
+		{
+			name:       "string param holding a quoted json string",
+			stepName:   "foo",
+			resultName: "res",
+			result:     `"hello"`,
+			envValue:   "$(steps.foo.results.res)",
+			want:       `"hello"`,
+			wantErr:    false,
+		},
+		{
+			name:       "array param without an index",
+			stepName:   "foo",
+			resultName: "res",
+			result:     `["Hello","World"]`,
+			envValue:   "$(steps.foo.results.res)",
+			want:       `["Hello","World"]`,
+			wantErr:    false,
+		},
+		{
 			name:       "bad-result-format",
 			stepName:   "foo",
 			resultName: "res",
@@ -1064,6 +1103,14 @@ func TestApplyStepWhenSubstitutions_Input(t *testing.T) {
 		when:       v1.StepWhenExpressions{{Input: "$(steps.foo.results.res.hello.bar)"}},
 		want:       v1.StepWhenExpressions{{Input: "$(steps.foo.results.res.hello.bar)"}},
 		wantErr:    true,
+	}, {
+		name:       "string param that looks like an empty array",
+		stepName:   "foo",
+		resultName: "res",
+		result:     "[]",
+		when:       v1.StepWhenExpressions{{Input: "$(steps.foo.results.res)", Operator: selection.NotIn, Values: []string{"[]"}}},
+		want:       v1.StepWhenExpressions{{Input: "[]", Operator: selection.NotIn, Values: []string{"[]"}}},
+		wantErr:    false,
 	}}
 	stepDir := t.TempDir()
 	for _, tc := range testCases {


### PR DESCRIPTION
# Changes

Fixes #10460.

A step result whose value is `[]` or `{}` was substituted as an empty string, even when the result is declared `type: string`. In the issue's repro the `when` expression comparing against `[]` never matched, so the step ran instead of being skipped, and the env var came out empty.

`loadStepResult` hands the result file contents to `ResultValue.UnmarshalJSON`, which picks the type from the first byte of the value: `[` gives an array, `{` gives an object. A bare `$(steps.<step>.results.<result>)` reference then reads `StringVal`, which is empty for both.

This is the fix @vdemeester proposed in the issue thread (option B). `ParseStepExpression` already knows what the reference asks for: a reference without array indexing or an object key parses as `"string"`. That type is now passed into `loadStepResult`, which uses the raw file contents when it is a string. JSON type inference still runs for `[i]`, `[*]` and `.key`  eferences, so array and object results are unaffected.

Option A from the thread, validating that array and object results are always referenced with `[i]`, `[*]` or `.key`, is not part of this PR. It is a separate change on the reconciler side and can go on top of this one.

## What changes for a bare reference

Skipping the unmarshal skips all of its decoding, not only the array and object inference. I ran the same substitution matrix before and after the change; 7 of 19 rows moved, all of them bare references:

| result file holds | bare ref used to give | now gives |
|---|---|---|
| `[]` or `{}` in a `string` result | `` (empty) | `[]` / `{}` |
| `["a","b"]` in an `array` result | `` (empty) | `["a","b"]` |
| `{"k":"v"}` in an `object` result | `` (empty) | `{"k":"v"}` |
| `"hello"` (quoted) | `hello` | `"hello"` |
| `"a\nb"` (quoted, escaped) | `a`, real newline, `b` | `"a\nb"` literally |
| `null` | `` (empty) | `null` |

Indexed and keyed references (`[i]`, `[*]`, `.key`) are byte for byte unchanged, as are unquoted values, numbers, booleans, empty files and trailing newlines. The array and object rows are the case @aThorp96 asked to have defined in the thread, and `docs/stepactions.md` now states it.

## Open question for reviewers

One row above is a behavior change that is not visible to the Task author, so I want it in front of you rather than in the release note alone. A `string` result written as the JSON quoted string `"a\nb"` used to substitute a real newline between `a` and `b`, because the file contents went through `json.Unmarshal`. With this change it substitutes the six literal characters `"a\nb"` instead. A Task that produces a result with `jq '.msg'` rather than `jq -r '.msg'` and reads it from a later step's `env`, `command`, `args` or `when` would see that difference, with no error or log line to point at it.

The row is pinned by `TestApplyStepResultSubstitutions_Env/string_param_holding_a_quoted_json_string`, so it is a deliberate part of this diff rather than a side effect, and flipping it back means changing that test.

If you consider the change unacceptable, a narrower version keeps a JSON string decode for the string case only and drops just the array and object inference: `if err := json.Unmarshal(fileContents, &v.StringVal); err != nil { v.StringVal = string(fileContents) }`. I ran it: it fixes #10460, and its output is identical to today's for every quoted, escaped and `null` row, so nothing that works now changes. `encoding/json` is already imported. The tradeoff is the rule you have to document: raw contents, unless they happen to parse as a JSON string. I did not ship it because option B as described is the simpler rule and the decoding was never documented, but the change is a few lines if you would rather have it.

Nothing in this repo depends on the old decoding. Every step result reference in `docs/`, `examples/` and `test/` writes unquoted plain text or uses an indexed or keyed reference.

## Testing

New cases in `TestApplyStepResultSubstitutions_Env` and `TestApplyStepWhenSubstitutions_Input` reproduce the issue and fail without the fix. Two further cases pin the rows in the table above that are not the reported bug. `go test ./pkg/...` passes. No e2e or cluster run: the defect is at the substitution layer in the entrypointer, and that is where the tests sit.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed step result substitution so that a bare `$(steps.<step>.results.<result>)` reference substitutes the raw contents of the result file. A `string` result holding `[]` or `{}` is no longer read back as an empty array or object and substituted as an empty string. Contents referenced this way are no longer JSON decoded, so a result written as a JSON quoted string now keeps its quotes and escapes.
```

/kind bug
