### PR TITLE
Enqueue only a resolver's own ResolutionRequests

### DIFF
--- a/pkg/remoteresolution/resolver/framework/controller.go
+++ b/pkg/remoteresolution/resolver/framework/controller.go
@@ -57,10 +57,19 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 		// The promote path and the informer's event handler below must filter
 		// ResolutionRequests with the same selector, or a resolver reconciles
 		// requests that are not addressed to it.
+		//
+		// This is a second GetSelector call: the one validated above runs with
+		// a different context and before Initialize, so re-validate the exact
+		// value both paths are about to use rather than trusting that the two
+		// calls agree. An empty selector here would otherwise widen the
+		// promote path back to every ResolutionRequest in the cluster.
 		selector := resolver.GetSelector(ctx)
+		if err := framework.ValidateResolver(ctx, selector); err != nil {
+			panic(err.Error())
+		}
 
 		r := &Reconciler{
-			LeaderAwareFuncs:           framework.LeaderAwareFuncs(rrInformer.Lister(), selector),
+			LeaderAwareFuncs:           framework.LeaderAwareFuncsWithSelector(rrInformer.Lister(), selector),
 			kubeClientSet:              kubeclientset,
 			resolutionRequestLister:    rrInformer.Lister(),
 			resolutionRequestClientSet: rrclientset,

--- a/pkg/remoteresolution/resolver/framework/controller.go
+++ b/pkg/remoteresolution/resolver/framework/controller.go
@@ -54,8 +54,13 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 			panic(err.Error())
 		}
 
+		// The promote path and the informer's event handler below must filter
+		// ResolutionRequests with the same selector, or a resolver reconciles
+		// requests that are not addressed to it.
+		selector := resolver.GetSelector(ctx)
+
 		r := &Reconciler{
-			LeaderAwareFuncs:           framework.LeaderAwareFuncs(rrInformer.Lister()),
+			LeaderAwareFuncs:           framework.LeaderAwareFuncs(rrInformer.Lister(), selector),
 			kubeClientSet:              kubeclientset,
 			resolutionRequestLister:    rrInformer.Lister(),
 			resolutionRequestClientSet: rrclientset,
@@ -78,7 +83,7 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 		})
 
 		_, err := rrInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: framework.FilterResolutionRequestsBySelector(resolver.GetSelector(ctx)),
+			FilterFunc: framework.FilterResolutionRequestsBySelector(selector),
 			Handler: cache.ResourceEventHandlerFuncs{
 				AddFunc: impl.Enqueue,
 				UpdateFunc: func(oldObj, newObj interface{}) {

--- a/pkg/resolution/resolver/framework/controller.go
+++ b/pkg/resolution/resolver/framework/controller.go
@@ -59,8 +59,13 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 			panic(err.Error())
 		}
 
+		// The promote path and the informer's event handler below must filter
+		// ResolutionRequests with the same selector, or a resolver reconciles
+		// requests that are not addressed to it.
+		selector := resolver.GetSelector(ctx)
+
 		r := &Reconciler{
-			LeaderAwareFuncs:           LeaderAwareFuncs(rrInformer.Lister()),
+			LeaderAwareFuncs:           LeaderAwareFuncs(rrInformer.Lister(), selector),
 			kubeClientSet:              kubeclientset,
 			resolutionRequestLister:    rrInformer.Lister(),
 			resolutionRequestClientSet: rrclientset,
@@ -82,7 +87,7 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 		})
 
 		_, err := rrInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: FilterResolutionRequestsBySelector(resolver.GetSelector(ctx)),
+			FilterFunc: FilterResolutionRequestsBySelector(selector),
 			Handler: cache.ResourceEventHandlerFuncs{
 				AddFunc: impl.Enqueue,
 				UpdateFunc: func(oldObj, newObj interface{}) {
@@ -151,14 +156,20 @@ func FilterResolutionRequestsBySelector(selector map[string]string) func(obj int
 	}
 }
 
-// TODO(sbwsg): I don't really understand the LeaderAwareness types beyond the
-// fact that the controller crashes if they're missing. It looks
-// like this is bucketing based on labels. Should we use the filter
-// selector from above in the call to lister.List here?
-func LeaderAwareFuncs(lister rrlister.ResolutionRequestLister) reconciler.LeaderAwareFuncs {
+// LeaderAwareFuncs returns the LeaderAwareFuncs for a resolver's reconciler.
+// On promotion it re-enqueues only the ResolutionRequests this resolver is
+// responsible for, matching the labels that FilterResolutionRequestsBySelector
+// applies to the informer's event handler. Listing without the selector hands
+// every resolver every ResolutionRequest, and since the reconciler has no label
+// guard of its own the wrong resolver then fails requests never addressed to it.
+//
+// selector must be non-empty: labels.SelectorFromSet treats an empty set as
+// labels.Everything(). Callers get this from ValidateResolver, which rejects a
+// selector without a resolution.tekton.dev/type label.
+func LeaderAwareFuncs(lister rrlister.ResolutionRequestLister, selector map[string]string) reconciler.LeaderAwareFuncs {
 	return reconciler.LeaderAwareFuncs{
 		PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
-			all, err := lister.List(labels.Everything())
+			all, err := lister.List(labels.SelectorFromSet(selector))
 			if err != nil {
 				return err
 			}

--- a/pkg/resolution/resolver/framework/controller.go
+++ b/pkg/resolution/resolver/framework/controller.go
@@ -62,10 +62,19 @@ func NewController(ctx context.Context, resolver Resolver, modifiers ...Reconcil
 		// The promote path and the informer's event handler below must filter
 		// ResolutionRequests with the same selector, or a resolver reconciles
 		// requests that are not addressed to it.
+		//
+		// This is a second GetSelector call: the one validated above runs with
+		// a different context and before Initialize, so re-validate the exact
+		// value both paths are about to use rather than trusting that the two
+		// calls agree. An empty selector here would otherwise widen the
+		// promote path back to every ResolutionRequest in the cluster.
 		selector := resolver.GetSelector(ctx)
+		if err := ValidateResolver(ctx, selector); err != nil {
+			panic(err.Error())
+		}
 
 		r := &Reconciler{
-			LeaderAwareFuncs:           LeaderAwareFuncs(rrInformer.Lister(), selector),
+			LeaderAwareFuncs:           LeaderAwareFuncsWithSelector(rrInformer.Lister(), selector),
 			kubeClientSet:              kubeclientset,
 			resolutionRequestLister:    rrInformer.Lister(),
 			resolutionRequestClientSet: rrclientset,
@@ -156,20 +165,48 @@ func FilterResolutionRequestsBySelector(selector map[string]string) func(obj int
 	}
 }
 
-// LeaderAwareFuncs returns the LeaderAwareFuncs for a resolver's reconciler.
-// On promotion it re-enqueues only the ResolutionRequests this resolver is
-// responsible for, matching the labels that FilterResolutionRequestsBySelector
-// applies to the informer's event handler. Listing without the selector hands
-// every resolver every ResolutionRequest, and since the reconciler has no label
-// guard of its own the wrong resolver then fails requests never addressed to it.
+// LeaderAwareFuncs returns the LeaderAwareFuncs for a resolver's reconciler,
+// re-enqueueing every ResolutionRequest in the cluster on promotion.
 //
-// selector must be non-empty: labels.SelectorFromSet treats an empty set as
-// labels.Everything(). Callers get this from ValidateResolver, which rejects a
-// selector without a resolution.tekton.dev/type label.
-func LeaderAwareFuncs(lister rrlister.ResolutionRequestLister, selector map[string]string) reconciler.LeaderAwareFuncs {
+// Deprecated: use LeaderAwareFuncsWithSelector. Listing without a selector
+// hands every resolver every ResolutionRequest, and since the reconciler has
+// no label guard of its own the wrong resolver then fails requests never
+// addressed to it. This signature is kept so that callers outside this
+// repository keep compiling, and its behaviour is unchanged.
+func LeaderAwareFuncs(lister rrlister.ResolutionRequestLister) reconciler.LeaderAwareFuncs {
+	return leaderAwareFuncs(lister, labels.Everything())
+}
+
+// LeaderAwareFuncsWithSelector returns the LeaderAwareFuncs for a resolver's
+// reconciler. On promotion it re-enqueues only the ResolutionRequests this
+// resolver is responsible for, matching the labels that
+// FilterResolutionRequestsBySelector applies to the informer's event handler,
+// so the two paths cannot drift.
+//
+// An empty selector fails closed and enqueues nothing. labels.SelectorFromSet
+// treats an empty set as labels.Everything(), which is the very bug this
+// function exists to fix, so it must not be reachable by way of a resolver
+// that returns no selector. Callers validate the selector with
+// ValidateResolver, which rejects one without a resolution.tekton.dev/type
+// label; failing closed here is the second line of defence.
+func LeaderAwareFuncsWithSelector(lister rrlister.ResolutionRequestLister, selector map[string]string) reconciler.LeaderAwareFuncs {
+	return leaderAwareFuncs(lister, promotionSelector(selector))
+}
+
+// promotionSelector converts a resolver's label set into the selector the
+// promote path lists with, mapping the empty set to labels.Nothing() rather
+// than to labels.Everything().
+func promotionSelector(selector map[string]string) labels.Selector {
+	if len(selector) == 0 {
+		return labels.Nothing()
+	}
+	return labels.SelectorFromSet(selector)
+}
+
+func leaderAwareFuncs(lister rrlister.ResolutionRequestLister, selector labels.Selector) reconciler.LeaderAwareFuncs {
 	return reconciler.LeaderAwareFuncs{
 		PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
-			all, err := lister.List(labels.SelectorFromSet(selector))
+			all, err := lister.List(selector)
 			if err != nil {
 				return err
 			}

--- a/pkg/resolution/resolver/framework/controller_test.go
+++ b/pkg/resolution/resolver/framework/controller_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/resolution/v1beta1"
+	rrlister "github.com/tektoncd/pipeline/pkg/client/resolution/listers/resolution/v1beta1"
+	resolutioncommon "github.com/tektoncd/pipeline/pkg/resolution/common"
+	"github.com/tektoncd/pipeline/pkg/resolution/resolver/framework"
+	"github.com/tektoncd/pipeline/test/diff"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	pkgreconciler "knative.dev/pkg/reconciler"
+)
+
+func resolutionRequest(namespace, name string, lbls map[string]string) *v1beta1.ResolutionRequest {
+	return &v1beta1.ResolutionRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    lbls,
+		},
+	}
+}
+
+// TestLeaderAwareFuncsPromoteFiltersBySelector checks that a resolver only
+// re-enqueues the ResolutionRequests addressed to it when it is promoted to
+// leader. Enqueueing every request into every resolver's workqueue makes the
+// wrong resolver fail requests it does not own, and because a failed request
+// is already done the correct resolver then skips it.
+func TestLeaderAwareFuncsPromoteFiltersBySelector(t *testing.T) {
+	requests := []*v1beta1.ResolutionRequest{
+		resolutionRequest("foo", "git-request", map[string]string{resolutioncommon.LabelKeyResolverType: "git"}),
+		resolutionRequest("foo", "http-request", map[string]string{resolutioncommon.LabelKeyResolverType: "http"}),
+		resolutionRequest("foo", "unlabeled-request", nil),
+		resolutionRequest("bar", "another-git-request", map[string]string{
+			resolutioncommon.LabelKeyResolverType: "git",
+			"custom-label":                        "some-value",
+		}),
+	}
+
+	for _, tc := range []struct {
+		name     string
+		selector map[string]string
+		want     []types.NamespacedName
+	}{{
+		name:     "only requests carrying the resolver's type are enqueued",
+		selector: map[string]string{resolutioncommon.LabelKeyResolverType: "git"},
+		want: []types.NamespacedName{
+			{Namespace: "bar", Name: "another-git-request"},
+			{Namespace: "foo", Name: "git-request"},
+		},
+	}, {
+		name:     "a request must match every label in the selector",
+		selector: map[string]string{resolutioncommon.LabelKeyResolverType: "git", "custom-label": "some-value"},
+		want: []types.NamespacedName{
+			{Namespace: "bar", Name: "another-git-request"},
+		},
+	}, {
+		name:     "a resolver with no matching requests enqueues nothing",
+		selector: map[string]string{resolutioncommon.LabelKeyResolverType: "bundles"},
+		want:     nil,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, rr := range requests {
+				if err := indexer.Add(rr); err != nil {
+					t.Fatalf("failed to seed indexer: %v", err)
+				}
+			}
+
+			var got []types.NamespacedName
+			enq := func(_ pkgreconciler.Bucket, key types.NamespacedName) {
+				got = append(got, key)
+			}
+
+			laf := framework.LeaderAwareFuncs(rrlister.NewResolutionRequestLister(indexer), tc.selector)
+			if err := laf.PromoteFunc(pkgreconciler.UniversalBucket(), enq); err != nil {
+				t.Fatalf("PromoteFunc returned an error: %v", err)
+			}
+
+			sortKeys := cmpopts.SortSlices(func(a, b types.NamespacedName) bool { return a.String() < b.String() })
+			if d := cmp.Diff(tc.want, got, sortKeys, cmpopts.EquateEmpty()); d != "" {
+				t.Errorf("wrong requests enqueued on promotion: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/resolution/resolver/framework/controller_test.go
+++ b/pkg/resolution/resolver/framework/controller_test.go
@@ -79,6 +79,18 @@ func TestLeaderAwareFuncsPromoteFiltersBySelector(t *testing.T) {
 		name:     "a resolver with no matching requests enqueues nothing",
 		selector: map[string]string{resolutioncommon.LabelKeyResolverType: "bundles"},
 		want:     nil,
+	}, {
+		// labels.SelectorFromSet maps the empty set to labels.Everything(),
+		// so a resolver that somehow reaches promotion without a selector
+		// would re-enqueue every request in the cluster -- the exact bug this
+		// filtering exists to fix. Fail closed instead.
+		name:     "a nil selector fails closed rather than matching everything",
+		selector: nil,
+		want:     nil,
+	}, {
+		name:     "an empty selector fails closed rather than matching everything",
+		selector: map[string]string{},
+		want:     nil,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
@@ -93,7 +105,7 @@ func TestLeaderAwareFuncsPromoteFiltersBySelector(t *testing.T) {
 				got = append(got, key)
 			}
 
-			laf := framework.LeaderAwareFuncs(rrlister.NewResolutionRequestLister(indexer), tc.selector)
+			laf := framework.LeaderAwareFuncsWithSelector(rrlister.NewResolutionRequestLister(indexer), tc.selector)
 			if err := laf.PromoteFunc(pkgreconciler.UniversalBucket(), enq); err != nil {
 				t.Fatalf("PromoteFunc returned an error: %v", err)
 			}
@@ -103,5 +115,45 @@ func TestLeaderAwareFuncsPromoteFiltersBySelector(t *testing.T) {
 				t.Errorf("wrong requests enqueued on promotion: %s", diff.PrintWantGot(d))
 			}
 		})
+	}
+}
+
+// TestLeaderAwareFuncsEnqueuesEverything pins the behaviour of the deprecated
+// LeaderAwareFuncs. It is kept for callers outside this repository, so it must
+// go on compiling with one argument and go on enqueueing every request --
+// narrowing it here would change what an external caller gets without them
+// touching a line of their own code.
+func TestLeaderAwareFuncsEnqueuesEverything(t *testing.T) {
+	requests := []*v1beta1.ResolutionRequest{
+		resolutionRequest("foo", "git-request", map[string]string{resolutioncommon.LabelKeyResolverType: "git"}),
+		resolutionRequest("foo", "http-request", map[string]string{resolutioncommon.LabelKeyResolverType: "http"}),
+		resolutionRequest("foo", "unlabeled-request", nil),
+	}
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, rr := range requests {
+		if err := indexer.Add(rr); err != nil {
+			t.Fatalf("failed to seed indexer: %v", err)
+		}
+	}
+
+	var got []types.NamespacedName
+	enq := func(_ pkgreconciler.Bucket, key types.NamespacedName) {
+		got = append(got, key)
+	}
+
+	laf := framework.LeaderAwareFuncs(rrlister.NewResolutionRequestLister(indexer))
+	if err := laf.PromoteFunc(pkgreconciler.UniversalBucket(), enq); err != nil {
+		t.Fatalf("PromoteFunc returned an error: %v", err)
+	}
+
+	want := []types.NamespacedName{
+		{Namespace: "foo", Name: "git-request"},
+		{Namespace: "foo", Name: "http-request"},
+		{Namespace: "foo", Name: "unlabeled-request"},
+	}
+	sortKeys := cmpopts.SortSlices(func(a, b types.NamespacedName) bool { return a.String() < b.String() })
+	if d := cmp.Diff(want, got, sortKeys, cmpopts.EquateEmpty()); d != "" {
+		t.Errorf("wrong requests enqueued on promotion: %s", diff.PrintWantGot(d))
 	}
 }


### PR DESCRIPTION
# Changes

On leader promotion the resolver framework listed ResolutionRequests with `labels.Everything()` and enqueued every one of them into every resolver's workqueue. The reconciler has no label guard of its own, so whichever resolver dequeued a request first ran `Validate()` and `Resolve()` on it regardless of its `resolution.tekton.dev/type` label. A request addressed to the http resolver could therefore be failed by the hub resolver with `missing required hub resolver params: name, version`, and since the request is then already done the correct resolver skips it.

The informer's event handler was already filtered by `FilterResolutionRequestsBySelector`. Only the promote path was not.

This passes the resolver's selector into `LeaderAwareFuncs` and lists with `labels.SelectorFromSet`, which applies the same AND-of-equality match the event handler uses. Both frameworks now read the selector once and share it between the two paths, so the two filters cannot drift apart. It also answers the `TODO(sbwsg)` that has sat on `LeaderAwareFuncs` since it was introduced ("Should we use the filter selector from above in the call to `lister.List` here?"), which is yes.

### Compatibility

No exported signature changes. `LeaderAwareFuncs` keeps its original one-argument form and its `labels.Everything()` behaviour, now marked deprecated; the filtered listing is a new `LeaderAwareFuncsWithSelector`, which is what the two in-tree `NewController` funcs call. Out-of-tree resolvers keep compiling untouched.

One behaviour note: an empty label set now maps to `labels.Nothing()` rather than `labels.Everything()`, and both controllers validate the selector and panic on an invalid one.

### Validation

- `go build ./...`, and every test binary under `./pkg/...` and `./cmd/...` compiles
- `go test ./pkg/resolution/... ./pkg/remoteresolution/...`, 21 packages pass
- `pre-commit run` on the changed files, including `make test-unit` over the whole repo
- The `lint-go` hook could not run because the install script rejects the golangci-lint v2.12.2 darwin/arm64 tarball on a checksum mismatch (`c8debe3b...` vs the expected `a9c54498...`). I installed that same pinned v2.12.2 with `go install` instead and ran it over both framework packages: 0 issues. Worth knowing if others hit it.
- The new `TestLeaderAwareFuncsPromoteFiltersBySelector` fails on all three table rows when the fix is reverted to `labels.Everything()`, with `http-request` and `unlabeled-request` leaking into the git resolver's queue.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

Fixes #10484

Relates to #

# Release Notes

```release-note
Resolvers no longer fail ResolutionRequests belonging to a different resolver after a leader election or a resolver pod restart.
```
