### PR TITLE
feat: Surface Pod warning events onto TaskRun status

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -62,10 +62,11 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "persistentvolumeclaims"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  # Write permissions to publish events.
+  # Read/write permissions for events: create/update/patch to publish events,
+  # get/list to surface Pod warning events onto TaskRun status (surface-pod-events flag).
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["create", "update", "patch"]
+    verbs: ["get", "list", "create", "update", "patch"]
   # Read-only access to these.
   - apiGroups: [""]
     resources: ["configmaps", "limitranges", "secrets", "serviceaccounts"]

--- a/config/300-crds/300-pipelinerun.yaml
+++ b/config/300-crds/300-pipelinerun.yaml
@@ -2371,6 +2371,8 @@ spec:
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable
                           type: boolean
+                        enableSurfacePodEvents:
+                          type: boolean
                         enableTektonOCIBundles:
                           description: |-
                             DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
@@ -2751,6 +2753,8 @@ spec:
                                   enableStepActions:
                                     description: EnableStepActions is a no-op flag since StepActions are stable
                                     type: boolean
+                                  enableSurfacePodEvents:
+                                    type: boolean
                                   enableTektonOCIBundles:
                                     description: |-
                                       DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
@@ -3023,6 +3027,8 @@ spec:
                                           type: boolean
                                         enableStepActions:
                                           description: EnableStepActions is a no-op flag since StepActions are stable
+                                          type: boolean
+                                        enableSurfacePodEvents:
                                           type: boolean
                                         enableTektonOCIBundles:
                                           description: |-
@@ -5469,6 +5475,8 @@ spec:
                           type: boolean
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable
+                          type: boolean
+                        enableSurfacePodEvents:
                           type: boolean
                         enableTektonOCIBundles:
                           description: |-

--- a/config/300-crds/300-taskrun.yaml
+++ b/config/300-crds/300-taskrun.yaml
@@ -1886,6 +1886,8 @@ spec:
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable
                           type: boolean
+                        enableSurfacePodEvents:
+                          type: boolean
                         enableTektonOCIBundles:
                           description: |-
                             DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
@@ -2158,6 +2160,8 @@ spec:
                                 type: boolean
                               enableStepActions:
                                 description: EnableStepActions is a no-op flag since StepActions are stable
+                                type: boolean
+                              enableSurfacePodEvents:
                                 type: boolean
                               enableTektonOCIBundles:
                                 description: |-
@@ -4040,6 +4044,8 @@ spec:
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable
                           type: boolean
+                        enableSurfacePodEvents:
+                          type: boolean
                         enableTektonOCIBundles:
                           description: |-
                             DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
@@ -4304,6 +4310,8 @@ spec:
                                 type: boolean
                               enableStepActions:
                                 description: EnableStepActions is a no-op flag since StepActions are stable
+                                type: boolean
+                              enableSurfacePodEvents:
                                 type: boolean
                               enableTektonOCIBundles:
                                 description: |-

--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -145,6 +145,11 @@ data:
   # Alpha feature — this is a short-term measure. External result storage
   # (TEP-0164) will address the underlying 4KB limitation.
   enable-termination-message-compression: "false"
+  # Setting this flag to "true" will enable surfacing Pod Warning events
+  # (e.g. FailedMount, FailedScheduling) onto the TaskRun status when a
+  # Pod is stuck pending with no useful status message.
+  # See https://github.com/tektoncd/pipeline/issues/10373 for more info.
+  surface-pod-events: "false"
   # Controls whether informer cache transforms are enabled. When enabled (default),
   # the controller strips large, unnecessary metadata fields (managedFields and the
   # kubectl last-applied-configuration annotation) from PipelineRuns, TaskRuns,

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -121,6 +121,11 @@ const (
 	EnableTerminationMessageCompression = "enable-termination-message-compression"
 	// DefaultEnableTerminationMessageCompression is the default value for EnableTerminationMessageCompression
 	DefaultEnableTerminationMessageCompression = false
+	// SurfacePodEvents is the flag to enable surfacing Pod Warning events
+	// onto TaskRun status when a Pod is stuck pending with no useful message.
+	SurfacePodEvents = "surface-pod-events"
+	// DefaultSurfacePodEvents is the default value for SurfacePodEvents
+	DefaultSurfacePodEvents = false
 
 	// EnableStepActions is the flag to enable step actions (no-op since it's stable)
 	EnableStepActions = "enable-step-actions"
@@ -193,6 +198,13 @@ var (
 		Enabled:   DefaultAlphaFeatureEnabled,
 	}
 
+	// DefaultSurfacePodEventsFlag is the default PerFeatureFlag value for SurfacePodEvents
+	DefaultSurfacePodEventsFlag = PerFeatureFlag{
+		Name:      SurfacePodEvents,
+		Stability: AlphaAPIFields,
+		Enabled:   DefaultAlphaFeatureEnabled,
+	}
+
 	DefaultEnableTektonOCIBundles = PerFeatureFlag{
 		Name:       EnableTektonOCIBundles,
 		Stability:  AlphaAPIFields,
@@ -235,6 +247,7 @@ type FeatureFlags struct {
 	EnableKubernetesSidecar             bool   `json:"enableKubernetesSidecar,omitempty"`
 	EnableWaitExponentialBackoff        bool   `json:"enableWaitExponentialBackoff,omitempty"`
 	EnableTerminationMessageCompression bool   `json:"enableTerminationMessageCompression,omitempty"`
+	EnableSurfacePodEvents              bool   `json:"enableSurfacePodEvents,omitempty"`
 	// DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
 	// to allow deletion of PipelineRuns created before v0.62.x.
 	// This field is not used and can be removed in a future release
@@ -349,6 +362,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setPerFeatureFlag(EnableTerminationMessageCompression, DefaultEnableTerminationMessageCompressionFlag, &tc.EnableTerminationMessageCompression); err != nil {
+		return nil, err
+	}
+	if err := setPerFeatureFlag(SurfacePodEvents, DefaultSurfacePodEventsFlag, &tc.EnableSurfacePodEvents); err != nil {
 		return nil, err
 	}
 

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -81,6 +81,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableConciseResolverSyntax:              true,
 				EnableKubernetesSidecar:                  true,
 				EnableTerminationMessageCompression:      true,
+				EnableSurfacePodEvents:                   true,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},
@@ -303,6 +304,9 @@ func TestNewFeatureFlagsConfigMapErrors(t *testing.T) {
 	}, {
 		fileName: "feature-flags-invalid-enable-termination-message-compression",
 		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax for feature enable-termination-message-compression`,
+	}, {
+		fileName: "feature-flags-invalid-surface-pod-events",
+		want:     `failed parsing feature flags config "invalid": strconv.ParseBool: parsing "invalid": invalid syntax for feature surface-pod-events`,
 	}, {
 		fileName: "feature-flags-invalid-set_security_context_read_only_root_filesystem",
 		want:     `failed parsing feature flags config "invalid read only root filesystem flag": strconv.ParseBool: parsing "invalid read only root filesystem flag": invalid syntax`,

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -39,3 +39,4 @@ data:
   enable-concise-resolver-syntax: "true"
   enable-kubernetes-sidecar: "true"
   enable-termination-message-compression: "true"
+  surface-pod-events: "true"

--- a/pkg/apis/config/testdata/feature-flags-invalid-surface-pod-events.yaml
+++ b/pkg/apis/config/testdata/feature-flags-invalid-surface-pod-events.yaml
@@ -1,0 +1,21 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: tekton-pipelines
+data:
+  surface-pod-events: "invalid"

--- a/pkg/pod/events.go
+++ b/pkg/pod/events.go
@@ -19,21 +19,23 @@ package pod
 import (
 	"context"
 	"fmt"
-	"strings"
+	"slices"
 
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/logging"
 )
 
-const maxEventMessageLength = 1024
+const (
+	maxEventMessageLength = 1024
+	truncationSuffix      = "..."
+)
 
 // latestWarningEvent returns the reason and message of the most recent Warning
-// event for the given Pod. It performs a single, field-selected List scoped to
-// the Pod's UID. If no Warning events exist or the lookup fails, it returns
-// empty strings.
-func latestWarningEvent(ctx context.Context, logger *zap.SugaredLogger, kubeclient kubernetes.Interface, pod *corev1.Pod) (reason, message string) {
+// event for the given Pod. If no Warning events exist or the lookup fails, it
+// returns empty strings.
+func latestWarningEvent(ctx context.Context, kubeclient kubernetes.Interface, pod *corev1.Pod) (reason, message string) {
 	if pod.UID == "" {
 		return "", ""
 	}
@@ -41,32 +43,29 @@ func latestWarningEvent(ctx context.Context, logger *zap.SugaredLogger, kubeclie
 		FieldSelector: fmt.Sprintf("involvedObject.uid=%s,type=Warning", pod.UID),
 	})
 	if err != nil {
-		logger.Debugw("Failed to list pod warning events", "pod", pod.Name, "namespace", pod.Namespace, "error", err)
+		logging.FromContext(ctx).Debugw("Failed to list pod warning events", "pod", pod.Name, "namespace", pod.Namespace, "error", err)
 		return "", ""
 	}
 	if len(events.Items) == 0 {
 		return "", ""
 	}
 
-	latest := events.Items[0]
-	for i := range events.Items[1:] {
-		ev := &events.Items[i+1]
-		if ev.LastTimestamp.After(latest.LastTimestamp.Time) {
-			latest = *ev
-		}
-	}
+	latest := slices.MaxFunc(events.Items, func(a, b corev1.Event) int {
+		return a.LastTimestamp.Compare(b.LastTimestamp.Time)
+	})
 
 	msg := latest.Message
 	if len(msg) > maxEventMessageLength {
-		msg = msg[:maxEventMessageLength] + "..."
+		msg = msg[:maxEventMessageLength-len(truncationSuffix)] + truncationSuffix
 	}
 	return latest.Reason, msg
 }
 
 // isGenericPending returns true when the Pod is stuck in a pending state that
 // carries no actionable detail — the container waiting reason is
-// "ContainerCreating" with an empty message, or getWaitingMessage fell through
-// to one of its generic fallbacks.
+// "ContainerCreating" with an empty message, the Pod has not been scheduled
+// onto a node yet, or getWaitingMessage fell through to one of its generic
+// fallbacks.
 func isGenericPending(pod *corev1.Pod) bool {
 	for _, s := range pod.Status.ContainerStatuses {
 		if s.State.Waiting != nil && s.State.Waiting.Reason == "ContainerCreating" && s.State.Waiting.Message == "" {
@@ -78,10 +77,11 @@ func isGenericPending(pod *corev1.Pod) bool {
 			return true
 		}
 	}
-	// If no container statuses exist yet the pod hasn't been scheduled so we
-	// can't determine anything useful.
+	// No container statuses means the kubelet has not started on this Pod, so it
+	// has not been scheduled onto a node. Whatever is blocking scheduling is
+	// reported only via Warning events such as FailedScheduling.
 	if len(pod.Status.ContainerStatuses) == 0 && len(pod.Status.InitContainerStatuses) == 0 {
-		return false
+		return true
 	}
 	// This matches the final fallback path in getWaitingMessage: no container
 	// has a waiting message, all pod conditions are True, and pod.Status.Message
@@ -109,13 +109,4 @@ func allConditionsTrue(pod *corev1.Pod) bool {
 		}
 	}
 	return true
-}
-
-// formatEventMessage formats an event reason and message into a string
-// suitable for a TaskRun status condition message.
-func formatEventMessage(reason, message string) string {
-	if strings.TrimSpace(message) == "" {
-		return reason
-	}
-	return fmt.Sprintf("%s: %s", reason, message)
 }

--- a/pkg/pod/events.go
+++ b/pkg/pod/events.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const maxEventMessageLength = 1024
+
+// latestWarningEvent returns the reason and message of the most recent Warning
+// event for the given Pod. It performs a single, field-selected List scoped to
+// the Pod's UID. If no Warning events exist or the lookup fails, it returns
+// empty strings.
+func latestWarningEvent(ctx context.Context, logger *zap.SugaredLogger, kubeclient kubernetes.Interface, pod *corev1.Pod) (reason, message string) {
+	if pod.UID == "" {
+		return "", ""
+	}
+	events, err := kubeclient.CoreV1().Events(pod.Namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.uid=%s,type=Warning", pod.UID),
+	})
+	if err != nil {
+		logger.Debugw("Failed to list pod warning events", "pod", pod.Name, "namespace", pod.Namespace, "error", err)
+		return "", ""
+	}
+	if len(events.Items) == 0 {
+		return "", ""
+	}
+
+	latest := events.Items[0]
+	for i := range events.Items[1:] {
+		ev := &events.Items[i+1]
+		if ev.LastTimestamp.After(latest.LastTimestamp.Time) {
+			latest = *ev
+		}
+	}
+
+	msg := latest.Message
+	if len(msg) > maxEventMessageLength {
+		msg = msg[:maxEventMessageLength] + "..."
+	}
+	return latest.Reason, msg
+}
+
+// isGenericPending returns true when the Pod is stuck in a pending state that
+// carries no actionable detail — the container waiting reason is
+// "ContainerCreating" with an empty message, or getWaitingMessage fell through
+// to one of its generic fallbacks.
+func isGenericPending(pod *corev1.Pod) bool {
+	for _, s := range pod.Status.ContainerStatuses {
+		if s.State.Waiting != nil && s.State.Waiting.Reason == "ContainerCreating" && s.State.Waiting.Message == "" {
+			return true
+		}
+	}
+	for _, s := range pod.Status.InitContainerStatuses {
+		if s.State.Waiting != nil && s.State.Waiting.Reason == "ContainerCreating" && s.State.Waiting.Message == "" {
+			return true
+		}
+	}
+	// If no container statuses exist yet the pod hasn't been scheduled so we
+	// can't determine anything useful.
+	if len(pod.Status.ContainerStatuses) == 0 && len(pod.Status.InitContainerStatuses) == 0 {
+		return false
+	}
+	// This matches the final fallback path in getWaitingMessage: no container
+	// has a waiting message, all pod conditions are True, and pod.Status.Message
+	// is empty, so getWaitingMessage would return the bare "Pending" string
+	// with no actionable detail.
+	if noContainerHasWaitingMessage(pod) && allConditionsTrue(pod) && pod.Status.Message == "" {
+		return true
+	}
+	return false
+}
+
+func noContainerHasWaitingMessage(pod *corev1.Pod) bool {
+	for _, s := range pod.Status.ContainerStatuses {
+		if s.State.Waiting != nil && s.State.Waiting.Message != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func allConditionsTrue(pod *corev1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Status != corev1.ConditionTrue {
+			return false
+		}
+	}
+	return true
+}
+
+// formatEventMessage formats an event reason and message into a string
+// suitable for a TaskRun status condition message.
+func formatEventMessage(reason, message string) string {
+	if strings.TrimSpace(message) == "" {
+		return reason
+	}
+	return fmt.Sprintf("%s: %s", reason, message)
+}

--- a/pkg/pod/events.go
+++ b/pkg/pod/events.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	maxEventMessageLength = 1024
-	truncationSuffix      = "..."
+	maxEventMessageLength          = 1024
+	truncationSuffix               = "..."
+	containerWaitingReasonCreating = "ContainerCreating"
 )
 
 // latestWarningEvent returns the reason and message of the most recent Warning
@@ -68,12 +69,12 @@ func latestWarningEvent(ctx context.Context, kubeclient kubernetes.Interface, po
 // fallbacks.
 func isGenericPending(pod *corev1.Pod) bool {
 	for _, s := range pod.Status.ContainerStatuses {
-		if s.State.Waiting != nil && s.State.Waiting.Reason == "ContainerCreating" && s.State.Waiting.Message == "" {
+		if s.State.Waiting != nil && s.State.Waiting.Reason == containerWaitingReasonCreating && s.State.Waiting.Message == "" {
 			return true
 		}
 	}
 	for _, s := range pod.Status.InitContainerStatuses {
-		if s.State.Waiting != nil && s.State.Waiting.Reason == "ContainerCreating" && s.State.Waiting.Message == "" {
+		if s.State.Waiting != nil && s.State.Waiting.Reason == containerWaitingReasonCreating && s.State.Waiting.Message == "" {
 			return true
 		}
 	}

--- a/pkg/pod/events_test.go
+++ b/pkg/pod/events_test.go
@@ -142,7 +142,7 @@ func TestIsGenericPending(t *testing.T) {
 					ContainerStatuses: []corev1.ContainerStatus{{
 						State: corev1.ContainerState{
 							Waiting: &corev1.ContainerStateWaiting{
-								Reason: "ContainerCreating",
+								Reason: containerWaitingReasonCreating,
 							},
 						},
 					}},
@@ -157,7 +157,7 @@ func TestIsGenericPending(t *testing.T) {
 					ContainerStatuses: []corev1.ContainerStatus{{
 						State: corev1.ContainerState{
 							Waiting: &corev1.ContainerStateWaiting{
-								Reason:  "ContainerCreating",
+								Reason:  containerWaitingReasonCreating,
 								Message: "something useful",
 							},
 						},
@@ -223,7 +223,7 @@ func TestIsGenericPending(t *testing.T) {
 					InitContainerStatuses: []corev1.ContainerStatus{{
 						State: corev1.ContainerState{
 							Waiting: &corev1.ContainerStateWaiting{
-								Reason: "ContainerCreating",
+								Reason: containerWaitingReasonCreating,
 							},
 						},
 					}},

--- a/pkg/pod/events_test.go
+++ b/pkg/pod/events_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
-	"knative.dev/pkg/logging"
 )
 
 func TestLatestWarningEvent(t *testing.T) {
@@ -53,7 +52,7 @@ func TestLatestWarningEvent(t *testing.T) {
 					Type:           "Warning",
 					Reason:         "FailedScheduling",
 					Message:        "old scheduling error",
-					LastTimestamp:   earlier,
+					LastTimestamp:  earlier,
 				},
 				{
 					ObjectMeta:     metav1.ObjectMeta{Name: "new-evt", Namespace: "ns"},
@@ -61,7 +60,7 @@ func TestLatestWarningEvent(t *testing.T) {
 					Type:           "Warning",
 					Reason:         "FailedMount",
 					Message:        `secret "my-secret" not found`,
-					LastTimestamp:   now,
+					LastTimestamp:  now,
 				},
 			},
 			wantReason: "FailedMount",
@@ -102,10 +101,10 @@ func TestLatestWarningEvent(t *testing.T) {
 				Type:           "Warning",
 				Reason:         "FailedMount",
 				Message:        strings.Repeat("x", 2000),
-				LastTimestamp:   now,
+				LastTimestamp:  now,
 			}},
 			wantReason: "FailedMount",
-			wantMsg:    strings.Repeat("x", maxEventMessageLength) + "...",
+			wantMsg:    strings.Repeat("x", maxEventMessageLength-len(truncationSuffix)) + truncationSuffix,
 		},
 	}
 
@@ -116,13 +115,15 @@ func TestLatestWarningEvent(t *testing.T) {
 				_, _ = kubeclient.CoreV1().Events(tt.events[i].Namespace).Create(t.Context(), &tt.events[i], metav1.CreateOptions{})
 			}
 
-			logger, _ := logging.NewLogger("", "")
-			reason, msg := latestWarningEvent(t.Context(), logger, kubeclient, tt.pod)
+			reason, msg := latestWarningEvent(t.Context(), kubeclient, tt.pod)
 			if reason != tt.wantReason {
 				t.Errorf("reason = %q, want %q", reason, tt.wantReason)
 			}
 			if msg != tt.wantMsg {
 				t.Errorf("message = %q, want %q", msg, tt.wantMsg)
+			}
+			if len(msg) > maxEventMessageLength {
+				t.Errorf("message length = %d, want at most %d", len(msg), maxEventMessageLength)
 			}
 		})
 	}
@@ -182,16 +183,22 @@ func TestIsGenericPending(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "no containers at all is not generic",
+			name: "unschedulable pod is generic",
 			pod: &corev1.Pod{
 				Status: corev1.PodStatus{
 					Conditions: []corev1.PodCondition{{
 						Type:   corev1.PodScheduled,
-						Status: corev1.ConditionTrue,
+						Status: corev1.ConditionFalse,
+						Reason: "Unschedulable",
 					}},
 				},
 			},
-			want: false,
+			want: true,
+		},
+		{
+			name: "pod with no container statuses yet is generic",
+			pod:  &corev1.Pod{},
+			want: true,
 		},
 		{
 			name: "ImagePullBackOff is not generic",
@@ -233,24 +240,5 @@ func TestIsGenericPending(t *testing.T) {
 				t.Errorf("isGenericPending() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestFormatEventMessage(t *testing.T) {
-	tests := []struct {
-		reason  string
-		message string
-		want    string
-	}{
-		{"FailedMount", "secret not found", "FailedMount: secret not found"},
-		{"FailedMount", "", "FailedMount"},
-		{"FailedMount", "   ", "FailedMount"},
-	}
-
-	for _, tt := range tests {
-		got := formatEventMessage(tt.reason, tt.message)
-		if got != tt.want {
-			t.Errorf("formatEventMessage(%q, %q) = %q, want %q", tt.reason, tt.message, got, tt.want)
-		}
 	}
 }

--- a/pkg/pod/events_test.go
+++ b/pkg/pod/events_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+	"knative.dev/pkg/logging"
+)
+
+func TestLatestWarningEvent(t *testing.T) {
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-5 * time.Minute))
+
+	tests := []struct {
+		name       string
+		pod        *corev1.Pod
+		events     []corev1.Event
+		wantReason string
+		wantMsg    string
+	}{
+		{
+			name: "returns most recent warning event",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod", Namespace: "ns", UID: types.UID("uid-1"),
+				},
+			},
+			events: []corev1.Event{
+				{
+					ObjectMeta:     metav1.ObjectMeta{Name: "old-evt", Namespace: "ns"},
+					InvolvedObject: corev1.ObjectReference{UID: "uid-1"},
+					Type:           "Warning",
+					Reason:         "FailedScheduling",
+					Message:        "old scheduling error",
+					LastTimestamp:   earlier,
+				},
+				{
+					ObjectMeta:     metav1.ObjectMeta{Name: "new-evt", Namespace: "ns"},
+					InvolvedObject: corev1.ObjectReference{UID: "uid-1"},
+					Type:           "Warning",
+					Reason:         "FailedMount",
+					Message:        `secret "my-secret" not found`,
+					LastTimestamp:   now,
+				},
+			},
+			wantReason: "FailedMount",
+			wantMsg:    `secret "my-secret" not found`,
+		},
+		{
+			name: "returns empty when no events exist",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod", Namespace: "ns", UID: types.UID("uid-2"),
+				},
+			},
+			events:     nil,
+			wantReason: "",
+			wantMsg:    "",
+		},
+		{
+			name: "returns empty when pod has no UID",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod", Namespace: "ns",
+				},
+			},
+			events:     nil,
+			wantReason: "",
+			wantMsg:    "",
+		},
+		{
+			name: "truncates long messages",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod", Namespace: "ns", UID: types.UID("uid-3"),
+				},
+			},
+			events: []corev1.Event{{
+				ObjectMeta:     metav1.ObjectMeta{Name: "long-evt", Namespace: "ns"},
+				InvolvedObject: corev1.ObjectReference{UID: "uid-3"},
+				Type:           "Warning",
+				Reason:         "FailedMount",
+				Message:        strings.Repeat("x", 2000),
+				LastTimestamp:   now,
+			}},
+			wantReason: "FailedMount",
+			wantMsg:    strings.Repeat("x", maxEventMessageLength) + "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubeclient := fakek8s.NewSimpleClientset()
+			for i := range tt.events {
+				_, _ = kubeclient.CoreV1().Events(tt.events[i].Namespace).Create(t.Context(), &tt.events[i], metav1.CreateOptions{})
+			}
+
+			logger, _ := logging.NewLogger("", "")
+			reason, msg := latestWarningEvent(t.Context(), logger, kubeclient, tt.pod)
+			if reason != tt.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tt.wantReason)
+			}
+			if msg != tt.wantMsg {
+				t.Errorf("message = %q, want %q", msg, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestIsGenericPending(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "ContainerCreating with empty message is generic",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason: "ContainerCreating",
+							},
+						},
+					}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ContainerCreating with a message is not generic",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  "ContainerCreating",
+								Message: "something useful",
+							},
+						},
+					}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "containers present but not waiting, all conditions true, no message is generic",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name:  "step-foo",
+						State: corev1.ContainerState{},
+					}},
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no containers at all is not generic",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ImagePullBackOff is not generic",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  "ImagePullBackOff",
+								Message: "pull failed",
+							},
+						},
+					}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "init container ContainerCreating with empty message is generic",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{{
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason: "ContainerCreating",
+							},
+						},
+					}},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isGenericPending(tt.pod)
+			if got != tt.want {
+				t.Errorf("isGenericPending() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatEventMessage(t *testing.T) {
+	tests := []struct {
+		reason  string
+		message string
+		want    string
+	}{
+		{"FailedMount", "secret not found", "FailedMount: secret not found"},
+		{"FailedMount", "", "FailedMount"},
+		{"FailedMount", "   ", "FailedMount"},
+	}
+
+	for _, tt := range tests {
+		got := formatEventMessage(tt.reason, tt.message)
+		if got != tt.want {
+			t.Errorf("formatEventMessage(%q, %q) = %q, want %q", tt.reason, tt.message, got, tt.want)
+		}
+	}
+}

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -142,7 +142,7 @@ func MakeTaskRunStatus(ctx context.Context, logger *zap.SugaredLogger, tr v1.Tas
 			updateCompletedTaskRunStatus(logger, trs, pod, "")
 		}
 	} else {
-		updateIncompleteTaskRunStatus(trs, pod)
+		updateIncompleteTaskRunStatus(ctx, logger, trs, pod, kubeclient)
 	}
 
 	trs.PodName = pod.Name
@@ -622,7 +622,7 @@ func updateCompletedTaskRunStatus(logger *zap.SugaredLogger, trs *v1.TaskRunStat
 	trs.CompletionTime = &metav1.Time{Time: time.Now()}
 }
 
-func updateIncompleteTaskRunStatus(trs *v1.TaskRunStatus, pod *corev1.Pod) {
+func updateIncompleteTaskRunStatus(ctx context.Context, logger *zap.SugaredLogger, trs *v1.TaskRunStatus, pod *corev1.Pod, kubeclient kubernetes.Interface) {
 	switch pod.Status.Phase {
 	case corev1.PodRunning:
 		markStatusRunning(trs, v1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
@@ -631,14 +631,19 @@ func updateIncompleteTaskRunStatus(trs *v1.TaskRunStatus, pod *corev1.Pod) {
 		case IsPodExceedingNodeResources(pod):
 			markStatusRunning(trs, ReasonExceededNodeResources, "TaskRun Pod exceeded available resources")
 		case isSubPathDirectoryError(pod):
-			// if subPath directory creation errors, mark as running and wait for recovery
 			markStatusRunning(trs, ReasonPodPending, "Waiting for subPath directory creation to complete")
 		case isPodHitConfigError(pod):
 			markStatusFailure(trs, ReasonCreateContainerConfigError, "Failed to create pod due to config error")
 		case isPullImageError(pod):
 			markStatusRunning(trs, ReasonPullImageFailed, getWaitingMessage(pod))
 		default:
-			markStatusRunning(trs, ReasonPodPending, getWaitingMessage(pod))
+			msg := getWaitingMessage(pod)
+			if config.FromContextOrDefaults(ctx).FeatureFlags.EnableSurfacePodEvents && isGenericPending(pod) {
+				if evReason, evMsg := latestWarningEvent(ctx, logger, kubeclient, pod); evMsg != "" {
+					msg = formatEventMessage(evReason, evMsg)
+				}
+			}
+			markStatusRunning(trs, ReasonPodPending, msg)
 		}
 	case corev1.PodSucceeded, corev1.PodFailed, corev1.PodUnknown:
 		// Do nothing; pod has completed or is in an unknown state.

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -142,7 +142,7 @@ func MakeTaskRunStatus(ctx context.Context, logger *zap.SugaredLogger, tr v1.Tas
 			updateCompletedTaskRunStatus(logger, trs, pod, "")
 		}
 	} else {
-		updateIncompleteTaskRunStatus(ctx, logger, trs, pod, kubeclient)
+		updateIncompleteTaskRunStatus(ctx, trs, pod, kubeclient)
 	}
 
 	trs.PodName = pod.Name
@@ -622,7 +622,7 @@ func updateCompletedTaskRunStatus(logger *zap.SugaredLogger, trs *v1.TaskRunStat
 	trs.CompletionTime = &metav1.Time{Time: time.Now()}
 }
 
-func updateIncompleteTaskRunStatus(ctx context.Context, logger *zap.SugaredLogger, trs *v1.TaskRunStatus, pod *corev1.Pod, kubeclient kubernetes.Interface) {
+func updateIncompleteTaskRunStatus(ctx context.Context, trs *v1.TaskRunStatus, pod *corev1.Pod, kubeclient kubernetes.Interface) {
 	switch pod.Status.Phase {
 	case corev1.PodRunning:
 		markStatusRunning(trs, v1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
@@ -639,8 +639,11 @@ func updateIncompleteTaskRunStatus(ctx context.Context, logger *zap.SugaredLogge
 		default:
 			msg := getWaitingMessage(pod)
 			if config.FromContextOrDefaults(ctx).FeatureFlags.EnableSurfacePodEvents && isGenericPending(pod) {
-				if evReason, evMsg := latestWarningEvent(ctx, logger, kubeclient, pod); evMsg != "" {
-					msg = formatEventMessage(evReason, evMsg)
+				if eventReason, eventMsg := latestWarningEvent(ctx, kubeclient, pod); eventReason != "" {
+					msg = eventReason
+					if eventMsg = strings.TrimSpace(eventMsg); eventMsg != "" {
+						msg += ": " + eventMsg
+					}
 				}
 			}
 			markStatusRunning(trs, ReasonPodPending, msg)

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -3939,7 +3939,7 @@ func TestUpdateIncompleteTaskRunStatus_SurfacePodEvents(t *testing.T) {
 						Name: "step-foo",
 						State: corev1.ContainerState{
 							Waiting: &corev1.ContainerStateWaiting{
-								Reason: "ContainerCreating",
+								Reason: containerWaitingReasonCreating,
 							},
 						},
 					}},
@@ -3975,7 +3975,7 @@ func TestUpdateIncompleteTaskRunStatus_SurfacePodEvents(t *testing.T) {
 						Name: "step-foo",
 						State: corev1.ContainerState{
 							Waiting: &corev1.ContainerStateWaiting{
-								Reason: "ContainerCreating",
+								Reason: containerWaitingReasonCreating,
 							},
 						},
 					}},
@@ -4011,7 +4011,7 @@ func TestUpdateIncompleteTaskRunStatus_SurfacePodEvents(t *testing.T) {
 						Name: "step-foo",
 						State: corev1.ContainerState{
 							Waiting: &corev1.ContainerStateWaiting{
-								Reason: "ContainerCreating",
+								Reason: containerWaitingReasonCreating,
 							},
 						},
 					}},
@@ -4040,7 +4040,7 @@ func TestUpdateIncompleteTaskRunStatus_SurfacePodEvents(t *testing.T) {
 						Name: "step-foo",
 						State: corev1.ContainerState{
 							Waiting: &corev1.ContainerStateWaiting{
-								Reason:  "ContainerCreating",
+								Reason:  containerWaitingReasonCreating,
 								Message: "some useful message from kubelet",
 							},
 						},
@@ -4110,7 +4110,7 @@ func TestUpdateIncompleteTaskRunStatus_SurfacePodEvents(t *testing.T) {
 						Name: "step-foo",
 						State: corev1.ContainerState{
 							Waiting: &corev1.ContainerStateWaiting{
-								Reason: "ContainerCreating",
+								Reason: containerWaitingReasonCreating,
 							},
 						},
 					}},

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -3905,8 +3905,184 @@ func TestUpdateIncompleteTaskRunStatus_SubPathError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			updateIncompleteTaskRunStatus(tt.trs, tt.pod)
+			ctx := config.ToContext(t.Context(), &config.Config{
+				FeatureFlags: &config.FeatureFlags{},
+			})
+			logger, _ := logging.NewLogger("", "")
+			kubeclient := fakek8s.NewSimpleClientset()
+			updateIncompleteTaskRunStatus(ctx, logger, tt.trs, tt.pod, kubeclient)
 			if d := cmp.Diff(tt.expected, tt.trs.GetCondition(apis.ConditionSucceeded), cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time")); d != "" {
+				t.Errorf("Unexpected status: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestUpdateIncompleteTaskRunStatus_SurfacePodEvents(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		events   []corev1.Event
+		flagOn   bool
+		expected *apis.Condition
+	}{
+		{
+			name: "generic pending with FailedMount event and flag on",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+					UID:       "test-uid",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "step-foo",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason: "ContainerCreating",
+							},
+						},
+					}},
+				},
+			},
+			events: []corev1.Event{{
+				ObjectMeta:     metav1.ObjectMeta{Name: "evt1", Namespace: "ns"},
+				InvolvedObject: corev1.ObjectReference{UID: "test-uid"},
+				Type:           "Warning",
+				Reason:         "FailedMount",
+				Message:        `MountVolume.SetUp failed for volume "vol" : secret "does-not-exist" not found`,
+				LastTimestamp:   metav1.Now(),
+			}},
+			flagOn: true,
+			expected: &apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionUnknown,
+				Reason:  "Pending",
+				Message: `FailedMount: MountVolume.SetUp failed for volume "vol" : secret "does-not-exist" not found`,
+			},
+		},
+		{
+			name: "generic pending with FailedMount event but flag off",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+					UID:       "test-uid",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "step-foo",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason: "ContainerCreating",
+							},
+						},
+					}},
+				},
+			},
+			events: []corev1.Event{{
+				ObjectMeta:     metav1.ObjectMeta{Name: "evt1", Namespace: "ns"},
+				InvolvedObject: corev1.ObjectReference{UID: "test-uid"},
+				Type:           "Warning",
+				Reason:         "FailedMount",
+				Message:        `MountVolume.SetUp failed for volume "vol" : secret "does-not-exist" not found`,
+				LastTimestamp:   metav1.Now(),
+			}},
+			flagOn: false,
+			expected: &apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionUnknown,
+				Reason:  "Pending",
+				Message: "Pending",
+			},
+		},
+		{
+			name: "generic pending with no events and flag on",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+					UID:       "test-uid",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "step-foo",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason: "ContainerCreating",
+							},
+						},
+					}},
+				},
+			},
+			events: nil,
+			flagOn: true,
+			expected: &apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionUnknown,
+				Reason:  "Pending",
+				Message: "Pending",
+			},
+		},
+		{
+			name: "non-generic pending skips event lookup even with flag on",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+					UID:       "test-uid",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "step-foo",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  "ContainerCreating",
+								Message: "some useful message from kubelet",
+							},
+						},
+					}},
+				},
+			},
+			events: []corev1.Event{{
+				ObjectMeta:     metav1.ObjectMeta{Name: "evt1", Namespace: "ns"},
+				InvolvedObject: corev1.ObjectReference{UID: "test-uid"},
+				Type:           "Warning",
+				Reason:         "FailedMount",
+				Message:        "should not appear",
+				LastTimestamp:   metav1.Now(),
+			}},
+			flagOn: true,
+			expected: &apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionUnknown,
+				Reason:  "Pending",
+				Message: `build step "step-foo" is pending with reason "some useful message from kubelet"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubeclient := fakek8s.NewSimpleClientset()
+			for i := range tt.events {
+				_, _ = kubeclient.CoreV1().Events(tt.events[i].Namespace).Create(t.Context(), &tt.events[i], metav1.CreateOptions{})
+			}
+
+			ctx := config.ToContext(t.Context(), &config.Config{
+				FeatureFlags: &config.FeatureFlags{
+					EnableSurfacePodEvents: tt.flagOn,
+				},
+			})
+
+			logger, _ := logging.NewLogger("", "")
+			trs := &v1.TaskRunStatus{}
+			updateIncompleteTaskRunStatus(ctx, logger, trs, tt.pod, kubeclient)
+			if d := cmp.Diff(tt.expected, trs.GetCondition(apis.ConditionSucceeded), cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time")); d != "" {
 				t.Errorf("Unexpected status: %s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -3908,9 +3908,8 @@ func TestUpdateIncompleteTaskRunStatus_SubPathError(t *testing.T) {
 			ctx := config.ToContext(t.Context(), &config.Config{
 				FeatureFlags: &config.FeatureFlags{},
 			})
-			logger, _ := logging.NewLogger("", "")
 			kubeclient := fakek8s.NewSimpleClientset()
-			updateIncompleteTaskRunStatus(ctx, logger, tt.trs, tt.pod, kubeclient)
+			updateIncompleteTaskRunStatus(ctx, tt.trs, tt.pod, kubeclient)
 			if d := cmp.Diff(tt.expected, tt.trs.GetCondition(apis.ConditionSucceeded), cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time")); d != "" {
 				t.Errorf("Unexpected status: %s", diff.PrintWantGot(d))
 			}
@@ -3952,7 +3951,7 @@ func TestUpdateIncompleteTaskRunStatus_SurfacePodEvents(t *testing.T) {
 				Type:           "Warning",
 				Reason:         "FailedMount",
 				Message:        `MountVolume.SetUp failed for volume "vol" : secret "does-not-exist" not found`,
-				LastTimestamp:   metav1.Now(),
+				LastTimestamp:  metav1.Now(),
 			}},
 			flagOn: true,
 			expected: &apis.Condition{
@@ -3988,7 +3987,7 @@ func TestUpdateIncompleteTaskRunStatus_SurfacePodEvents(t *testing.T) {
 				Type:           "Warning",
 				Reason:         "FailedMount",
 				Message:        `MountVolume.SetUp failed for volume "vol" : secret "does-not-exist" not found`,
-				LastTimestamp:   metav1.Now(),
+				LastTimestamp:  metav1.Now(),
 			}},
 			flagOn: false,
 			expected: &apis.Condition{
@@ -4054,7 +4053,7 @@ func TestUpdateIncompleteTaskRunStatus_SurfacePodEvents(t *testing.T) {
 				Type:           "Warning",
 				Reason:         "FailedMount",
 				Message:        "should not appear",
-				LastTimestamp:   metav1.Now(),
+				LastTimestamp:  metav1.Now(),
 			}},
 			flagOn: true,
 			expected: &apis.Condition{
@@ -4062,6 +4061,74 @@ func TestUpdateIncompleteTaskRunStatus_SurfacePodEvents(t *testing.T) {
 				Status:  corev1.ConditionUnknown,
 				Reason:  "Pending",
 				Message: `build step "step-foo" is pending with reason "some useful message from kubelet"`,
+			},
+		},
+		{
+			name: "unschedulable pod surfaces FailedScheduling event",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+					UID:       "test-uid",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+						Reason: "Unschedulable",
+					}},
+				},
+			},
+			events: []corev1.Event{{
+				ObjectMeta:     metav1.ObjectMeta{Name: "evt1", Namespace: "ns"},
+				InvolvedObject: corev1.ObjectReference{UID: "test-uid"},
+				Type:           "Warning",
+				Reason:         "FailedScheduling",
+				Message:        "0/3 nodes are available: 3 Insufficient cpu.",
+				LastTimestamp:  metav1.Now(),
+			}},
+			flagOn: true,
+			expected: &apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionUnknown,
+				Reason:  "Pending",
+				Message: "FailedScheduling: 0/3 nodes are available: 3 Insufficient cpu.",
+			},
+		},
+		{
+			name: "event with reason but no message surfaces the reason alone",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "ns",
+					UID:       "test-uid",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "step-foo",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason: "ContainerCreating",
+							},
+						},
+					}},
+				},
+			},
+			events: []corev1.Event{{
+				ObjectMeta:     metav1.ObjectMeta{Name: "evt1", Namespace: "ns"},
+				InvolvedObject: corev1.ObjectReference{UID: "test-uid"},
+				Type:           "Warning",
+				Reason:         "FailedCreatePodSandBox",
+				LastTimestamp:  metav1.Now(),
+			}},
+			flagOn: true,
+			expected: &apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionUnknown,
+				Reason:  "Pending",
+				Message: "FailedCreatePodSandBox",
 			},
 		},
 	}
@@ -4079,9 +4146,8 @@ func TestUpdateIncompleteTaskRunStatus_SurfacePodEvents(t *testing.T) {
 				},
 			})
 
-			logger, _ := logging.NewLogger("", "")
 			trs := &v1.TaskRunStatus{}
-			updateIncompleteTaskRunStatus(ctx, logger, trs, tt.pod, kubeclient)
+			updateIncompleteTaskRunStatus(ctx, trs, tt.pod, kubeclient)
 			if d := cmp.Diff(tt.expected, trs.GetCondition(apis.ConditionSucceeded), cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time")); d != "" {
 				t.Errorf("Unexpected status: %s", diff.PrintWantGot(d))
 			}


### PR DESCRIPTION
# Changes

Fixes #10373

When a Pod is stuck `Pending` with `ContainerCreating` and no useful message
(e.g. a Secret mounted as a volume doesn't exist), the actionable reason
exists only in Kubernetes Events — never on the Pod object. Today the TaskRun
sits with a generic `"Pending"` message until timeout.

This PR adds a new alpha feature flag `surface-pod-events` (disabled by
default) that, when enabled, performs a single field-selected Events List
scoped to the stuck Pod's UID. If a Warning event is found (e.g.
`FailedMount`, `FailedScheduling`, `FailedCreatePodSandBox`), its reason and
message are surfaced onto the TaskRun status condition.

**What changed:**

- **Feature flag**: Added `surface-pod-events` alpha flag to
  `pkg/apis/config/feature_flags.go` and `config/config-feature-flags.yaml`.
- **Event lookup**: Introduced `pkg/pod/events.go` with `latestWarningEvent`,
  `isGenericPending`, and `formatEventMessage` helpers.
- **Status wiring**: Extended `updateIncompleteTaskRunStatus` in
  `pkg/pod/status.go` to look up Pod events when the flag is enabled and the
  Pod is in a generic pending state.
- **RBAC**: Added `get`, `list` to the controller's `events` permissions in
  `config/200-clusterrole.yaml`.
- **Tests**: Added unit tests for all new helpers (`pkg/pod/events_test.go`),
  integration tests for the feature-flagged status path
  (`pkg/pod/status_test.go`), and feature flag parsing tests.

**Design decisions:**
- No informer or watch on Events — single targeted List per reconcile, only
  when the Pod is stuck with no useful status.
- Event message bounded to 1024 characters to avoid etcd bloat.
- Most-recent Warning event is selected when multiple exist.
- Errors from the Events API are logged at debug level and silently fall back
  to the existing generic message.

# Submitter Checklist

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Surface Pod infrastructure failure reasons (from Warning events such as
FailedMount, FailedScheduling, FailedCreatePodSandBox) onto the TaskRun
status condition when a Pod is stuck pending with no useful message. Gated
behind the new `surface-pod-events` alpha feature flag (disabled by default).
```