### PR TITLE
test(notifications): cover CustomRun initTracing span propagation

### DIFF
--- a/pkg/reconciler/notifications/customrun/tracing_test.go
+++ b/pkg/reconciler/notifications/customrun/tracing_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customrun
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/logging"
+)
+
+func TestInitTracing(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	const parentTraceParent = "00-0f57e147e992b304d977436289d10628-73d5909e31793992-01"
+	parentSpanContextJSON, err := json.Marshal(map[string]string{
+		"traceparent": parentTraceParent,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal span context: %v", err)
+	}
+
+	testcases := []struct {
+		name                   string
+		customRun              *v1beta1.CustomRun
+		tracerProvider         trace.TracerProvider
+		expectValidSpanContext bool
+		parentTraceParent      string
+	}{{
+		name: "with-tracerprovider-no-parent-trace",
+		customRun: &v1beta1.CustomRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "testns",
+			},
+		},
+		tracerProvider:         tracesdk.NewTracerProvider(),
+		expectValidSpanContext: true,
+	}, {
+		name: "with-tracerprovider-with-parent-trace-from-annotation",
+		customRun: &v1beta1.CustomRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "testns",
+				Annotations: map[string]string{
+					SpanContextAnnotation: string(parentSpanContextJSON),
+				},
+			},
+		},
+		tracerProvider:         tracesdk.NewTracerProvider(),
+		expectValidSpanContext: true,
+		parentTraceParent:      parentTraceParent,
+	}, {
+		name: "without-tracerprovider",
+		customRun: &v1beta1.CustomRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "testns",
+			},
+		},
+		tracerProvider:         trace.NewNoopTracerProvider(),
+		expectValidSpanContext: false,
+	}}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := logging.WithLogger(t.Context(), logging.FromContext(context.Background()))
+			returnedCtx := initTracing(ctx, tc.tracerProvider, tc.customRun)
+
+			if returnedCtx == nil {
+				t.Fatalf("returned nil context from initTracing")
+			}
+
+			spanCtx := trace.SpanContextFromContext(returnedCtx)
+			if tc.expectValidSpanContext {
+				if !spanCtx.IsValid() {
+					t.Fatalf("span context is invalid after initializing tracing")
+				}
+
+				if tc.parentTraceParent != "" {
+					carrier := propagation.MapCarrier{}
+					otel.GetTextMapPropagator().Inject(returnedCtx, carrier)
+					if got := carrier["traceparent"]; got != tc.parentTraceParent {
+						t.Fatalf("expected traceparent %q, got %q", tc.parentTraceParent, got)
+					}
+				}
+			} else if spanCtx.IsValid() {
+				t.Fatalf("expected invalid span context with noop tracer provider")
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

Adds unit tests for `initTracing` in the CustomRun notifications reconciler, mirroring `pkg/reconciler/taskrun/tracing_test.go`.

Follow-up to #10097 / closed #9780. Supersedes the test coverage gap noted in review on #9803 (closed as superseded by #10097).

- Verifies a new root span is created when no `tekton.dev/customrunSpanContext` annotation is present
- Asserts the propagated `traceparent` from the annotation is preserved as the parent trace (not just "some valid span")
- Verifies noop tracer provider leaves tracing disabled

# Submitter Checklist

- [x] Has Docs if any changes are user facing (N/A — tests only)
- [x] Has Tests included if any functionality added or changed
- [x] pre-commit Passed
- [x] Follows the commit message standard
- [x] Meets the Tekton contributor standards
- [ ] Has a kind label (`/kind feature` to be added)
- [x] Release notes block below has been updated
- [ ] Release notes contains "action required" (N/A)

# Release Notes

```release-note
NONE
```