### PR TITLE
apis: allow debug.breakpoints.beforeSteps without onFailure

### DIFF
--- a/pkg/apis/pipeline/v1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation.go
@@ -273,14 +273,11 @@ func combineParamSpec(p ParamSpec, paramSpecForValidation map[string]ParamSpec) 
 }
 
 // validateDebug validates the debug section of the TaskRun.
-// if set, onFailure breakpoint must be "enabled"
+// onFailure and beforeSteps breakpoints are independent and may be set separately;
+// if onFailure is set, its value must be "enabled"
 func validateDebug(db *TaskRunDebug) (errs *apis.FieldError) {
 	if db == nil || db.Breakpoints == nil {
 		return errs
-	}
-
-	if db.Breakpoints.OnFailure == "" {
-		errs = errs.Also(apis.ErrInvalidValue("onFailure breakpoint is empty, it is only allowed to be set as enabled", "breakpoints.onFailure"))
 	}
 
 	if db.Breakpoints.OnFailure != "" && db.Breakpoints.OnFailure != EnabledOnFailureBreakpoint {

--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -750,20 +750,6 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wantErr: apis.ErrGeneric("before step must be unique, the same step: step-1 is defined multiple times at", "debug.breakpoints.beforeSteps[1]"),
 		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
-		name: "empty onFailure breakpoint",
-		spec: v1.TaskRunSpec{
-			TaskRef: &v1.TaskRef{
-				Name: "my-task",
-			},
-			Debug: &v1.TaskRunDebug{
-				Breakpoints: &v1.TaskBreakpoints{
-					OnFailure: "",
-				},
-			},
-		},
-		wantErr: apis.ErrInvalidValue("onFailure breakpoint is empty, it is only allowed to be set as enabled", "debug.breakpoints.onFailure"),
-		wc:      cfgtesting.EnableAlphaAPIFields,
-	}, {
 		name: "stepSpecs disallowed without beta feature gate",
 		spec: v1.TaskRunSpec{
 			TaskRef: &v1.TaskRef{
@@ -970,6 +956,30 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "beforeSteps breakpoint without onFailure",
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
+				Name: "my-task",
+			},
+			Debug: &v1.TaskRunDebug{
+				Breakpoints: &v1.TaskBreakpoints{
+					BeforeSteps: []string{"my-step"},
+				},
+			},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
+	}, {
+		name: "empty breakpoints is a no-op",
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
+				Name: "my-task",
+			},
+			Debug: &v1.TaskRunDebug{
+				Breakpoints: &v1.TaskBreakpoints{},
+			},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "valid task-level (spec.resources) resource requirements",
 		spec: v1.TaskRunSpec{

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -274,14 +274,11 @@ func combineParamSpec(p ParamSpec, paramSpecForValidation map[string]ParamSpec) 
 }
 
 // validateDebug validates the debug section of the TaskRun.
-// if set, onFailure breakpoint must be "enabled"
+// onFailure and beforeSteps breakpoints are independent and may be set separately;
+// if onFailure is set, its value must be "enabled"
 func validateDebug(db *TaskRunDebug) (errs *apis.FieldError) {
 	if db == nil || db.Breakpoints == nil {
 		return errs
-	}
-
-	if db.Breakpoints.OnFailure == "" {
-		errs = errs.Also(apis.ErrInvalidValue("onFailure breakpoint is empty, it is only allowed to be set as enabled", "breakpoints.onFailure"))
 	}
 
 	if db.Breakpoints.OnFailure != "" && db.Breakpoints.OnFailure != EnabledOnFailureBreakpoint {

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -745,20 +745,6 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wantErr: apis.ErrGeneric("before step must be unique, the same step: step-1 is defined multiple times at", "debug.breakpoints.beforeSteps[1]"),
 		wc:      cfgtesting.EnableAlphaAPIFields,
 	}, {
-		name: "empty onFailure breakpoint",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: "my-task",
-			},
-			Debug: &v1beta1.TaskRunDebug{
-				Breakpoints: &v1beta1.TaskBreakpoints{
-					OnFailure: "",
-				},
-			},
-		},
-		wantErr: apis.ErrInvalidValue("onFailure breakpoint is empty, it is only allowed to be set as enabled", "debug.breakpoints.onFailure"),
-		wc:      cfgtesting.EnableAlphaAPIFields,
-	}, {
 		name: "duplicate stepOverride names",
 		spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -941,6 +927,30 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "beforeSteps breakpoint without onFailure",
+		spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: "my-task",
+			},
+			Debug: &v1beta1.TaskRunDebug{
+				Breakpoints: &v1beta1.TaskBreakpoints{
+					BeforeSteps: []string{"my-step"},
+				},
+			},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
+	}, {
+		name: "empty breakpoints is a no-op",
+		spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: "my-task",
+			},
+			Debug: &v1beta1.TaskRunDebug{
+				Breakpoints: &v1beta1.TaskBreakpoints{},
+			},
+		},
+		wc: cfgtesting.EnableAlphaAPIFields,
 	}, {
 		name: "valid task-level (spec.resources) resource requirements",
 		spec: v1beta1.TaskRunSpec{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`validateDebug` in `pkg/apis/pipeline/{v1,v1beta1}/taskrun_validation.go` unconditionally
rejected any TaskRun with a non-nil `debug.breakpoints` unless `breakpoints.onFailure` was
also explicitly set to `"enabled"`. `onFailure` and `beforeSteps` are independent breakpoint
types (`onFailure` pauses after a step fails, `beforeSteps` pauses before a named step for
inspection), so a TaskRun that only wanted `beforeSteps` was forced to also set
`onFailure: enabled`. Valid YAML like:

```yaml
spec:
  debug:
    breakpoints:
      beforeSteps:
        - my-step
```

was rejected at admission with `"onFailure breakpoint is empty, it is only allowed to be
set as enabled"`.

This removes the `OnFailure == ""` rejection in both `v1` and `v1beta1` (the duplicated
`validateDebug` implementations are kept in lockstep). The remaining check - that a
non-empty `onFailure` must equal `"enabled"` - is unchanged, so `onFailure` is now optional
but still validated when set.

This is a narrower, separate concern from the volume-cleanup fix from a previous change to
this function (https://github.com/tektoncd/pipeline/issues/7787): that fix gates debug-volume creation in `pkg/pod/pod.go` on
`Debug.NeedsDebug()`, which already treats a fully-empty `Breakpoints{}` (and a
`Breakpoints` without `onFailure=="enabled"`) as a no-op independent of admission
validation, so this change does not reintroduce the redundant-volume behavior that earlier
fix addressed. A new test case locks in that a fully empty `Breakpoints{}` continues to
validate as a no-op.

User-visible behavior changes only in that a TaskRun using `beforeSteps` without
`onFailure` is now accepted instead of rejected at admission; no runtime/pod behavior
changes.

**Validation performed:**
- `go build ./...`
- `go test ./pkg/apis/pipeline/v1/... ./pkg/apis/pipeline/v1beta1/...` (all pass)
- `golangci-lint run --new-from-rev=HEAD ./pkg/apis/pipeline/v1/... ./pkg/apis/pipeline/v1beta1/...`: 0 new issues (mirrors this repo's CI lint job, which lints only the diff against the merge base)
- `gofmt -l` on the four changed files: clean
- Failing-then-passing reproduction: stashing only the two production `taskrun_validation.go` changes (keeping the new test) makes the new `"beforeSteps breakpoint without onFailure"` case fail with the old `"onFailure breakpoint is empty"` error in both `v1` and `v1beta1`; restoring the fix makes it pass.
- Not run: no live cluster / e2e reproduction against a real TaskRun admission webhook - not required here since the defect and fix are fully exercised by the unit-test validation path above.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
**TaskRun**: `debug.breakpoints.beforeSteps` can now be set without also setting
`debug.breakpoints.onFailure`. Previously, a TaskRun with only `beforeSteps` configured
was rejected at admission requiring `onFailure: enabled` to also be set, even though the
two breakpoint types are independent.
```

Fixes #9719