### PR TITLE
Move test selector helpers to reconciler/testing

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_pinp_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_pinp_test.go
@@ -1,7 +1,6 @@
 package pipelinerun
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -119,44 +118,15 @@ func reconcileOncePinP(
 	)
 
 	// fetch created child PipelineRun(s)
-	childPipelineRuns := getChildPipelineRunsForPipelineRun(
+	childPipelineRuns := th.GetChildPipelineRunsForPipelineRun(
 		prt.TestAssets.Ctx,
 		t,
-		clients,
+		clients.Pipeline,
 		namespace,
 		parentPipelineRunName,
 	)
 
 	return reconciledRun, childPipelineRuns
-}
-
-func getChildPipelineRunsForPipelineRun(
-	ctx context.Context,
-	t *testing.T,
-	clients test.Clients,
-	namespace, parentPipelineRunName string,
-) map[string]*v1.PipelineRun {
-	t.Helper()
-
-	opt := metav1.ListOptions{
-		LabelSelector: pipeline.PipelineRunLabelKey + "=" + parentPipelineRunName,
-	}
-
-	pipelineRunList, err := clients.
-		Pipeline.
-		TektonV1().
-		PipelineRuns(namespace).
-		List(ctx, opt)
-	if err != nil {
-		t.Fatalf("failed to list child PipelineRuns: %v", err)
-	}
-
-	result := make(map[string]*v1.PipelineRun)
-	for _, pipelineRun := range pipelineRunList.Items {
-		result[pipelineRun.Name] = &pipelineRun
-	}
-
-	return result
 }
 
 func validatePinP(
@@ -184,11 +154,11 @@ func validatePinP(
 	}
 	th.VerifyChildPipelineRunStatusesNames(t, reconciledRunStatus, expectedNames...)
 
-	validateChildPipelineRunCount(t, childPipelineRuns, len(expectedChildPipelineRuns))
+	th.ValidateChildPipelineRunCount(t, childPipelineRuns, len(expectedChildPipelineRuns))
 
 	// validate the actual child PipelineRuns are as expected
 	for _, expectedChild := range expectedChildPipelineRuns {
-		actualChild := getChildPipelineRunByName(t, childPipelineRuns, expectedChild.Name)
+		actualChild := th.GetChildPipelineRunByName(t, childPipelineRuns, expectedChild.Name)
 		if d := cmp.Diff(expectedChild, actualChild, ignoreTypeMeta, ignoreResourceVersion); d != "" {
 			t.Errorf("expected to see child PipelineRun %v created. Diff %s", expectedChild, diff.PrintWantGot(d))
 		}
@@ -198,26 +168,6 @@ func validatePinP(
 			t.Errorf("Child PipelineRun should be owned by parent %s", reconciledRunName)
 		}
 	}
-}
-
-func validateChildPipelineRunCount(t *testing.T, pipelineRuns map[string]*v1.PipelineRun, expectedCount int) {
-	t.Helper()
-
-	actualCount := len(pipelineRuns)
-	if actualCount != expectedCount {
-		t.Fatalf("Expected %d child PipelineRuns, got %d", expectedCount, actualCount)
-	}
-}
-
-func getChildPipelineRunByName(t *testing.T, pipelineRuns map[string]*v1.PipelineRun, expectedName string) *v1.PipelineRun {
-	t.Helper()
-
-	pr, exist := pipelineRuns[expectedName]
-	if !exist {
-		t.Fatalf("Expected pipelinerun %s does not exist", expectedName)
-	}
-
-	return pr
 }
 
 // TestReconcile_NestedChildPipelineRuns verifies the reconciliation logic for multi-level nested PipelineRuns.
@@ -265,7 +215,7 @@ func TestReconcile_NestedChildPipelineRuns(t *testing.T) {
 
 	// GIVEN
 	// use the child from previous reconcile
-	childPipelineRun := getChildPipelineRunByName(t, childPipelineRuns, expectedChildPipelineRun.Name)
+	childPipelineRun := th.GetChildPipelineRunByName(t, childPipelineRuns, expectedChildPipelineRun.Name)
 	childTestData := test.Data{
 		PipelineRuns: []*v1.PipelineRun{childPipelineRun},
 		ConfigMaps:   th.NewAlphaFeatureFlagsConfigMapInSlice(),
@@ -354,7 +304,7 @@ func TestReconcile_ChildPipelineRunHasDefaultLabels(t *testing.T) {
 	)
 
 	// THEN
-	validateChildPipelineRunCount(t, childPipelineRuns, 1)
+	th.ValidateChildPipelineRunCount(t, childPipelineRuns, 1)
 
 	actualLabels := childPipelineRuns[expectedChildPipelineRun.Name].Labels
 	for k, v := range expectedLabels {
@@ -510,7 +460,7 @@ func TestReconcile_NestedChildPipelineRunsWithPipelineRef(t *testing.T) {
 	)
 
 	// use the child from previous reconcile
-	childPipelineRun := getChildPipelineRunByName(t, childPipelineRuns, expectedChildPipelineRun.Name)
+	childPipelineRun := th.GetChildPipelineRunByName(t, childPipelineRuns, expectedChildPipelineRun.Name)
 	childTestData := test.Data{
 		PipelineRuns: []*v1.PipelineRun{childPipelineRun},
 		Pipelines:    []*v1.Pipeline{childPipeline, grandchildPipeline},
@@ -696,7 +646,7 @@ func TestReconcile_ChildPipelineRunsMultiplePipelineRefs(t *testing.T) {
 		corev1.ConditionUnknown,
 		v1.PipelineRunReasonRunning.String(),
 	)
-	validateChildPipelineRunCount(t, childPipelineRuns, 2)
+	th.ValidateChildPipelineRunCount(t, childPipelineRuns, 2)
 }
 
 // TestReconcile_ChildPipelineRunsMixedPipelineRefSpecAndTaskRef verifies that a parent
@@ -733,7 +683,7 @@ func TestReconcile_ChildPipelineRunsMixedPipelineRefSpecAndTaskRef(t *testing.T)
 	)
 	// Two child PipelineRuns (pipelineRef + pipelineSpec); the direct taskRef task
 	// produces a TaskRun, not a child PipelineRun.
-	validateChildPipelineRunCount(t, childPipelineRuns, 2)
+	th.ValidateChildPipelineRunCount(t, childPipelineRuns, 2)
 }
 
 // TestReconcile_ChildPipelineRunPipelineRefWhenSkipped verifies that a pipelineRef
@@ -762,7 +712,7 @@ func TestReconcile_ChildPipelineRunPipelineRefWhenSkipped(t *testing.T) {
 	)
 
 	// No child PipelineRun is created for the skipped task, and the run succeeds.
-	validateChildPipelineRunCount(t, childPipelineRuns, 0)
+	th.ValidateChildPipelineRunCount(t, childPipelineRuns, 0)
 	th.CheckPipelineRunConditionStatusAndReason(
 		t,
 		reconciledRun.Status,
@@ -1036,7 +986,7 @@ func TestReconcile_ChildPipelineRunPipelineRefCycleDetection_TwoLevel(t *testing
 	)
 
 	// Verify that the child PipelineRun for B was created
-	validateChildPipelineRunCount(t, childPipelineRuns, 1)
+	th.ValidateChildPipelineRunCount(t, childPipelineRuns, 1)
 	var childPR *v1.PipelineRun
 	for _, cpr := range childPipelineRuns {
 		childPR = cpr
@@ -1117,7 +1067,7 @@ func TestReconcile_ChildPipelineRunPipelineRefParentNotFound(t *testing.T) {
 		corev1.ConditionUnknown,
 		v1.PipelineRunReasonRunning.String(),
 	)
-	validateChildPipelineRunCount(t, childPipelineRuns, 1)
+	th.ValidateChildPipelineRunCount(t, childPipelineRuns, 1)
 }
 
 // TestDetectPipelineRefCycle_OwnerNotPipelineRun verifies that the cycle walker

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -179,69 +179,6 @@ func initializePipelineRunControllerAssets(t *testing.T, d test.Data, opts pipel
 	}, cancel
 }
 
-// validateTaskRunsCount ensure that there are `expectedCount` TaskRuns
-// It will fatal the test if the number of TaskRuns is not `expectedCount`
-func validateTaskRunsCount(t *testing.T, taskRuns map[string]*v1.TaskRun, expectedCount int) {
-	t.Helper()
-
-	actualCount := len(taskRuns)
-	if actualCount != expectedCount {
-		t.Fatalf("Expected %d taskruns but it has %d", expectedCount, actualCount)
-	}
-}
-
-// getTaskRunByName retrieves the TaskRun with the specified name from the given TaskRuns
-// It will fatal the test if the name does not exist
-func getTaskRunByName(t *testing.T, taskRuns map[string]*v1.TaskRun, expectedName string) *v1.TaskRun {
-	t.Helper()
-
-	tr, exist := taskRuns[expectedName]
-	if !exist {
-		t.Fatalf("Expected taskrun %s does not exist", expectedName)
-	}
-
-	return tr
-}
-
-// getTaskRunsForPipelineRun returns the set of TaskRuns associated with the input PipelineRun.
-// It will fatal the test if an error occurred.
-func getTaskRunsForPipelineRun(ctx context.Context, t *testing.T, clients test.Clients, namespace string, prName string) map[string]*v1.TaskRun {
-	t.Helper()
-	labelSelector := pipeline.PipelineRunLabelKey + "=" + prName
-	return getTaskRuns(ctx, t, clients, namespace, labelSelector)
-}
-
-// getTaskRunsForPipelineTask returns the set of TaskRuns associated with the input PipelineRun and PipelineTask
-// It will fatal the test if an error occurred.
-func getTaskRunsForPipelineTask(ctx context.Context, t *testing.T, clients test.Clients, namespace string, prName string, ptLabel string) map[string]*v1.TaskRun {
-	t.Helper()
-	labelSelector := pipeline.PipelineRunLabelKey + "=" + prName + "," + pipeline.PipelineTaskLabelKey + "=" + ptLabel
-	return getTaskRuns(ctx, t, clients, namespace, labelSelector)
-}
-
-// getTaskRuns returns the set of TaskRuns matching the label selector.
-// It will fatal the test if an error occurred.
-func getTaskRuns(ctx context.Context, t *testing.T, clients test.Clients, namespace string, labelSelector string) map[string]*v1.TaskRun {
-	t.Helper()
-
-	opt := metav1.ListOptions{
-		LabelSelector: labelSelector,
-	}
-
-	taskRuns, err := clients.Pipeline.TektonV1().TaskRuns(namespace).List(ctx, opt)
-	if err != nil {
-		t.Fatalf("failed to list taskruns, %s", err)
-	}
-
-	outputs := make(map[string]*v1.TaskRun)
-	for _, item := range taskRuns.Items {
-		tr := item
-		outputs[item.Name] = &tr
-	}
-
-	return outputs
-}
-
 // runTestReconcile runs "Reconcile" on a PipelineRun with one
 // Task that has not been started yet.  It verifies that the TaskRun is created,
 // it checks the resulting API actions, status and events.
@@ -380,12 +317,12 @@ spec:
 	}
 	reconciledRun, clients := prt.reconcileRun(namespace, prName, wantEvents, false)
 
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
 	// Ensure that there are 2 TaskRuns associated with this PipelineRun
-	validateTaskRunsCount(t, taskRuns, 2)
+	th.ValidateTaskRunsCount(t, taskRuns, 2)
 
 	// Check that the expected TaskRun was created
-	actual := getTaskRunByName(t, taskRuns, trName)
+	actual := th.GetTaskRunByName(t, taskRuns, trName)
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
 		taskRunObjectMeta(trName, namespace, prName,
 			"test-pipeline", "unit-test-1", false),
@@ -665,10 +602,10 @@ spec:
 	reconciledRun, clients := prt.reconcileRun(namespace, prName, wantEvents, false)
 
 	// Check that the expected TaskRun was created
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
-	validateTaskRunsCount(t, taskRuns, 1)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
+	th.ValidateTaskRunsCount(t, taskRuns, 1)
 
-	actual := getTaskRunByName(t, taskRuns, trName)
+	actual := th.GetTaskRunByName(t, taskRuns, trName)
 	expectedTaskRun := parse.MustParseV1TaskRun(t, fmt.Sprintf(`
 spec:
   taskSpec:
@@ -1357,10 +1294,10 @@ status:
 	}
 
 	// Check that the expected TaskRun was created
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, "foo", "test-pipeline-missing-results")
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, "foo", "test-pipeline-missing-results")
 
 	// We expect only 1 TaskRun to be created, since the PipelineRun should fail before creating the 2nd TaskRun due to the InvalidTaskResultReference
-	validateTaskRunsCount(t, taskRuns, 1)
+	th.ValidateTaskRunsCount(t, taskRuns, 1)
 }
 
 func TestReconcile_InvalidPipelineRunNames(t *testing.T) {
@@ -1492,8 +1429,8 @@ status:
 	wantEvents := []string{}
 	reconciledRun, clients := prt.reconcileRun(namespace, pipelineRunName, wantEvents, false)
 
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, pipelineRunName)
-	validateTaskRunsCount(t, taskRuns, 1)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, pipelineRunName)
+	th.ValidateTaskRunsCount(t, taskRuns, 1)
 
 	// This PipelineRun should still be complete and the status should reflect that
 	if reconciledRun.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
@@ -3865,10 +3802,10 @@ spec:
 	_, clients := prt.reconcileRun(namespace, prName, []string{}, false)
 
 	// Check that the expected TaskRun was created
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
-	validateTaskRunsCount(t, taskRuns, 1)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
+	th.ValidateTaskRunsCount(t, taskRuns, 1)
 
-	actual := getTaskRunByName(t, taskRuns, trName)
+	actual := th.GetTaskRunByName(t, taskRuns, trName)
 	// We're ignoring TypeMeta here because parse.MustParseV1TaskRun populates that, but ktesting does not, so actual does not have it.
 	if d := cmp.Diff(expected, actual, ignoreTypeMeta, ignoreResourceVersion); d != "" {
 		t.Errorf("expected to see TaskRun %v created. Diff %s", expected, diff.PrintWantGot(d))
@@ -4119,10 +4056,10 @@ spec:
 	_, clients := prt.reconcileRun("foo", prName, []string{}, false)
 
 	// Check that the expected TaskRun was created
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
-	validateTaskRunsCount(t, taskRuns, 1)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
+	th.ValidateTaskRunsCount(t, taskRuns, 1)
 
-	actual := getTaskRunByName(t, taskRuns, trName)
+	actual := th.GetTaskRunByName(t, taskRuns, trName)
 	expectedTaskRunObjectMeta := taskRunObjectMeta(trName, namespace, prName, "test-pipeline", "hello-world-1", false)
 	expectedTaskRunObjectMeta.Annotations["PipelineRunAnnotation"] = "PipelineRunValue"
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t, expectedTaskRunObjectMeta, `
@@ -4233,10 +4170,10 @@ spec:
 	_, clients := prt.reconcileRun("foo", prName, []string{}, false)
 
 	// Check that the expected TaskRun was created with correct timeout
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
-	validateTaskRunsCount(t, taskRuns, 1)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
+	th.ValidateTaskRunsCount(t, taskRuns, 1)
 
-	actual := getTaskRunByName(t, taskRuns, trName)
+	actual := th.GetTaskRunByName(t, taskRuns, trName)
 	expectedTimeout := metav1.Duration{Duration: 2 * time.Hour}
 	if actual.Spec.Timeout == nil {
 		t.Errorf("expected TaskRun timeout to be set, but was nil")
@@ -4290,10 +4227,10 @@ spec:
 	_, clients := prt.reconcileRun("foo", prName, []string{}, false)
 
 	// Check that TaskRun uses taskRunSpec timeout, not pipeline task timeout
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
-	validateTaskRunsCount(t, taskRuns, 1)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
+	th.ValidateTaskRunsCount(t, taskRuns, 1)
 
-	actual := getTaskRunByName(t, taskRuns, trName)
+	actual := th.GetTaskRunByName(t, taskRuns, trName)
 	expectedTimeout := metav1.Duration{Duration: 30 * time.Minute}
 	if actual.Spec.Timeout == nil {
 		t.Errorf("expected TaskRun timeout to be set, but was nil")
@@ -4557,10 +4494,10 @@ spec:
 
 			_, clients := prt.reconcileRun(namespace, prName, []string{}, false)
 
-			taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
-			validateTaskRunsCount(t, taskRuns, 1)
+			taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
+			th.ValidateTaskRunsCount(t, taskRuns, 1)
 
-			actual := getTaskRunByName(t, taskRuns, trName)
+			actual := th.GetTaskRunByName(t, taskRuns, trName)
 
 			if tc.expectedTimeout == nil {
 				if actual.Spec.Timeout != nil {
@@ -4641,7 +4578,7 @@ status:
 
 	_, clients := prt.reconcileRun(namespace, prName, []string{}, false)
 
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
 
 	var finallyTaskRun *v1.TaskRun
 	for name, tr := range taskRuns {
@@ -7785,8 +7722,8 @@ status:
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun(namespace, prOutOfSyncName, []string{}, false)
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prOutOfSyncName)
-	validateTaskRunsCount(t, taskRuns, 2)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prOutOfSyncName)
+	th.ValidateTaskRunsCount(t, taskRuns, 2)
 
 	// This PipelineRun should still be running and the status should reflect that
 	if !reconciledRun.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
@@ -9146,10 +9083,10 @@ metadata:
 	reconciledRun, clients := prt.reconcileRun(namespace, prName, wantEvents, false)
 
 	// Check that the expected TaskRun was created
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
-	validateTaskRunsCount(t, taskRuns, 1)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
+	th.ValidateTaskRunsCount(t, taskRuns, 1)
 
-	actual := getTaskRunByName(t, taskRuns, trName)
+	actual := th.GetTaskRunByName(t, taskRuns, trName)
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
 		taskRunObjectMeta(trName, namespace, prName,
 			"test-pipeline", "unit-test-1", false), `
@@ -9440,10 +9377,10 @@ spec:
 	reconciledRun, clients := prt.reconcileRun(namespace, prName, nil, false)
 
 	// Check that the expected TaskRun was created
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
-	validateTaskRunsCount(t, taskRuns, 1)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
+	th.ValidateTaskRunsCount(t, taskRuns, 1)
 
-	actual := getTaskRunByName(t, taskRuns, trName)
+	actual := th.GetTaskRunByName(t, taskRuns, trName)
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
 		taskRunObjectMeta(trName, namespace, prName,
 			"test-pipeline-run-success", "unit-test-1", false),
@@ -10486,10 +10423,10 @@ spec:
 
 	_, clients := prt.reconcileRun(namespace, prName, []string{}, false)
 
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
-	validateTaskRunsCount(t, taskRuns, 1)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
+	th.ValidateTaskRunsCount(t, taskRuns, 1)
 
-	actual := getTaskRunByName(t, taskRuns, trName)
+	actual := th.GetTaskRunByName(t, taskRuns, trName)
 	expectedTaskRunObjectMeta := taskRunObjectMeta(trName, namespace, prName, "test-pipeline", "hello-world-1", false)
 	expectedTaskRunObjectMeta.Labels["PipelineTaskRunSpecLabel"] = "PipelineTaskRunSpecValue"
 	expectedTaskRunObjectMeta.Annotations["PipelineTaskRunSpecAnnotation"] = "PipelineTaskRunSpecValue"
@@ -10563,10 +10500,10 @@ spec:
 
 	_, clients := prt.reconcileRun(namespace, prName, []string{}, false)
 
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
-	validateTaskRunsCount(t, taskRuns, 1)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
+	th.ValidateTaskRunsCount(t, taskRuns, 1)
 
-	actual := getTaskRunByName(t, taskRuns, trName)
+	actual := th.GetTaskRunByName(t, taskRuns, trName)
 	expectedTaskRunObjectMeta := taskRunObjectMeta(trName, namespace, prName, "test-pipeline", "hello-world-1", false)
 	expectedTaskRunObjectMeta.Labels["TestPrecedenceLabel"] = "PipelineTaskRunSpecValue"
 	expectedTaskRunObjectMeta.Annotations["TestPrecedenceAnnotation"] = "PipelineTaskRunSpecValue"
@@ -11362,12 +11299,12 @@ labels:
 			defer prt.Cancel()
 
 			pipelineRun, clients := prt.reconcileRun(pr.Namespace, pr.Name /*wantEvents*/, []string{} /*permanentError*/, false)
-			taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, pr.Namespace, pr.Name)
-			validateTaskRunsCount(t, taskRuns, len(expectedTaskRuns))
+			taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, pr.Namespace, pr.Name)
+			th.ValidateTaskRunsCount(t, taskRuns, len(expectedTaskRuns))
 
 			for i, expectedTaskRun := range expectedTaskRuns {
 				trName := expectedTaskRun.Name
-				actual := getTaskRunByName(t, taskRuns, trName)
+				actual := th.GetTaskRunByName(t, taskRuns, trName)
 				if d := cmp.Diff(expectedTaskRun, actual, ignoreResourceVersion, ignoreTypeMeta); d != "" {
 					t.Errorf("expected to see TaskRun %v created. Diff %s", expectedTaskRuns[i].Name, diff.PrintWantGot(d))
 				}
@@ -13240,11 +13177,11 @@ spec:
 			defer prt.Cancel()
 			pipelineRun, clients := prt.reconcileRun(pr.Namespace, pr.Name, []string{} /* wantEvents*/, false /* permanentError*/)
 
-			taskRuns := getTaskRunsForPipelineTask(prt.TestAssets.Ctx, t, clients, pr.Namespace, pr.Name, "echo-platforms")
-			validateTaskRunsCount(t, taskRuns, len(tt.expectedTaskRuns))
+			taskRuns := th.GetTaskRunsForPipelineTask(prt.TestAssets.Ctx, t, clients.Pipeline, pr.Namespace, pr.Name, "echo-platforms")
+			th.ValidateTaskRunsCount(t, taskRuns, len(tt.expectedTaskRuns))
 			for _, expectedTaskRun := range tt.expectedTaskRuns {
 				trName := expectedTaskRun.Name
-				actual := getTaskRunByName(t, taskRuns, trName)
+				actual := th.GetTaskRunByName(t, taskRuns, trName)
 				if d := cmp.Diff(expectedTaskRun, actual, ignoreResourceVersion, ignoreTypeMeta); d != "" {
 					t.Errorf("expected to see TaskRun %v created. Diff %s", expectedTaskRun.Name, diff.PrintWantGot(d))
 				}
@@ -14573,9 +14510,9 @@ spec:
 			pipelineRun, clients := prt.reconcileRun(pr.Namespace, pr.Name, wantEvents /* wantEvents*/, true /* permanentError*/)
 			// Validate the PR failed due to out of bounds array index reference
 			th.CheckPipelineRunConditionStatusAndReason(t, pipelineRun.Status, corev1.ConditionFalse, "PipelineValidationFailed")
-			taskRuns := getTaskRunsForPipelineTask(prt.TestAssets.Ctx, t, clients, pr.Namespace, pr.Name, "echo-platforms")
+			taskRuns := th.GetTaskRunsForPipelineTask(prt.TestAssets.Ctx, t, clients.Pipeline, pr.Namespace, pr.Name, "echo-platforms")
 			// Validate no TaskRuns were created
-			validateTaskRunsCount(t, taskRuns, 0)
+			th.ValidateTaskRunsCount(t, taskRuns, 0)
 		})
 	}
 }
@@ -16503,11 +16440,11 @@ spec:
 	reconciledRun, clients := prt.reconcileRun(namespace, prName, wantEvents, false)
 
 	// Check that the expected TaskRun was created
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
 	// Ensure that there are 2 TaskRuns associated with this PipelineRun
-	validateTaskRunsCount(t, taskRuns, 2)
+	th.ValidateTaskRunsCount(t, taskRuns, 2)
 
-	actual := getTaskRunByName(t, taskRuns, trName)
+	actual := th.GetTaskRunByName(t, taskRuns, trName)
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
 		taskRunObjectMeta(trName, namespace, prName,
 			"test-pipeline", "unit-test-1", false),
@@ -18043,12 +17980,12 @@ spec:
 `)
 	// The taskSpec is already set by the reconcile to avoid an extra resolution
 	expectedTaskRun.Spec.TaskSpec = &ps[0].Spec.Tasks[1].TaskSpec.TaskSpec
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, prt.TestAssets.Clients, "foo", "7103-reproducer-run-7jp4w")
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, prt.TestAssets.Clients.Pipeline, "foo", "7103-reproducer-run-7jp4w")
 	// Ensure that there are 2 TaskRuns associated with this PipelineRun
-	validateTaskRunsCount(t, taskRuns, 3)
+	th.ValidateTaskRunsCount(t, taskRuns, 3)
 
 	// Check that the expected TaskRun was created
-	actual := getTaskRunByName(t, taskRuns, "7103-reproducer-run-7jp4w-task3")
+	actual := th.GetTaskRunByName(t, taskRuns, "7103-reproducer-run-7jp4w-task3")
 	// The TaskRun for task3 should include resolved results
 	if d := cmp.Diff(expectedTaskRun, actual, ignoreResourceVersion, ignoreLastTransitionTime, ignoreTypeMeta, ignoreProvenance, ignoreStartTime); d != "" {
 		t.Errorf("Expected to see PipelineRun run with a task3 child reference %s", diff.PrintWantGot(d))
@@ -18638,8 +18575,8 @@ spec:
 	reconciledRun, clients := prt.reconcileRun(namespace, prName, wantEvents, true)
 
 	// Check that the expected TaskRun was not created
-	taskRuns := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prName)
-	validateTaskRunsCount(t, taskRuns, 0)
+	taskRuns := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prName)
+	th.ValidateTaskRunsCount(t, taskRuns, 0)
 	th.VerifyTaskRunStatusesCount(t, reconciledRun.Status, 0)
 }
 
@@ -19080,7 +19017,7 @@ spec:
 	})
 
 	// Verify no TaskRuns were created for the externally managed PipelineRun
-	taskRunsOther := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prManagedByOtherName)
+	taskRunsOther := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prManagedByOtherName)
 	if len(taskRunsOther) != 0 {
 		t.Errorf("Expected no TaskRuns for externally managed PipelineRun, but found %d", len(taskRunsOther))
 	}
@@ -19103,7 +19040,7 @@ spec:
 	reconciledTekton, clients := prt.reconcileRun(namespace, prManagedByTektonName, wantEvents, false)
 
 	// Verify a TaskRun was created for the Tekton-managed PipelineRun
-	taskRunsTekton := getTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients, namespace, prManagedByTektonName)
+	taskRunsTekton := th.GetTaskRunsForPipelineRun(prt.TestAssets.Ctx, t, clients.Pipeline, namespace, prManagedByTektonName)
 	if len(taskRunsTekton) != 1 {
 		t.Errorf("Expected 1 TaskRun for Tekton-managed PipelineRun, but found %d", len(taskRunsTekton))
 	}

--- a/pkg/reconciler/testing/selectors.go
+++ b/pkg/reconciler/testing/selectors.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ValidateTaskRunsCount ensures that there are `expectedCount` TaskRuns.
+// It will fatal the test if the number of TaskRuns is not `expectedCount`.
+func ValidateTaskRunsCount(t *testing.T, taskRuns map[string]*v1.TaskRun, expectedCount int) {
+	t.Helper()
+
+	actualCount := len(taskRuns)
+	if actualCount != expectedCount {
+		t.Fatalf("Expected %d taskruns but it has %d", expectedCount, actualCount)
+	}
+}
+
+// GetTaskRunByName retrieves the TaskRun with the specified name from the given TaskRuns.
+// It will fatal the test if the name does not exist.
+func GetTaskRunByName(t *testing.T, taskRuns map[string]*v1.TaskRun, expectedName string) *v1.TaskRun {
+	t.Helper()
+
+	tr, exist := taskRuns[expectedName]
+	if !exist {
+		t.Fatalf("Expected taskrun %s does not exist", expectedName)
+	}
+
+	return tr
+}
+
+// GetTaskRunsForPipelineRun returns the set of TaskRuns associated with the input PipelineRun.
+// It will fatal the test if an error occurred.
+func GetTaskRunsForPipelineRun(ctx context.Context, t *testing.T, clients clientset.Interface, namespace string, prName string) map[string]*v1.TaskRun {
+	t.Helper()
+	labelSelector := pipeline.PipelineRunLabelKey + "=" + prName
+	return getTaskRuns(ctx, t, clients, namespace, labelSelector)
+}
+
+// GetTaskRunsForPipelineTask returns the set of TaskRuns associated with the input PipelineRun and PipelineTask.
+// It will fatal the test if an error occurred.
+func GetTaskRunsForPipelineTask(ctx context.Context, t *testing.T, clients clientset.Interface, namespace string, prName string, ptLabel string) map[string]*v1.TaskRun {
+	t.Helper()
+	labelSelector := pipeline.PipelineRunLabelKey + "=" + prName + "," + pipeline.PipelineTaskLabelKey + "=" + ptLabel
+	return getTaskRuns(ctx, t, clients, namespace, labelSelector)
+}
+
+// getTaskRuns returns the set of TaskRuns matching the label selector.
+// It will fatal the test if an error occurred.
+func getTaskRuns(ctx context.Context, t *testing.T, clients clientset.Interface, namespace string, labelSelector string) map[string]*v1.TaskRun {
+	t.Helper()
+
+	opt := metav1.ListOptions{
+		LabelSelector: labelSelector,
+	}
+
+	taskRuns, err := clients.TektonV1().TaskRuns(namespace).List(ctx, opt)
+	if err != nil {
+		t.Fatalf("failed to list taskruns, %s", err)
+	}
+
+	outputs := make(map[string]*v1.TaskRun)
+	for _, item := range taskRuns.Items {
+		tr := item
+		outputs[item.Name] = &tr
+	}
+
+	return outputs
+}
+
+// GetChildPipelineRunsForPipelineRun returns the set of child PipelineRuns associated with the input parent PipelineRun.
+// It will fatal the test if an error occurred.
+func GetChildPipelineRunsForPipelineRun(
+	ctx context.Context,
+	t *testing.T,
+	clients clientset.Interface,
+	namespace, parentPipelineRunName string,
+) map[string]*v1.PipelineRun {
+	t.Helper()
+
+	opt := metav1.ListOptions{
+		LabelSelector: pipeline.PipelineRunLabelKey + "=" + parentPipelineRunName,
+	}
+
+	pipelineRunList, err := clients.
+		TektonV1().
+		PipelineRuns(namespace).
+		List(ctx, opt)
+	if err != nil {
+		t.Fatalf("failed to list child PipelineRuns: %v", err)
+	}
+
+	result := make(map[string]*v1.PipelineRun)
+	for _, pipelineRun := range pipelineRunList.Items {
+		result[pipelineRun.Name] = &pipelineRun
+	}
+
+	return result
+}
+
+// ValidateChildPipelineRunCount ensures that there are `expectedCount` child PipelineRuns.
+// It will fatal the test if the number of child PipelineRuns is not `expectedCount`.
+func ValidateChildPipelineRunCount(t *testing.T, pipelineRuns map[string]*v1.PipelineRun, expectedCount int) {
+	t.Helper()
+
+	actualCount := len(pipelineRuns)
+	if actualCount != expectedCount {
+		t.Fatalf("Expected %d child PipelineRuns, got %d", expectedCount, actualCount)
+	}
+}
+
+// GetChildPipelineRunByName retrieves the PipelineRun with the specified name from the given PipelineRuns.
+// It will fatal the test if the name does not exist.
+func GetChildPipelineRunByName(t *testing.T, pipelineRuns map[string]*v1.PipelineRun, expectedName string) *v1.PipelineRun {
+	t.Helper()
+
+	pr, exist := pipelineRuns[expectedName]
+	if !exist {
+		t.Fatalf("Expected pipelinerun %s does not exist", expectedName)
+	}
+
+	return pr
+}


### PR DESCRIPTION
# Changes

The PipelineRun reconciler tests define their child-run selector helpers
(fetch by name, count checks, status validation) inline in
`pipelinerun_test.go`, with some copies in `pipelinerun_pinp_test.go`.

This PR moves them to a new shared file `pkg/reconciler/testing/selectors.go`
and updates both test files to use it.

Test-only change. No change in behavior.

Part of #8906

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

Co-authored-by: Claude
