### PR TITLE
Add ImageVolumeSource as a workspace binding type

### DIFF
--- a/config/300-crds/300-pipelinerun.yaml
+++ b/config/300-crds/300-pipelinerun.yaml
@@ -1669,6 +1669,27 @@ spec:
                               - type: integer
                               - type: string
                             x-kubernetes-int-or-string: true
+                      image:
+                        description: Image
+                        type: object
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                       name:
                         description: Name
                         type: string
@@ -2360,6 +2381,8 @@ spec:
                           type: boolean
                         enableConciseResolverSyntax:
                           type: boolean
+                        enableImageWorkspace:
+                          type: boolean
                         enableKeepPodOnCancel:
                           type: boolean
                         enableKubernetesSidecar:
@@ -2740,6 +2763,8 @@ spec:
                                     type: boolean
                                   enableConciseResolverSyntax:
                                     type: boolean
+                                  enableImageWorkspace:
+                                    type: boolean
                                   enableKeepPodOnCancel:
                                     type: boolean
                                   enableKubernetesSidecar:
@@ -3012,6 +3037,8 @@ spec:
                                         enableCELInWhenExpression:
                                           type: boolean
                                         enableConciseResolverSyntax:
+                                          type: boolean
+                                        enableImageWorkspace:
                                           type: boolean
                                         enableKeepPodOnCancel:
                                           type: boolean
@@ -4784,6 +4811,30 @@ spec:
                               - type: integer
                               - type: string
                             x-kubernetes-int-or-string: true
+                      image:
+                        description: |-
+                          Image represents a volume populated from a container image's filesystem.
+                          The image is pulled at pod startup. Contents are mounted read-only.
+                          Requires Kubernetes 1.31+ with the ImageVolume feature gate enabled.
+                        type: object
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                       name:
                         description: Name is the name of the workspace populated by the volume.
                         type: string
@@ -5458,6 +5509,8 @@ spec:
                         enableCELInWhenExpression:
                           type: boolean
                         enableConciseResolverSyntax:
+                          type: boolean
+                        enableImageWorkspace:
                           type: boolean
                         enableKeepPodOnCancel:
                           type: boolean

--- a/config/300-crds/300-taskrun.yaml
+++ b/config/300-crds/300-taskrun.yaml
@@ -1215,6 +1215,27 @@ spec:
                               - type: integer
                               - type: string
                             x-kubernetes-int-or-string: true
+                      image:
+                        description: Image
+                        type: object
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                       name:
                         description: Name
                         type: string
@@ -1875,6 +1896,8 @@ spec:
                           type: boolean
                         enableConciseResolverSyntax:
                           type: boolean
+                        enableImageWorkspace:
+                          type: boolean
                         enableKeepPodOnCancel:
                           type: boolean
                         enableKubernetesSidecar:
@@ -2147,6 +2170,8 @@ spec:
                               enableCELInWhenExpression:
                                 type: boolean
                               enableConciseResolverSyntax:
+                                type: boolean
+                              enableImageWorkspace:
                                 type: boolean
                               enableKeepPodOnCancel:
                                 type: boolean
@@ -3351,6 +3376,30 @@ spec:
                               - type: integer
                               - type: string
                             x-kubernetes-int-or-string: true
+                      image:
+                        description: |-
+                          Image represents a volume populated from a container image's filesystem.
+                          The image is pulled at pod startup. Contents are mounted read-only.
+                          Requires Kubernetes 1.31+ with the ImageVolume feature gate enabled.
+                        type: object
+                        properties:
+                          pullPolicy:
+                            description: |-
+                              Policy for pulling OCI objects. Possible values are:
+                              Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            type: string
+                          reference:
+                            description: |-
+                              Required: Image or artifact reference to be used.
+                              Behaves in the same way as pod.spec.containers[*].image.
+                              Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                              More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config management to default or override
+                              container images in workload controllers like Deployments and StatefulSets.
+                            type: string
                       name:
                         description: Name is the name of the workspace populated by the volume.
                         type: string
@@ -4029,6 +4078,8 @@ spec:
                           type: boolean
                         enableConciseResolverSyntax:
                           type: boolean
+                        enableImageWorkspace:
+                          type: boolean
                         enableKeepPodOnCancel:
                           type: boolean
                         enableKubernetesSidecar:
@@ -4293,6 +4344,8 @@ spec:
                               enableCELInWhenExpression:
                                 type: boolean
                               enableConciseResolverSyntax:
+                                type: boolean
+                              enableImageWorkspace:
                                 type: boolean
                               enableKeepPodOnCancel:
                                 type: boolean

--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -157,3 +157,7 @@ data:
   #
   # See https://github.com/tektoncd/pipeline/issues/7691 for more info.
   enable-informer-cache-transforms: "true"
+  # Setting this flag to "true" will enable image volume sources in workspace bindings.
+  # This allows using container images as read-only workspace content.
+  # Requires Kubernetes 1.31+ with the ImageVolume feature gate enabled (beta since Kubernetes 1.33).
+  enable-image-workspace: "false"

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -441,6 +441,10 @@ Defaults to "ignore".
   source from where a remote Task/Pipeline definition was fetched. By default, this is set to `true`.
   To disable populating this field, set this flag to `"false"`.
 
+- `enable-image-workspace`: Set this flag to `"true"` to enable image volume sources in workspace bindings.
+  This allows using container images as read-only workspace content. Requires Kubernetes 1.31+ with the
+  `ImageVolume` feature gate enabled (beta since Kubernetes 1.33). Defaults to `"false"`.
+
 - `enable-termination-message-compression`: Set this flag to `"true"` to enable zlib compression of
   termination messages written by the entrypoint. This increases the effective capacity for results
   from ~33 to ~187 in typical scenarios (5.7x improvement). Has no effect when `results-from` is
@@ -483,6 +487,7 @@ Features currently in "alpha" are:
 | [CEL in WhenExpression](./pipelines.md#use-cel-expression-in-whenexpression)                                                  | [TEP-0145](https://github.com/tektoncd/community/blob/main/teps/0145-cel-in-whenexpression.md)                       | [v0.53.0](https://github.com/tektoncd/pipeline/releases/tag/v0.53.0) | `enable-cel-in-whenexpression`                   |
 | [Param Enum](./taskruns.md#parameter-enums)                                                                  | [TEP-0144](https://github.com/tektoncd/community/blob/main/teps/0144-param-enum.md)                                  | [v0.54.0](https://github.com/tektoncd/pipeline/releases/tag/v0.54.0) | `enable-param-enum`                              |
 | Termination Message Compression                                                                             | N/A                                                                                                                  | N/A                                                                  | `enable-termination-message-compression`         |
+| [Image Workspace](./workspaces.md#image)                                                                    | N/A                                                                                                                  | N/A                                                                  | `enable-image-workspace`                         |
 
 ### Beta Features
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -591,6 +591,24 @@ policies=internal-app \
 ttl=20m
 ```
 
+##### `image`
+
+The `image` field references an [`image` volume](https://kubernetes.io/docs/concepts/storage/volumes/#image).
+Using an `image` volume has the following limitations:
+
+- This feature is gated behind the `enable-image-workspace` feature flag. Set `enable-image-workspace: "true"` in the `feature-flags` ConfigMap to enable it.
+- Requires Kubernetes 1.31+ with the `ImageVolume` feature gate enabled (beta since Kubernetes 1.33).
+- `image` volume sources are always mounted read-only by the kubelet. Workspaces using `image` should be declared with `readOnly: true`.
+- `subPath` is not supported with `image` volumes on Kubernetes 1.31 and 1.32. Support for `subPath` begins in Kubernetes 1.33.
+
+```yaml
+workspaces:
+  - name: my-tools
+    image:
+      reference: quay.io/example/my-tools:latest
+      pullPolicy: IfNotPresent
+```
+
 If you need support for a `VolumeSource` type not listed above, [open an issue](https://github.com/tektoncd/pipeline/issues) or
 a [pull request](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md).
 

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -122,6 +122,11 @@ const (
 	// DefaultEnableTerminationMessageCompression is the default value for EnableTerminationMessageCompression
 	DefaultEnableTerminationMessageCompression = false
 
+	// EnableImageWorkspace is the flag to enable image volume sources in workspace bindings
+	EnableImageWorkspace = "enable-image-workspace"
+	// DefaultEnableImageWorkspace is the default value for EnableImageWorkspace
+	DefaultEnableImageWorkspace = false
+
 	// EnableStepActions is the flag to enable step actions (no-op since it's stable)
 	EnableStepActions = "enable-step-actions"
 
@@ -193,6 +198,13 @@ var (
 		Enabled:   DefaultAlphaFeatureEnabled,
 	}
 
+	// DefaultEnableImageWorkspaceFlag is the default PerFeatureFlag value for "enable-image-workspace"
+	DefaultEnableImageWorkspaceFlag = PerFeatureFlag{
+		Name:      EnableImageWorkspace,
+		Stability: AlphaAPIFields,
+		Enabled:   DefaultAlphaFeatureEnabled,
+	}
+
 	DefaultEnableTektonOCIBundles = PerFeatureFlag{
 		Name:       EnableTektonOCIBundles,
 		Stability:  AlphaAPIFields,
@@ -235,6 +247,7 @@ type FeatureFlags struct {
 	EnableKubernetesSidecar             bool   `json:"enableKubernetesSidecar,omitempty"`
 	EnableWaitExponentialBackoff        bool   `json:"enableWaitExponentialBackoff,omitempty"`
 	EnableTerminationMessageCompression bool   `json:"enableTerminationMessageCompression,omitempty"`
+	EnableImageWorkspace                bool   `json:"enableImageWorkspace,omitempty"`
 	// DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
 	// to allow deletion of PipelineRuns created before v0.62.x.
 	// This field is not used and can be removed in a future release
@@ -349,6 +362,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setPerFeatureFlag(EnableTerminationMessageCompression, DefaultEnableTerminationMessageCompressionFlag, &tc.EnableTerminationMessageCompression); err != nil {
+		return nil, err
+	}
+	if err := setPerFeatureFlag(EnableImageWorkspace, DefaultEnableImageWorkspaceFlag, &tc.EnableImageWorkspace); err != nil {
 		return nil, err
 	}
 

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -81,6 +81,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableConciseResolverSyntax:              true,
 				EnableKubernetesSidecar:                  true,
 				EnableTerminationMessageCompression:      true,
+				EnableImageWorkspace:                     true,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -39,3 +39,4 @@ data:
   enable-concise-resolver-syntax: "true"
   enable-kubernetes-sidecar: "true"
   enable-termination-message-compression: "true"
+  enable-image-workspace: "true"

--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -4751,12 +4751,18 @@ func schema_pkg_apis_pipeline_v1_WorkspaceBinding(ref common.ReferenceCallback) 
 							Ref:         ref("k8s.io/api/core/v1.CSIVolumeSource"),
 						},
 					},
+					"image": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Image represents a volume populated from a container image's filesystem. The image is pulled at pod startup. Contents are mounted read-only. Requires Kubernetes 1.31+ with the ImageVolume feature gate enabled.",
+							Ref:         ref("k8s.io/api/core/v1.ImageVolumeSource"),
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.CSIVolumeSource", "k8s.io/api/core/v1.ConfigMapVolumeSource", "k8s.io/api/core/v1.EmptyDirVolumeSource", "k8s.io/api/core/v1.PersistentVolumeClaim", "k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource", "k8s.io/api/core/v1.ProjectedVolumeSource", "k8s.io/api/core/v1.SecretVolumeSource"},
+			"k8s.io/api/core/v1.CSIVolumeSource", "k8s.io/api/core/v1.ConfigMapVolumeSource", "k8s.io/api/core/v1.EmptyDirVolumeSource", "k8s.io/api/core/v1.ImageVolumeSource", "k8s.io/api/core/v1.PersistentVolumeClaim", "k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource", "k8s.io/api/core/v1.ProjectedVolumeSource", "k8s.io/api/core/v1.SecretVolumeSource"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -974,8 +974,11 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			Message: "expected exactly one, got neither",
 			Paths: []string{
 				"workspaces[0].configmap",
+				"workspaces[0].csi",
 				"workspaces[0].emptydir",
+				"workspaces[0].image",
 				"workspaces[0].persistentvolumeclaim",
+				"workspaces[0].projected",
 				"workspaces[0].secret",
 				"workspaces[0].volumeclaimtemplate",
 			},

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -2472,6 +2472,10 @@
           "description": "EmptyDir represents a temporary directory that shares a Task's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir Either this OR PersistentVolumeClaim can be used.",
           "$ref": "#/definitions/v1.EmptyDirVolumeSource"
         },
+        "image": {
+          "description": "Image represents a volume populated from a container image's filesystem. The image is pulled at pod startup. Contents are mounted read-only. Requires Kubernetes 1.31+ with the ImageVolume feature gate enabled.",
+          "$ref": "#/definitions/v1.ImageVolumeSource"
+        },
         "name": {
           "description": "Name is the name of the workspace populated by the volume.",
           "type": "string",

--- a/pkg/apis/pipeline/v1/workspace_types.go
+++ b/pkg/apis/pipeline/v1/workspace_types.go
@@ -86,6 +86,11 @@ type WorkspaceBinding struct {
 	// CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
 	// +optional
 	CSI *corev1.CSIVolumeSource `json:"csi,omitempty"`
+	// Image represents a volume populated from a container image's filesystem.
+	// The image is pulled at pod startup. Contents are mounted read-only.
+	// Requires Kubernetes 1.31+ with the ImageVolume feature gate enabled.
+	// +optional
+	Image *corev1.ImageVolumeSource `json:"image,omitempty"`
 }
 
 // WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun

--- a/pkg/apis/pipeline/v1/workspace_validation.go
+++ b/pkg/apis/pipeline/v1/workspace_validation.go
@@ -18,7 +18,9 @@ package v1
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/pkg/apis"
 )
@@ -31,6 +33,9 @@ var allVolumeSourceFields = []string{
 	"emptydir",
 	"configmap",
 	"secret",
+	"projected",
+	"csi",
+	"image",
 }
 
 // Validate looks at the Volume provided in wb and makes sure that it is valid.
@@ -80,6 +85,17 @@ func (b *WorkspaceBinding) Validate(ctx context.Context) (errs *apis.FieldError)
 		}
 	}
 
+	// Image workspace bindings require the enable-image-workspace feature flag.
+	if b.Image != nil {
+		cfg := config.FromContextOrDefaults(ctx)
+		if !cfg.FeatureFlags.EnableImageWorkspace {
+			return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use image workspace bindings", config.EnableImageWorkspace), "")
+		}
+		if b.Image.Reference == "" {
+			return apis.ErrMissingField("image.reference")
+		}
+	}
+
 	return nil
 }
 
@@ -106,6 +122,9 @@ func (b *WorkspaceBinding) numSources() int {
 		n++
 	}
 	if b.CSI != nil {
+		n++
+	}
+	if b.Image != nil {
 		n++
 	}
 	return n

--- a/pkg/apis/pipeline/v1/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1/workspace_validation_test.go
@@ -110,6 +110,17 @@ func TestWorkspaceBindingValidateValid(t *testing.T) {
 				Driver: "my-csi",
 			},
 		},
+	}, {
+		name: "Valid image",
+		binding: &v1.WorkspaceBinding{
+			Name: "beth",
+			Image: &corev1.ImageVolumeSource{
+				Reference: "quay.io/example/my-image:latest",
+			},
+		},
+		wc: func(ctx context.Context) context.Context {
+			return cfgtesting.SetFeatureFlags(ctx, t, map[string]string{"enable-image-workspace": "true"})
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := t.Context()
@@ -179,6 +190,25 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 			},
 		},
 		wc: cfgtesting.EnableBetaAPIFields,
+	}, {
+		name: "Provide image without feature flag",
+		binding: &v1.WorkspaceBinding{
+			Name: "beth",
+			Image: &corev1.ImageVolumeSource{
+				Reference: "quay.io/example/my-image:latest",
+			},
+		},
+	}, {
+		name: "Provide image without a reference",
+		binding: &v1.WorkspaceBinding{
+			Name: "beth",
+			Image: &corev1.ImageVolumeSource{
+				Reference: "",
+			},
+		},
+		wc: func(ctx context.Context) context.Context {
+			return cfgtesting.SetFeatureFlags(ctx, t, map[string]string{"enable-image-workspace": "true"})
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := t.Context()

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -2274,6 +2274,11 @@ func (in *WorkspaceBinding) DeepCopyInto(out *WorkspaceBinding) {
 		*out = new(corev1.CSIVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Image != nil {
+		in, out := &in.Image, &out.Image
+		*out = new(corev1.ImageVolumeSource)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -6224,12 +6224,18 @@ func schema_pkg_apis_pipeline_v1beta1_WorkspaceBinding(ref common.ReferenceCallb
 							Ref:         ref("k8s.io/api/core/v1.CSIVolumeSource"),
 						},
 					},
+					"image": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Image represents a volume populated from a container image's filesystem. The image is pulled at pod startup. Contents are mounted read-only. Requires Kubernetes 1.31+ with the ImageVolume feature gate enabled.",
+							Ref:         ref("k8s.io/api/core/v1.ImageVolumeSource"),
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.CSIVolumeSource", "k8s.io/api/core/v1.ConfigMapVolumeSource", "k8s.io/api/core/v1.EmptyDirVolumeSource", "k8s.io/api/core/v1.PersistentVolumeClaim", "k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource", "k8s.io/api/core/v1.ProjectedVolumeSource", "k8s.io/api/core/v1.SecretVolumeSource"},
+			"k8s.io/api/core/v1.CSIVolumeSource", "k8s.io/api/core/v1.ConfigMapVolumeSource", "k8s.io/api/core/v1.EmptyDirVolumeSource", "k8s.io/api/core/v1.ImageVolumeSource", "k8s.io/api/core/v1.PersistentVolumeClaim", "k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource", "k8s.io/api/core/v1.ProjectedVolumeSource", "k8s.io/api/core/v1.SecretVolumeSource"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -1116,8 +1116,11 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			Message: "expected exactly one, got neither",
 			Paths: []string{
 				"workspaces[0].configmap",
+				"workspaces[0].csi",
 				"workspaces[0].emptydir",
+				"workspaces[0].image",
 				"workspaces[0].persistentvolumeclaim",
+				"workspaces[0].projected",
 				"workspaces[0].secret",
 				"workspaces[0].volumeclaimtemplate",
 			},

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -3399,6 +3399,10 @@
           "description": "EmptyDir represents a temporary directory that shares a Task's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir Either this OR PersistentVolumeClaim can be used.",
           "$ref": "#/definitions/v1.EmptyDirVolumeSource"
         },
+        "image": {
+          "description": "Image represents a volume populated from a container image's filesystem. The image is pulled at pod startup. Contents are mounted read-only. Requires Kubernetes 1.31+ with the ImageVolume feature gate enabled.",
+          "$ref": "#/definitions/v1.ImageVolumeSource"
+        },
         "name": {
           "description": "Name is the name of the workspace populated by the volume.",
           "type": "string",

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -236,6 +236,12 @@ func TestTaskRunConversion(t *testing.T) {
 								},
 								VolumeAttributes: map[string]string{"key": "attribute-val"},
 							},
+						}, {
+							Name: "workspace-image",
+							Image: &corev1.ImageVolumeSource{
+								Reference:  "quay.io/example/my-tools:latest",
+								PullPolicy: corev1.PullIfNotPresent,
+							},
 						},
 					},
 					StepOverrides: []v1beta1.TaskRunStepOverride{{

--- a/pkg/apis/pipeline/v1beta1/workspace_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_conversion.go
@@ -82,6 +82,7 @@ func (w WorkspaceBinding) convertTo(ctx context.Context, sink *v1.WorkspaceBindi
 	sink.Secret = w.Secret
 	sink.Projected = w.Projected
 	sink.CSI = w.CSI
+	sink.Image = w.Image
 }
 
 // ConvertFrom converts v1beta1 Param from v1 Param
@@ -95,4 +96,5 @@ func (w *WorkspaceBinding) ConvertFrom(ctx context.Context, source v1.WorkspaceB
 	w.Secret = source.Secret
 	w.Projected = source.Projected
 	w.CSI = source.CSI
+	w.Image = source.Image
 }

--- a/pkg/apis/pipeline/v1beta1/workspace_types.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_types.go
@@ -86,6 +86,11 @@ type WorkspaceBinding struct {
 	// CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
 	// +optional
 	CSI *corev1.CSIVolumeSource `json:"csi,omitempty"`
+	// Image represents a volume populated from a container image's filesystem.
+	// The image is pulled at pod startup. Contents are mounted read-only.
+	// Requires Kubernetes 1.31+ with the ImageVolume feature gate enabled.
+	// +optional
+	Image *corev1.ImageVolumeSource `json:"image,omitempty"`
 }
 
 // WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun

--- a/pkg/apis/pipeline/v1beta1/workspace_validation.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_validation.go
@@ -18,7 +18,9 @@ package v1beta1
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/pkg/apis"
 )
@@ -31,6 +33,9 @@ var allVolumeSourceFields = []string{
 	"emptydir",
 	"configmap",
 	"secret",
+	"projected",
+	"csi",
+	"image",
 }
 
 // Validate looks at the Volume provided in wb and makes sure that it is valid.
@@ -76,6 +81,17 @@ func (b *WorkspaceBinding) Validate(ctx context.Context) (errs *apis.FieldError)
 		return apis.ErrMissingField("csi.driver")
 	}
 
+	// Image workspace bindings require the enable-image-workspace feature flag.
+	if b.Image != nil {
+		cfg := config.FromContextOrDefaults(ctx)
+		if !cfg.FeatureFlags.EnableImageWorkspace {
+			return apis.ErrGeneric(fmt.Sprintf("feature flag %s should be set to true to use image workspace bindings", config.EnableImageWorkspace), "")
+		}
+		if b.Image.Reference == "" {
+			return apis.ErrMissingField("image.reference")
+		}
+	}
+
 	return nil
 }
 
@@ -102,6 +118,9 @@ func (b *WorkspaceBinding) numSources() int {
 		n++
 	}
 	if b.CSI != nil {
+		n++
+	}
+	if b.Image != nil {
 		n++
 	}
 	return n

--- a/pkg/apis/pipeline/v1beta1/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -109,6 +110,17 @@ func TestWorkspaceBindingValidateValid(t *testing.T) {
 				Driver: "my-csi",
 			},
 		},
+	}, {
+		name: "Valid image",
+		binding: &v1beta1.WorkspaceBinding{
+			Name: "beth",
+			Image: &corev1.ImageVolumeSource{
+				Reference: "quay.io/example/my-image:latest",
+			},
+		},
+		wc: func(ctx context.Context) context.Context {
+			return cfgtesting.SetFeatureFlags(ctx, t, map[string]string{"enable-image-workspace": "true"})
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := t.Context()
@@ -175,6 +187,25 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 			CSI: &corev1.CSIVolumeSource{
 				Driver: "",
 			},
+		},
+	}, {
+		name: "Provide image without feature flag",
+		binding: &v1beta1.WorkspaceBinding{
+			Name: "beth",
+			Image: &corev1.ImageVolumeSource{
+				Reference: "quay.io/example/my-image:latest",
+			},
+		},
+	}, {
+		name: "Provide image without a reference",
+		binding: &v1beta1.WorkspaceBinding{
+			Name: "beth",
+			Image: &corev1.ImageVolumeSource{
+				Reference: "",
+			},
+		},
+		wc: func(ctx context.Context) context.Context {
+			return cfgtesting.SetFeatureFlags(ctx, t, map[string]string{"enable-image-workspace": "true"})
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -2926,6 +2926,11 @@ func (in *WorkspaceBinding) DeepCopyInto(out *WorkspaceBinding) {
 		*out = new(corev1.CSIVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Image != nil {
+		in, out := &in.Image, &out.Image
+		*out = new(corev1.ImageVolumeSource)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/workspace/apply.go
+++ b/pkg/workspace/apply.go
@@ -93,6 +93,9 @@ func CreateVolumes(wb []v1.WorkspaceBinding) map[string]corev1.Volume {
 		case w.CSI != nil:
 			csi := *w.CSI
 			v.setVolumeSource(w.Name, name, corev1.VolumeSource{CSI: &csi})
+		case w.Image != nil:
+			img := *w.Image
+			v.setVolumeSource(w.Name, name, corev1.VolumeSource{Image: &img})
 		}
 	}
 	return v
@@ -349,6 +352,9 @@ func replaceWorkspaceBindingVars(wb *v1.WorkspaceBinding, replacements map[strin
 	if wb.CSI != nil {
 		wb.CSI = applyCSIVolumeSource(wb.CSI, replacements)
 	}
+	if wb.Image != nil {
+		wb.Image = applyImageVolumeSource(wb.Image, replacements)
+	}
 	return wb
 }
 
@@ -388,6 +394,11 @@ func applyCSIVolumeSource(csi *corev1.CSIVolumeSource, replacements map[string]s
 		csi.NodePublishSecretRef.Name = substitution.ApplyReplacements(csi.NodePublishSecretRef.Name, replacements)
 	}
 	return csi
+}
+
+func applyImageVolumeSource(img *corev1.ImageVolumeSource, replacements map[string]string) *corev1.ImageVolumeSource {
+	img.Reference = substitution.ApplyReplacements(img.Reference, replacements)
+	return img
 }
 
 func applyKeyToPathItems(items []corev1.KeyToPath, replacements map[string]string) []corev1.KeyToPath {

--- a/pkg/workspace/apply_test.go
+++ b/pkg/workspace/apply_test.go
@@ -738,6 +738,45 @@ func TestApply(t *testing.T) {
 				ReadOnly:  true,
 			}},
 		},
+	}, {
+		name: "binding a single workspace with Image",
+		ts: v1.TaskSpec{
+			Workspaces: []v1.WorkspaceDeclaration{{
+				Name:      "custom",
+				MountPath: "/workspace/image",
+				ReadOnly:  true,
+			}},
+		},
+		workspaces: []v1.WorkspaceBinding{{
+			Name: "custom",
+			Image: &corev1.ImageVolumeSource{
+				Reference:  "quay.io/example/my-tools:latest",
+				PullPolicy: corev1.PullAlways,
+			},
+		}},
+		expectedTaskSpec: v1.TaskSpec{
+			StepTemplate: &v1.StepTemplate{
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "ws-20573",
+					MountPath: "/workspace/image",
+					ReadOnly:  true,
+				}},
+			},
+			Volumes: []corev1.Volume{{
+				Name: "ws-20573",
+				VolumeSource: corev1.VolumeSource{
+					Image: &corev1.ImageVolumeSource{
+						Reference:  "quay.io/example/my-tools:latest",
+						PullPolicy: corev1.PullAlways,
+					},
+				},
+			}},
+			Workspaces: []v1.WorkspaceDeclaration{{
+				Name:      "custom",
+				MountPath: "/workspace/image",
+				ReadOnly:  true,
+			}},
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			vols := workspace.CreateVolumes(tc.workspaces)
@@ -1568,6 +1607,26 @@ func TestReplaceWorkspaceBindingsVars(t *testing.T) {
 						NodePublishSecretRef: &corev1.LocalObjectReference{
 							Name: "replaced",
 						},
+					},
+				},
+			},
+		},
+		{
+			name: "Replace Image",
+			replacements: map[string]string{
+				"params.to-replace": "replaced",
+			},
+			workspaceBindings: []v1.WorkspaceBinding{
+				{
+					Image: &corev1.ImageVolumeSource{
+						Reference: "$(params.to-replace)",
+					},
+				},
+			},
+			expected: []v1.WorkspaceBinding{
+				{
+					Image: &corev1.ImageVolumeSource{
+						Reference: "replaced",
 					},
 				},
 			},


### PR DESCRIPTION
Add support for Kubernetes Image Volumes (corev1.ImageVolumeSource) as a new workspace volume source type in WorkspaceBinding. This allows users to mount container image filesystems as read-only workspace volumes in TaskRuns and PipelineRuns.

The feature is gated behind the "enable-image-workspace" per-feature flag at alpha stability, disabled by default.

Changes:
- Add Image field to WorkspaceBinding in v1 and v1beta1 APIs
- Add "enable-image-workspace" per-feature flag (alpha, default off)
- Add validation requiring image.reference when Image is set
- Gate Image workspace usage behind the feature flag
- Add Image to allVolumeSourceFields (also adds missing projected/csi)
- Add volume creation and parameter substitution support
- Add v1beta1 <-> v1 conversion
- Update deepcopy functions
- Add documentation with Kubernetes version requirements
- Add tests for validation, feature gating, volume creation, and parameter substitution

Fixes: #10592

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add support for Kubernetes Image Volumes as a workspace binding type. When the `enable-image-workspace` feature flag is set to `true`, users can bind workspaces to container image filesystems using the new `image` field. Requires Kubernetes 1.31+ with the ImageVolume feature gate enabled.
```

/kind feature