### PR TITLE
Move v1.3.x to End of Life releases

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -19,7 +19,6 @@ release-branches:
   - release-v1.12.x
   - release-v1.9.x
   - release-v1.6.x
-  - release-v1.3.x
 # Package ecosystems to monitor
 # Each ecosystem will be configured for:
 # - main branch: all updates (major, minor, patch)

--- a/releases.md
+++ b/releases.md
@@ -65,13 +65,13 @@ Further documentation available:
 - **End of Life**: 2026-10-31
 - **Patch Releases**: [v1.6.0][v1.6-0], [v1.6.1][v1.6-1], [v1.6.2][v1.6-2]
 
+## End of Life Releases
+
 ### v1.3 (LTS)
 - **Latest Release**: [v1.3.4][v1.3-4] (2026-04-21) ([docs][v1.3-4-docs], [examples][v1.3-4-examples])
 - **Initial Release**: [v1.3.0][v1.3-0] (2025-08-04)
 - **End of Life**: 2026-08-04
 - **Patch Releases**: [v1.3.0][v1.3-0], [v1.3.1][v1.3-1], [v1.3.2][v1.3-2], [v1.3.3][v1.3-3], [v1.3.4][v1.3-4]
-
-## End of Life Releases
 
 ### v1.14
 - **Latest Release**: [v1.14.1][v1.14-1] (2026-07-22) ([docs][v1.14-1-docs], [examples][v1.14-1-examples])


### PR DESCRIPTION
# Changes

v1.3.x reached its End of Life on 2026-08-04. This:
- Moves v1.3 from the active "Release" section to "End of Life Releases" in `releases.md`
- Removes `release-v1.3.x` from `dependabot.config.yml`

The dependabot automation will regenerate `dependabot.yml` without v1.3.x entries on the next scheduled run.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```