### PR TITLE
fix(remoteresolution): always create a fresh cache in git resolver Initialize

### DIFF
--- a/pkg/remoteresolution/resolver/git/resolver.go
+++ b/pkg/remoteresolution/resolver/git/resolver.go
@@ -79,9 +79,7 @@ type Resolver struct {
 func (r *Resolver) Initialize(ctx context.Context) error {
 	r.kubeClient = kubeclient.Get(ctx)
 	r.logger = logging.FromContext(ctx).Named(gitResolverName)
-	if r.cache == nil {
-		r.cache = k8scache.NewLRUExpireCache(cacheSize)
-	}
+	r.cache = k8scache.NewLRUExpireCache(cacheSize)
 	if r.ttl == 0 {
 		r.ttl = ttl
 	}

--- a/pkg/remoteresolution/resolver/git/resolver_test.go
+++ b/pkg/remoteresolution/resolver/git/resolver_test.go
@@ -52,6 +52,28 @@ import (
 	_ "knative.dev/pkg/system/testing"
 )
 
+func TestInitialize_ResetsCache(t *testing.T) {
+	ctx, _ := ttesting.SetupFakeContext(t)
+
+	resolver := Resolver{}
+	if err := resolver.Initialize(ctx); err != nil {
+		t.Fatalf("first Initialize failed: %v", err)
+	}
+
+	resolver.cache.Add("some-key", "some-value", time.Minute)
+	if _, ok := resolver.cache.Get("some-key"); !ok {
+		t.Fatalf("expected key to be present in cache before re-initializing")
+	}
+
+	if err := resolver.Initialize(ctx); err != nil {
+		t.Fatalf("second Initialize failed: %v", err)
+	}
+
+	if _, ok := resolver.cache.Get("some-key"); ok {
+		t.Fatalf("expected cache to be reset on re-initialize, but stale entry was still present")
+	}
+}
+
 func TestGetSelector(t *testing.T) {
 	resolver := Resolver{}
 	sel := resolver.GetSelector(t.Context())


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`Resolver.Initialize()` in `pkg/remoteresolution/resolver/git/resolver.go` guarded LRU
cache creation with `if r.cache == nil`, so calling `Initialize()` a second time on the
same `*Resolver` reused the existing cache instead of creating a fresh one. The
deprecated `pkg/resolution/resolver/git/resolver.go` always creates a fresh cache in
`Initialize()`.

This divergence was masked while the cache key was a pointer type (`*secretCacheKey`):
pointer-address comparisons meant every lookup was effectively a cache miss. Once the
cache key became a struct value, the cache started hitting correctly, exposing real
test coupling — `TestResolve` in `resolver_test.go` reuses a single `*Resolver` across
many table-driven `t.Run` cases (each triggers a fresh `Initialize()` call via the
resolver framework's controller construction), and several cases reuse the same secret
name (`"token-secret"`), so a value cached by one case could leak into a later,
unrelated case.

The fix removes the nil guard so `Initialize()` unconditionally creates a new
`LRUExpireCache`, matching the deprecated resolver's cache-reset behavior.
`Initialize()` is only called once per `*Resolver` in production
(`pkg/remoteresolution/resolver/framework/controller.go`'s `NewController`, before the
informer handler is registered), so this does not change production behavior — it only
affects callers, such as tests, that invoke `Initialize()` more than once on the same
instance.

Added `TestInitialize_ResetsCache`, which calls `Initialize()`, manually seeds an entry
into `resolver.cache`, calls `Initialize()` again, and asserts the entry is gone.
Verified locally (via `git stash` of just the `resolver.go` change) that this test
fails against the old code and passes with the fix.

Validation performed:
```
go build ./...
go test ./pkg/remoteresolution/...
golangci-lint run --new-from-rev=HEAD ./pkg/remoteresolution/resolver/git/...
```
All passed.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

Fixes #9597