### PR TITLE
fix: Reject bare workspace variable references in Task validation

### DIFF
--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -78,6 +78,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(ValidateVolumes(ts.Volumes).ViaField("volumes"))
 	errs = errs.Also(validateDeclaredWorkspaces(ts.Workspaces, ts.Steps, ts.StepTemplate).ViaField("workspaces"))
 	errs = errs.Also(validateWorkspaceUsages(ctx, ts))
+	errs = errs.Also(validateWorkspaceVariableExpressions(ts))
 	mergedSteps, err := MergeStepsWithStepTemplate(ts.StepTemplate, ts.Steps)
 	if err != nil {
 		errs = errs.Also(&apis.FieldError{
@@ -196,6 +197,71 @@ func validateWorkspaceUsages(ctx context.Context, ts *TaskSpec) (errs *apis.Fiel
 		}
 	}
 
+	return errs
+}
+
+// validateWorkspaceVariableExpressions checks that workspace variable references in Steps
+// and Sidecars always include a property suffix (path, bound, claim, or volume).
+// A bare reference like $(workspaces.myws) is invalid.
+func validateWorkspaceVariableExpressions(ts *TaskSpec) (errs *apis.FieldError) {
+	wsNames := sets.NewString()
+	for _, w := range ts.Workspaces {
+		wsNames.Insert(w.Name)
+	}
+	if wsNames.Len() == 0 {
+		return nil
+	}
+
+	for idx, step := range ts.Steps {
+		errs = errs.Also(validateStepHasNoBareWorkspaceVars(step, wsNames).ViaFieldIndex("steps", idx))
+	}
+	for idx, sidecar := range ts.Sidecars {
+		errs = errs.Also(validateSidecarHasNoBareWorkspaceVars(sidecar, wsNames).ViaFieldIndex("sidecars", idx))
+	}
+	return errs
+}
+
+func validateStepHasNoBareWorkspaceVars(step Step, wsNames sets.String) *apis.FieldError {
+	errs := substitution.ValidateNoReferencesToBareVariables(step.Name, "workspaces", wsNames).ViaField("name")
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(step.Image, "workspaces", wsNames).ViaField("image"))
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(step.WorkingDir, "workspaces", wsNames).ViaField("workingDir"))
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(step.Script, "workspaces", wsNames).ViaField("script"))
+	for i, cmd := range step.Command {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(cmd, "workspaces", wsNames).ViaFieldIndex("command", i))
+	}
+	for i, arg := range step.Args {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(arg, "workspaces", wsNames).ViaFieldIndex("args", i))
+	}
+	for _, env := range step.Env {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(env.Value, "workspaces", wsNames).ViaFieldKey("env", env.Name))
+	}
+	for i, v := range step.VolumeMounts {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.Name, "workspaces", wsNames).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.MountPath, "workspaces", wsNames).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.SubPath, "workspaces", wsNames).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
+	}
+	return errs
+}
+
+func validateSidecarHasNoBareWorkspaceVars(sidecar Sidecar, wsNames sets.String) *apis.FieldError {
+	errs := substitution.ValidateNoReferencesToBareVariables(sidecar.Name, "workspaces", wsNames).ViaField("name")
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(sidecar.Image, "workspaces", wsNames).ViaField("image"))
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(sidecar.WorkingDir, "workspaces", wsNames).ViaField("workingDir"))
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(sidecar.Script, "workspaces", wsNames).ViaField("script"))
+	for i, cmd := range sidecar.Command {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(cmd, "workspaces", wsNames).ViaFieldIndex("command", i))
+	}
+	for i, arg := range sidecar.Args {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(arg, "workspaces", wsNames).ViaFieldIndex("args", i))
+	}
+	for _, env := range sidecar.Env {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(env.Value, "workspaces", wsNames).ViaFieldKey("env", env.Name))
+	}
+	for i, v := range sidecar.VolumeMounts {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.Name, "workspaces", wsNames).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.MountPath, "workspaces", wsNames).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.SubPath, "workspaces", wsNames).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
+	}
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -394,6 +394,17 @@ func TestTaskSpecValidate(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "valid workspace variable reference with property",
+		fields: fields{
+			Steps: []v1.Step{{
+				Image:  "my-image",
+				Script: "echo $(workspaces.myws.path)",
+			}},
+			Workspaces: []v1.WorkspaceDeclaration{{
+				Name: "myws",
+			}},
+		},
+	}, {
 		name: "valid step with displayName",
 		fields: fields{
 			Steps: []v1.Step{{
@@ -1350,6 +1361,38 @@ func TestTaskSpecValidateError(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: "workspace mount path \"/workspace/some-workspace\" must be unique",
 			Paths:   []string{"workspaces[0].mountpath"},
+		},
+	}, {
+		name: "bare workspace variable reference in step script",
+		fields: fields{
+			Steps: []v1.Step{{
+				Name:   "mystep",
+				Image:  "myimage",
+				Script: "echo $(workspaces.myws)",
+			}},
+			Workspaces: []v1.WorkspaceDeclaration{{
+				Name: "myws",
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `variable $(workspaces.myws) must specify a property (path, bound, claim, or volume)`,
+			Paths:   []string{"steps[0].script"},
+		},
+	}, {
+		name: "bare workspace variable reference in step args",
+		fields: fields{
+			Steps: []v1.Step{{
+				Name:  "mystep",
+				Image: "myimage",
+				Args:  []string{"$(workspaces.myws)"},
+			}},
+			Workspaces: []v1.WorkspaceDeclaration{{
+				Name: "myws",
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `variable $(workspaces.myws) must specify a property (path, bound, claim, or volume)`,
+			Paths:   []string{"steps[0].args[0]"},
 		},
 	}, {
 		name: "result name not valid",

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -85,6 +85,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(ValidateVolumes(ts.Volumes).ViaField("volumes"))
 	errs = errs.Also(validateDeclaredWorkspaces(ts.Workspaces, ts.Steps, ts.StepTemplate).ViaField("workspaces"))
 	errs = errs.Also(validateWorkspaceUsages(ctx, ts))
+	errs = errs.Also(validateWorkspaceVariableExpressions(ts))
 	mergedSteps, err := MergeStepsWithStepTemplate(ts.StepTemplate, ts.Steps)
 	if err != nil {
 		errs = errs.Also(&apis.FieldError{
@@ -222,6 +223,71 @@ func validateWorkspaceUsages(ctx context.Context, ts *TaskSpec) (errs *apis.Fiel
 		}
 	}
 
+	return errs
+}
+
+// validateWorkspaceVariableExpressions checks that workspace variable references in Steps
+// and Sidecars always include a property suffix (path, bound, claim, or volume).
+// A bare reference like $(workspaces.myws) is invalid.
+func validateWorkspaceVariableExpressions(ts *TaskSpec) (errs *apis.FieldError) {
+	wsNames := sets.NewString()
+	for _, w := range ts.Workspaces {
+		wsNames.Insert(w.Name)
+	}
+	if wsNames.Len() == 0 {
+		return nil
+	}
+
+	for idx, step := range ts.Steps {
+		errs = errs.Also(validateStepHasNoBareWorkspaceVars(step, wsNames).ViaFieldIndex("steps", idx))
+	}
+	for idx, sidecar := range ts.Sidecars {
+		errs = errs.Also(validateSidecarHasNoBareWorkspaceVars(sidecar, wsNames).ViaFieldIndex("sidecars", idx))
+	}
+	return errs
+}
+
+func validateStepHasNoBareWorkspaceVars(step Step, wsNames sets.String) *apis.FieldError {
+	errs := substitution.ValidateNoReferencesToBareVariables(step.Name, "workspaces", wsNames).ViaField("name")
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(step.Image, "workspaces", wsNames).ViaField("image"))
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(step.WorkingDir, "workspaces", wsNames).ViaField("workingDir"))
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(step.Script, "workspaces", wsNames).ViaField("script"))
+	for i, cmd := range step.Command {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(cmd, "workspaces", wsNames).ViaFieldIndex("command", i))
+	}
+	for i, arg := range step.Args {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(arg, "workspaces", wsNames).ViaFieldIndex("args", i))
+	}
+	for _, env := range step.Env {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(env.Value, "workspaces", wsNames).ViaFieldKey("env", env.Name))
+	}
+	for i, v := range step.VolumeMounts {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.Name, "workspaces", wsNames).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.MountPath, "workspaces", wsNames).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.SubPath, "workspaces", wsNames).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
+	}
+	return errs
+}
+
+func validateSidecarHasNoBareWorkspaceVars(sidecar Sidecar, wsNames sets.String) *apis.FieldError {
+	errs := substitution.ValidateNoReferencesToBareVariables(sidecar.Name, "workspaces", wsNames).ViaField("name")
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(sidecar.Image, "workspaces", wsNames).ViaField("image"))
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(sidecar.WorkingDir, "workspaces", wsNames).ViaField("workingDir"))
+	errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(sidecar.Script, "workspaces", wsNames).ViaField("script"))
+	for i, cmd := range sidecar.Command {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(cmd, "workspaces", wsNames).ViaFieldIndex("command", i))
+	}
+	for i, arg := range sidecar.Args {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(arg, "workspaces", wsNames).ViaFieldIndex("args", i))
+	}
+	for _, env := range sidecar.Env {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(env.Value, "workspaces", wsNames).ViaFieldKey("env", env.Name))
+	}
+	for i, v := range sidecar.VolumeMounts {
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.Name, "workspaces", wsNames).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.MountPath, "workspaces", wsNames).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(substitution.ValidateNoReferencesToBareVariables(v.SubPath, "workspaces", wsNames).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
+	}
 	return errs
 }
 

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -50,6 +50,35 @@ var paramIndexingRegex = regexp.MustCompile(paramIndexing)
 // intIndexRegex will match all `[int]` for param expression
 var intIndexRegex = regexp.MustCompile(intIndex)
 
+// ValidateNoReferencesToBareVariables returns an error if the input string contains references
+// like $(prefix.name) where name is one of vars but no property suffix follows.
+// For example, $(workspaces.myws) is bare because it lacks .path, .bound, etc.
+func ValidateNoReferencesToBareVariables(value, prefix string, vars sets.String) *apis.FieldError {
+	if value == "" || vars.Len() == 0 {
+		return nil
+	}
+	// Build a regex that matches $(prefix.name) exactly — no trailing .property.
+	// We escape both the prefix and each variable name for regex safety.
+	escapedNames := make([]string, 0, vars.Len())
+	for _, name := range vars.List() {
+		escapedNames = append(escapedNames, regexp.QuoteMeta(name))
+	}
+	names := strings.Join(escapedNames, "|")
+	pattern := `\$\(` + regexp.QuoteMeta(prefix) + `\.(` + names + `)\)`
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil
+	}
+	matches := re.FindAllStringSubmatch(value, -1)
+	for _, match := range matches {
+		return &apis.FieldError{
+			Message: fmt.Sprintf("variable %s must specify a property (path, bound, claim, or volume)", match[0]),
+			Paths:   []string{""},
+		}
+	}
+	return nil
+}
+
 // ValidateNoReferencesToUnknownVariables returns an error if the input string contains references to unknown variables
 // Inputs:
 // - value: a string containing a reference to a variable that can be substituted, e.g. "echo $(params.foo)"

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -801,3 +801,112 @@ func TestExtractVariablesFromString(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNoReferencesToBareVariables(t *testing.T) {
+	type args struct {
+		value  string
+		prefix string
+		vars   sets.String
+	}
+	for _, tc := range []struct {
+		name          string
+		args          args
+		expectedError *apis.FieldError
+	}{{
+		name: "bare workspace reference is rejected",
+		args: args{
+			value:  "echo $(workspaces.myws)",
+			prefix: "workspaces",
+			vars:   sets.NewString("myws"),
+		},
+		expectedError: &apis.FieldError{
+			Message: `variable $(workspaces.myws) must specify a property (path, bound, claim, or volume)`,
+			Paths:   []string{""},
+		},
+	}, {
+		name: "qualified workspace reference is allowed",
+		args: args{
+			value:  "echo $(workspaces.myws.path)",
+			prefix: "workspaces",
+			vars:   sets.NewString("myws"),
+		},
+		expectedError: nil,
+	}, {
+		name: "bare reference for undeclared workspace is not flagged",
+		args: args{
+			value:  "echo $(workspaces.other)",
+			prefix: "workspaces",
+			vars:   sets.NewString("myws"),
+		},
+		expectedError: nil,
+	}, {
+		name: "no variable references at all",
+		args: args{
+			value:  "echo hello",
+			prefix: "workspaces",
+			vars:   sets.NewString("myws"),
+		},
+		expectedError: nil,
+	}, {
+		name: "empty value is fine",
+		args: args{
+			value:  "",
+			prefix: "workspaces",
+			vars:   sets.NewString("myws"),
+		},
+		expectedError: nil,
+	}, {
+		name: "bare reference with bracket notation is not matched",
+		args: args{
+			value:  `echo $(workspaces.myws["path"])`,
+			prefix: "workspaces",
+			vars:   sets.NewString("myws"),
+		},
+		expectedError: nil,
+	}, {
+		name: "multiple bare references returns error for first",
+		args: args{
+			value:  "$(workspaces.ws1) and $(workspaces.ws2)",
+			prefix: "workspaces",
+			vars:   sets.NewString("ws1", "ws2"),
+		},
+		expectedError: &apis.FieldError{
+			Message: `variable $(workspaces.ws1) must specify a property (path, bound, claim, or volume)`,
+			Paths:   []string{""},
+		},
+	}, {
+		name: "workspace name with hyphen is caught",
+		args: args{
+			value:  "$(workspaces.my-ws)",
+			prefix: "workspaces",
+			vars:   sets.NewString("my-ws"),
+		},
+		expectedError: &apis.FieldError{
+			Message: `variable $(workspaces.my-ws) must specify a property (path, bound, claim, or volume)`,
+			Paths:   []string{""},
+		},
+	}, {
+		name: "no false positive when var name is prefix of actual reference",
+		args: args{
+			value:  "$(workspaces.myws)",
+			prefix: "workspaces",
+			vars:   sets.NewString("my"),
+		},
+		expectedError: nil,
+	}, {
+		name: "array star notation is not bare",
+		args: args{
+			value:  "$(workspaces.myws[*])",
+			prefix: "workspaces",
+			vars:   sets.NewString("myws"),
+		},
+		expectedError: nil,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := substitution.ValidateNoReferencesToBareVariables(tc.args.value, tc.args.prefix, tc.args.vars)
+			if d := cmp.Diff(tc.expectedError, got, cmp.AllowUnexported(apis.FieldError{})); d != "" {
+				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

Adds validation to reject bare workspace variable references like `$(workspaces.myws)` in Task steps and sidecars. Users must specify a property suffix such as `.path`, `.bound`, `.claim`, or `.volume`.

Previously, a bare `$(workspaces.myws)` would pass validation but silently resolve to an empty string at runtime, leading to confusing failures. This change surfaces the error at admission time with a clear message.

Fixes #10490

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Bare workspace variable references like $(workspaces.myws) are now rejected during Task validation. Users must specify a property (e.g. $(workspaces.myws.path)).