### PR TITLE
docs: update testing section with e2e test instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -441,6 +441,25 @@ Available formats:
 | `standard-quiet` | Standard `go test` format |
 | `standard-verbose` | Standard `go test -v` format |
 
+##### End-to-end (e2e) tests
+
+Before running the e2e tests, ensure that Pipelines is installed locally in a kind cluster. The steps below summarize the process:
+
+```shell
+ko apply -R -f config/
+kubectl apply -f optional_config/enable-log-access-to-controller/
+export KO_DOCKER_REPO=kind.local
+export SYSTEM_NAMESPACE=tekton-pipelines
+```
+
+Then run the e2e tests:
+
+```shell
+go test -v -count=1 -tags=e2e -timeout=20m ./test -skipRootUserTests=true
+```
+
+For more details, flags, and advanced options see the [e2e testing guide](test/README.md#running).
+
 ---
 
 ### Managing Tekton Objects using `ko`

--- a/test/README.md
+++ b/test/README.md
@@ -180,8 +180,41 @@ export SYSTEM_NAMESPACE=tekton-pipelines
 
 ### Running
 
+Before running e2e tests, make sure you have:
+
+1. A running Kubernetes cluster (e.g. `kind`) with Tekton installed:
+
+```shell
+  ko apply -R -f config/
+```
+
+2. Apply the optional RBAC required by the controller to access pod logs:
+
+```shell
+  kubectl apply -f optional_config/enable-log-access-to-controller/
+```
+
+3. The required environment variables should be set:
+
+```shell
+  export KO_DOCKER_REPO=kind.local          # or your custom registry
+  export SYSTEM_NAMESPACE=tekton-pipelines
+```
+
 End to end tests live in this directory. To run these tests, you must provide
-`go` with `-tags=e2e`. By default the tests run against your current kubeconfig
+`go` with `-tags=e2e`. To run the full e2e test suite against your current cluster locally, deactivate the tests that require root access:
+
+```shell
+go test -v -count=1 -tags=e2e -timeout=20m ./test -skipRootUserTests=true
+```
+
+To run a specific e2e test:
+
+```shell
+go test -v -count=1 -tags=e2e -timeout=20m ./test -run ^TestPipelineRun
+```
+
+By default the tests run against your current kubeconfig
 context, but you can change that and other settings with [the flags](#flags):
 
 ```shell


### PR DESCRIPTION
Closes [tektoncd#10564](https://github.com/tektoncd/pipeline/issues/10564)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Added a brief e2e testing section in DEVELOPMENT.md with the most important steps to run e2e tests locally. Updated the Running section in test/README.md with missing prerequisites that are required for e2e tests to work correctly.

# Verification

<img width="1913" height="348" alt="image" src="https://github.com/user-attachments/assets/c6fe4086-18ae-4f96-94ba-bee16a240f5d" />

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
