### PR TITLE
fix(pipelinerun): keep object param defaults for keys a PipelineRun omits

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -233,7 +233,14 @@ func buildUnresolvedArrayParamDefaults(params []v1.ParamSpec, resolvedArrayParam
 }
 
 // buildUnresolvedObjectParamDefaults builds a map of parameter defaults that haven't been provided by the PipelineRun.
-// It filters for object-type parameters only and excludes those already present in resolvedObjectParams.
+// It filters for object-type parameters only and excludes the individual keys already present in
+// resolvedObjectParams.
+//
+// Object params differ from string and array params here: a PipelineRun may supply only some of the
+// keys, and the remaining ones are expected to fall back to the ParamSpec default. Validation already
+// works that way -- MissingKeysObjectParamNames counts a key as provided when the default carries it --
+// so skipping the whole default as soon as the run mentions the param would leave the keys it omitted
+// with no value at all, and $(params.<name>.<key>) would reach the TaskRun unresolved.
 func buildUnresolvedObjectParamDefaults(params []v1.ParamSpec, resolvedObjectParams map[string]map[string]string) map[string]map[string]string {
 	result := map[string]map[string]string{}
 
@@ -246,14 +253,34 @@ func buildUnresolvedObjectParamDefaults(params []v1.ParamSpec, resolvedObjectPar
 			continue
 		}
 
-		if paramExists(param.Name, resolvedObjectParams) {
+		provided := resolvedObjectParamValue(param.Name, resolvedObjectParams)
+		unresolved := map[string]string{}
+		for key, value := range param.Default.ObjectVal {
+			if _, ok := provided[key]; ok {
+				continue
+			}
+			unresolved[key] = value
+		}
+
+		if len(unresolved) == 0 {
 			continue
 		}
 
-		addPatternEntry(param.Name, param.Default.ObjectVal, result)
+		addPatternEntry(param.Name, unresolved, result)
 	}
 
 	return result
+}
+
+// resolvedObjectParamValue returns the value a PipelineRun supplied for an object param, looked up
+// under any of the supported reference patterns. It returns nil when the run did not supply the param.
+func resolvedObjectParamValue(paramName string, bucket map[string]map[string]string) map[string]string {
+	for _, pattern := range paramPatterns {
+		if value, exists := bucket[fmt.Sprintf(pattern, paramName)]; exists {
+			return value
+		}
+	}
+	return nil
 }
 
 // resolveStringParamRecursively resolves a string parameter by recursively resolving any $(params.*) references.
@@ -376,7 +403,12 @@ func resolveObjectParam(paramKey string, paramValue map[string]string, resolvedS
 	for key, value := range paramValue {
 		resolvedValues[key] = substitution.ApplyReplacements(value, resolvedStringParams)
 	}
-	resolvedObjectParams[paramKey] = resolvedValues
+	// paramValue holds only the keys the run left out. When the run supplied the param its value
+	// stays the whole-object replacement, so the entry must not be overwritten with this partial
+	// map -- only individual key access below falls back to the default.
+	if _, supplied := resolvedObjectParams[paramKey]; !supplied {
+		resolvedObjectParams[paramKey] = resolvedValues
+	}
 
 	// Add keyed access to enable references like $(params.config.host) in other params
 	for key, value := range resolvedValues {

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -403,12 +403,15 @@ func resolveObjectParam(paramKey string, paramValue map[string]string, resolvedS
 	for key, value := range paramValue {
 		resolvedValues[key] = substitution.ApplyReplacements(value, resolvedStringParams)
 	}
-	// paramValue holds only the keys the run left out. When the run supplied the param its value
-	// stays the whole-object replacement, so the entry must not be overwritten with this partial
-	// map -- only individual key access below falls back to the default.
-	if _, supplied := resolvedObjectParams[paramKey]; !supplied {
-		resolvedObjectParams[paramKey] = resolvedValues
+	// paramValue holds only the keys the run left out, so the entry is merged rather than replaced:
+	// the value of a partially supplied object param is the default with the run's keys layered on
+	// top, which is what $(params.<name>[*]) has to hand on. The TaskRun side already resolves the
+	// whole-object form that way (getTaskParameters merges run values key by key into the
+	// default's), so merging here makes the same expression mean the same thing at both levels.
+	for key, value := range resolvedObjectParams[paramKey] {
+		resolvedValues[key] = value
 	}
+	resolvedObjectParams[paramKey] = resolvedValues
 
 	// Add keyed access to enable references like $(params.config.host) in other params
 	for key, value := range resolvedValues {

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -2073,6 +2073,46 @@ func TestApplyParameters(t *testing.T) {
 				}},
 			},
 		},
+		{
+			// An object param may be supplied partially: the API explicitly allows it, and
+			// MissingKeysObjectParamNames treats a key as provided when the ParamSpec default
+			// carries it. The keys the PipelineRun leaves out must therefore keep coming from the
+			// default, otherwise $(params.<name>.<key>) is left unresolved in the produced TaskRun.
+			name: "object param supplied partially keeps default values for the missing keys",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "prepare", Type: v1.ParamTypeObject, Default: v1.NewObject(map[string]string{
+						"command": "make build",
+						"image":   "golang:1.24",
+					})},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-command", Value: *v1.NewStructuredValues("$(params.prepare.command)")},
+						{Name: "task-image", Value: *v1.NewStructuredValues("$(params.prepare.image)")},
+					},
+				}},
+			},
+			params: v1.Params{
+				{Name: "prepare", Value: *v1.NewObject(map[string]string{
+					"command": "make test",
+				})},
+			},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "prepare", Type: v1.ParamTypeObject, Default: v1.NewObject(map[string]string{
+						"command": "make build",
+						"image":   "golang:1.24",
+					})},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-command", Value: *v1.NewStructuredValues("make test")},
+						{Name: "task-image", Value: *v1.NewStructuredValues("golang:1.24")},
+					},
+				}},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -2113,6 +2113,47 @@ func TestApplyParameters(t *testing.T) {
 				}},
 			},
 		},
+		{
+			// The whole-object form has to carry the same value as the individual keys: the default
+			// with the run's keys layered on top. The TaskRun side already resolves $(params.<name>[*])
+			// that way, so a partially supplied object must not reach a Task missing the keys the
+			// default was supposed to cover.
+			name: "object param supplied partially resolves the whole-object form from the default too",
+			original: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "prepare", Type: v1.ParamTypeObject, Default: v1.NewObject(map[string]string{
+						"command": "make build",
+						"image":   "golang:1.24",
+					})},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-prepare", Value: *v1.NewStructuredValues("$(params.prepare[*])")},
+					},
+				}},
+			},
+			params: v1.Params{
+				{Name: "prepare", Value: *v1.NewObject(map[string]string{
+					"command": "make test",
+				})},
+			},
+			expected: v1.PipelineSpec{
+				Params: []v1.ParamSpec{
+					{Name: "prepare", Type: v1.ParamTypeObject, Default: v1.NewObject(map[string]string{
+						"command": "make build",
+						"image":   "golang:1.24",
+					})},
+				},
+				Tasks: []v1.PipelineTask{{
+					Params: v1.Params{
+						{Name: "task-prepare", Value: *v1.NewObject(map[string]string{
+							"command": "make test",
+							"image":   "golang:1.24",
+						})},
+					},
+				}},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
fix #10560

An object param may be supplied partially — the keys a PipelineRun omits are expected to fall back to
the `ParamSpec` default, which is what `docs/tasks.md` documents and what validation implements
(`MissingKeysObjectParamNames` treats the default's keys as provided). PipelineRun-level resolution
stopped honouring that, in two ways, so this PR is split into two commits that can be taken
independently:

1. **`keep object param defaults for keys a PipelineRun omits`** — restores the regression.
   `buildUnresolvedObjectParamDefaults` skips a param's default entirely once the run mentions that
   param, so `$(params.<name>.<key>)` for an omitted key is never registered as a replacement, the
   reference survives substitution, and the run fails only at pod creation with
   `non-existent variable in "$(params.prepare.image)": steps[0].image`. The default is now filtered
   key by key: keys the run left out still resolve, keys it supplied keep winning.

   Introduced by f7d3aee3de1854760de7940bd40ec2146d0a5079 ("fix: re-work parameter resolution
   algorithm"), so it affects **v1.9.0 through v1.15.0**.

2. **`resolve the whole-object form of a partial object param from the default`** — aligns
   `$(params.<name>[*])` with the same contract. Today it resolves to the run-supplied keys alone, so
   a partially supplied object that passes Pipeline-level validation is then rejected at Task level
   with `missing keys for these params which are required in ParamSpec's properties
   map[prepare:[image]]`. The TaskRun side already merges run values key by key into the default
   (`getTaskParameters`), so merging here makes the same expression mean the same thing at both
   levels. This one is not part of the regression above — it is a long-standing inconsistency that
   surfaces from the same root cause. **Happy to drop this commit if you would rather keep the change
   to the strict regression fix.**

No docs change: `docs/tasks.md` already describes the behaviour this restores.

Verified beyond the unit tests — both cases reproduce on a cluster with a controller built from
`main`, and both succeed with these two commits applied, using the same manifest and changing nothing
but the controller image. Reproduction manifest and the exact failure output are in #10560.

AI-assisted (see the `Assisted-by:` trailers); I reviewed, ran and tested every change myself.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release (not applicable — no action required)

# Release Notes

```release-note
Fix object params supplied partially in a PipelineRun losing the ParamSpec default for the keys the run omits
```
