### PR TITLE
docs: include command to apply optional config to run e2e locally in development documentation

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -149,6 +149,12 @@ Environment variables used by end to end tests:
   is used to create/delete a bucket which will be used for output to input
   linking by the `PipelineRun` controller.
 
+Please note that in order to run the e2e tests in local machine, apply below optional RBAC config that grants controller access to Pod logs:
+
+```shell
+kubectl apply -f optional_config/enable-log-access-to-controller/
+```
+
 To create a service account usable in the e2e tests:
 
 ```bash


### PR DESCRIPTION
# Changes

To run e2e tests in local machine, added below command to apply optional configurations that grants controller access to Pod logs.

```bash
kubectl apply -f optional_config/enable-log-access-to-controller
```

**Screenshot of e2e tests passing in local**

<img width="699" height="231" alt="image" src="https://github.com/user-attachments/assets/debed55a-face-414d-9d14-95fdeab96b2e" /> 

Closes #10552

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
