### PR TITLE
fix(nightlies): pass previousReleaseTag/releaseName to tkn pipeline start

### DIFF
--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -154,11 +154,12 @@ jobs:
 
       - name: Start Tekton Build Pipeline
         run: |
-          set -euo pipefail  # Exit on any error, undefined variables, or pipe failures
+          set -euo pipefail
 
           echo "Starting Tekton pipeline..."
 
-          PIPELINE_RUN=$(tkn pipeline start pipeline-release \
+          set +e
+          tkn pipeline start pipeline-release \
             --serviceaccount=release-right-meow \
             --param package="${PACKAGE}" \
             --param repoName="${REPO_NAME}" \
@@ -176,22 +177,35 @@ jobs:
             --param releaseAsLatest="true" \
             --param runTests="false" \
             --param releaseMode="nightly" \
+            --param previousReleaseTag="" \
+            --param releaseName="" \
             --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml \
             --workspace name=release-secret,secret=release-secret \
             --workspace name=release-images-secret,secret=release-images-secret \
             --tasks-timeout 2h \
             --pipeline-timeout 3h \
-            --output name) || {
+            --output name >/tmp/tkn-start-out 2>/tmp/tkn-start-err
+          START_RC=$?
+          set -e
+          if [ "${START_RC}" -ne 0 ]; then
             echo "Failed to start Tekton pipeline!"
+            echo "----- tkn pipeline start stdout (prompts appear here) -----"
+            cat /tmp/tkn-start-out || true
+            echo "----- tkn pipeline start stderr (error appears here) -----"
+            cat /tmp/tkn-start-err || true
+            echo "-----------------------------------------------------------"
             exit 1
-          }
+          fi
+          PIPELINE_RUN=$(awk 'NF{line=$0} END{print line}' /tmp/tkn-start-out)
+          if [ -z "${PIPELINE_RUN}" ]; then
+            echo "Could not determine PipelineRun name from tkn output!"
+            cat /tmp/tkn-start-out || true
+            exit 1
+          fi
 
           echo "Pipeline started: ${PIPELINE_RUN}"
-          # Note: tkn pipelinerun logs -f exits 0 even when the PipelineRun fails,
-          # so the jq check below is the authoritative success gate.
           tkn pipelinerun logs "${PIPELINE_RUN}" -f
 
-          # Check if pipeline succeeded
           tkn pipelinerun describe "${PIPELINE_RUN}" -o json \
             | jq -e '.status.conditions[] | select(.type=="Succeeded") | .status == "True"' > /dev/null || {
             echo "Pipeline failed!"


### PR DESCRIPTION
# Changes

Since #9420 the release Pipeline (`tekton/release-pipeline.yaml`) declares two new params, `previousReleaseTag` and `releaseName`. The nightly build workflow (`.github/workflows/nightly-builds.yaml`) never passed them, so `tkn pipeline
start` treated them as missing and tried to prompt for their values interactively:

```
? Value for param `previousReleaseTag` of type `string`? (Default is ``)
Error: EOF
```

In the headless GitHub Actions runner there is no TTY/stdin, so the prompt immediately reads EOF and the **Start Tekton Build Pipeline** step fails before the PipelineRun is ever created.

Note this happens at *param resolution* time, which is **before** any `when` guards or task skipping are evaluated. That is why #10441 (`releaseMode=nightly` gating of the draft-release tasks) does not prevent it. The failure occurs
earlier, at ** `tkn pipeline start`, regardless of which tasks would later be skipped.**

This PR:

- Passes `previousReleaseTag` and `releaseName` explicitly with empty values.  They are only consumed by the draft-release tasks, which are skipped in  nightly mode, so empty values are correct and match the cheat sheet style introduced in #9420.
- Makes the start step diagnosable: `tkn pipeline start` stdout and stderr are captured to separate files so that on failure **both** the interactive prompt  (stdout) and the terminating error (stderr) are printed. `PIPELINE_RUN` is derived from the captured stdout with a guard against empty output.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
