### PR TITLE
Move object-meta and builder helpers to shared test package

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -106,11 +106,10 @@ var (
 	ignoreCompletionTime     = cmpopts.IgnoreFields(v1.PipelineRunStatusFields{}, "CompletionTime")
 	ignoreFinallyStartTime   = cmpopts.IgnoreFields(v1.PipelineRunStatusFields{}, "FinallyStartTime")
 	ignoreProvenance         = cmpopts.IgnoreFields(v1.PipelineRunStatusFields{}, "Provenance")
-	trueb                    = true
-	simpleHelloWorldTask     = &v1.Task{ObjectMeta: baseObjectMeta("hello-world", "foo")}
-	simpleSomeTask           = &v1.Task{ObjectMeta: baseObjectMeta("some-task", "foo")}
+	simpleHelloWorldTask     = &v1.Task{ObjectMeta: th.BaseObjectMeta("hello-world", "foo")}
+	simpleSomeTask           = &v1.Task{ObjectMeta: th.BaseObjectMeta("some-task", "foo")}
 	simpleHelloWorldPipeline = &v1.Pipeline{
-		ObjectMeta: baseObjectMeta("test-pipeline", "foo"),
+		ObjectMeta: th.BaseObjectMeta("test-pipeline", "foo"),
 		Spec: v1.PipelineSpec{
 			Tasks: []v1.PipelineTask{{
 				Name: "hello-world-1",
@@ -387,7 +386,7 @@ spec:
 	// Check that the expected TaskRun was created
 	actual := getTaskRunByName(t, taskRuns, trName)
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta(trName, namespace, prName,
+		th.TaskRunObjectMeta(trName, namespace, prName,
 			"test-pipeline", "unit-test-1", false),
 		`
 spec:
@@ -518,7 +517,7 @@ spec:
           field2: value
 `),
 		wantRun: parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("test-pipelinerun-custom-task", "namespace", "test-pipelinerun", "test-pipelinerun", "custom-task", false),
+			th.TaskRunObjectMeta("test-pipelinerun-custom-task", "namespace", "test-pipelinerun", "test-pipelinerun", "custom-task", false),
 			`
 spec:
   params:
@@ -563,7 +562,7 @@ spec:
     subPath: foo
 `),
 		wantRun: parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMetaWithAnnotations("test-pipelinerun-custom-task", "namespace", "test-pipelinerun",
+			th.TaskRunObjectMetaWithAnnotations("test-pipelinerun-custom-task", "namespace", "test-pipelinerun",
 				"test-pipelinerun", "custom-task", false, map[string]string{
 					"pipeline.tekton.dev/affinity-assistant": GetAffinityAssistantName("pipelinews", pipelineRunName),
 				}),
@@ -678,7 +677,7 @@ spec:
   serviceAccountName: %s
 `, config.DefaultServiceAccountValue))
 
-	expectedTaskRun.ObjectMeta = taskRunObjectMeta(trName, "foo", "test-pipeline-run-success", "test-pipeline", "unit-test-task-spec", false)
+	expectedTaskRun.ObjectMeta = th.TaskRunObjectMeta(trName, "foo", "test-pipeline-run-success", "test-pipeline", "unit-test-task-spec", false)
 
 	// ignore IgnoreUnexported ignore both after and before steps fields
 	if d := cmp.Diff(expectedTaskRun, actual, ignoreTypeMeta, ignoreResourceVersion, cmpopts.SortSlices(func(x, y v1.TaskSpec) bool { return len(x.Steps) == len(y.Steps) })); d != "" {
@@ -1161,7 +1160,7 @@ spec:
           script: 'echo $(params.param1)'
 `)}
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-missing-results-task1", "foo",
+		th.TaskRunObjectMeta("test-pipeline-missing-results-task1", "foo",
 			"test-pipeline-missing-results", "test-pipeline", "task1", true),
 		`
 spec:
@@ -1235,7 +1234,7 @@ spec:
 `)}
 
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-missing-results-task1", "foo",
+		th.TaskRunObjectMeta("test-pipeline-missing-results-task1", "foo",
 			"test-pipeline-missing-results", "test-pipeline", "task1", true),
 		`
 spec:
@@ -1445,7 +1444,7 @@ status:
 `, pipelineRunName))}
 	ps := []*v1.Pipeline{simpleHelloWorldPipeline}
 	ts := []*v1.Task{simpleHelloWorldTask}
-	trs := []*v1.TaskRun{createHelloWorldTaskRunWithStatus(t, taskRunName, "foo",
+	trs := []*v1.TaskRun{th.CreateHelloWorldTaskRunWithStatus(t, taskRunName, "foo",
 		pipelineRunName, "test-pipeline", "",
 		apis.Condition{
 			Type: apis.ConditionSucceeded,
@@ -1525,10 +1524,10 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			prs := []*v1.PipelineRun{createCancelledPipelineRun(t, "test-pipeline-run-cancelled", tc.specStatus)}
+			prs := []*v1.PipelineRun{th.CreateCancelledPipelineRun(t, "test-pipeline-run-cancelled", tc.specStatus, now)}
 			ps := []*v1.Pipeline{simpleHelloWorldPipeline}
 			ts := []*v1.Task{simpleHelloWorldTask}
-			trs := []*v1.TaskRun{createHelloWorldTaskRun(t, "test-pipeline-run-cancelled-hello-world", "foo",
+			trs := []*v1.TaskRun{th.CreateHelloWorldTaskRun(t, "test-pipeline-run-cancelled-hello-world", "foo",
 				"test-pipeline-run-cancelled", "test-pipeline")}
 
 			d := test.Data{
@@ -1619,7 +1618,7 @@ status:
     name: metrics-pr-success-tr
     pipelineTaskName: hello-world-1
 `),
-		taskRun: createHelloWorldTaskRunWithStatus(t, "metrics-pr-success-tr", "foo",
+		taskRun: th.CreateHelloWorldTaskRunWithStatus(t, "metrics-pr-success-tr", "foo",
 			"metrics-pr-success", "test-pipeline", "",
 			apis.Condition{
 				Type:   apis.ConditionSucceeded,
@@ -1645,7 +1644,7 @@ status:
     name: metrics-pr-failed-tr
     pipelineTaskName: hello-world-1
 `),
-		taskRun: createHelloWorldTaskRunWithStatus(t, "metrics-pr-failed-tr", "foo",
+		taskRun: th.CreateHelloWorldTaskRunWithStatus(t, "metrics-pr-failed-tr", "foo",
 			"metrics-pr-failed", "test-pipeline", "",
 			apis.Condition{
 				Type:   apis.ConditionSucceeded,
@@ -1654,8 +1653,8 @@ status:
 		wantStatus: "failed",
 	}, {
 		name:        "cancelled",
-		pipelineRun: createCancelledPipelineRun(t, "metrics-pr-cancelled", v1.PipelineRunSpecStatusCancelled),
-		taskRun:     createHelloWorldTaskRun(t, "metrics-pr-cancelled-tr", "foo", "metrics-pr-cancelled", "test-pipeline"),
+		pipelineRun: th.CreateCancelledPipelineRun(t, "metrics-pr-cancelled", v1.PipelineRunSpecStatusCancelled, now),
+		taskRun:     th.CreateHelloWorldTaskRun(t, "metrics-pr-cancelled-tr", "foo", "metrics-pr-cancelled", "test-pipeline"),
 		wantStatus:  "cancelled",
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1706,7 +1705,7 @@ spec:
     serviceAccountName: test-sa
 `)}
 	runs := []*v1beta1.CustomRun{parse.MustParseCustomRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-custom-task-with-timeout-hello-world-1", "test", "test-pipeline-run-custom-task-with-timeout",
+		th.TaskRunObjectMeta("test-pipeline-run-custom-task-with-timeout-hello-world-1", "test", "test-pipeline-run-custom-task-with-timeout",
 			"test-pipeline", "hello-world-1", true),
 		`
 spec:
@@ -1814,7 +1813,7 @@ status:
 			prs[0].Spec.Timeouts = tc.timeouts
 
 			customRuns := []*v1beta1.CustomRun{parse.MustParseCustomRunWithObjectMeta(t,
-				taskRunObjectMeta("test-pipeline-run-custom-task-hello-world-1", "test", "test-pipeline-run-custom-task",
+				th.TaskRunObjectMeta("test-pipeline-run-custom-task-hello-world-1", "test", "test-pipeline-run-custom-task",
 					"test-pipeline", "hello-world-1", true),
 				`
 spec:
@@ -1893,8 +1892,8 @@ func TestReconcileOnCancelledRunFinallyPipelineRun(t *testing.T) {
 	// TestReconcileOnCancelledRunFinallyPipelineRun runs "Reconcile" on a PipelineRun that has been gracefully cancelled.
 	// It verifies that reconcile is successful, the pipeline status updated and events generated.
 	d := test.Data{
-		PipelineRuns: []*v1.PipelineRun{createCancelledPipelineRun(t, "test-pipeline-run-cancelled-run-finally", v1.PipelineRunSpecStatusCancelledRunFinally)},
-		Pipelines:    []*v1.Pipeline{helloWorldPipelineWithRunAfter(t)},
+		PipelineRuns: []*v1.PipelineRun{th.CreateCancelledPipelineRun(t, "test-pipeline-run-cancelled-run-finally", v1.PipelineRunSpecStatusCancelledRunFinally, now)},
+		Pipelines:    []*v1.Pipeline{th.HelloWorldPipelineWithRunAfter(t)},
 		Tasks:        []*v1.Task{simpleHelloWorldTask},
 		ConfigMaps:   th.NewFeatureFlagsConfigMapInSlice(),
 	}
@@ -1936,7 +1935,7 @@ func TestReconcileOnCancelledRunFinallyPipelineRun(t *testing.T) {
 // that reconcile is successful, final tasks run, the pipeline status updated
 // and events generated.
 func TestReconcileOnCancelledRunFinallyPipelineRunWithFinalTask(t *testing.T) {
-	prs := []*v1.PipelineRun{createCancelledPipelineRun(t, "test-pipeline-run-cancelled-run-finally", v1.PipelineRunSpecStatusCancelledRunFinally)}
+	prs := []*v1.PipelineRun{th.CreateCancelledPipelineRun(t, "test-pipeline-run-cancelled-run-finally", v1.PipelineRunSpecStatusCancelledRunFinally, now)}
 	ps := []*v1.Pipeline{
 		parse.MustParseV1Pipeline(t, `
 metadata:
@@ -2040,13 +2039,13 @@ spec:
 		simpleSomeTask,
 	}
 	trs := []*v1.TaskRun{
-		createHelloWorldTaskRunWithStatus(t, "test-pipeline-run-cancelled-run-finally-hello-world", "foo",
+		th.CreateHelloWorldTaskRunWithStatus(t, "test-pipeline-run-cancelled-run-finally-hello-world", "foo",
 			"test-pipeline-run-cancelled-run-finally", "test-pipeline", "my-pod-name",
 			apis.Condition{
 				Type:   apis.ConditionSucceeded,
 				Status: corev1.ConditionTrue,
 			}),
-		createHelloWorldTaskRun(t, "test-pipeline-run-cancelled-run-finally-final-task", "foo",
+		th.CreateHelloWorldTaskRun(t, "test-pipeline-run-cancelled-run-finally-final-task", "foo",
 			"test-pipeline-run-cancelled-run-finally", "test-pipeline"),
 	}
 	d := test.Data{
@@ -2094,7 +2093,7 @@ func TestReconcileOnCancelledRunFinallyPipelineRunWithFinalTaskAndRetries(t *tes
 	// been gracefully cancelled. It verifies that reconcile is successful, the pipeline status updated and events generated.
 	// Pipeline has a DAG task "hello-world-1" and Finally task "hello-world-2"
 	ps := []*v1.Pipeline{{
-		ObjectMeta: baseObjectMeta("test-pipeline", "foo"),
+		ObjectMeta: th.BaseObjectMeta("test-pipeline", "foo"),
 		Spec: v1.PipelineSpec{
 			Tasks: []v1.PipelineTask{{
 				Name: "hello-world-1",
@@ -2115,7 +2114,7 @@ func TestReconcileOnCancelledRunFinallyPipelineRunWithFinalTaskAndRetries(t *tes
 	// PipelineRun has been gracefully cancelled, and it has a TaskRun for DAG task "hello-world-1" that has failed
 	// with reason of cancellation
 	prs := []*v1.PipelineRun{{
-		ObjectMeta: baseObjectMeta("test-pipeline-run-cancelled-run-finally", "foo"),
+		ObjectMeta: th.BaseObjectMeta("test-pipeline-run-cancelled-run-finally", "foo"),
 		Spec: v1.PipelineRunSpec{
 			PipelineRef: &v1.PipelineRef{Name: "test-pipeline"},
 			TaskRunTemplate: v1.PipelineTaskRunTemplate{
@@ -2138,7 +2137,7 @@ func TestReconcileOnCancelledRunFinallyPipelineRunWithFinalTaskAndRetries(t *tes
 	})
 
 	// TaskRun exists for DAG task "hello-world-1" that has failed with reason of cancellation
-	trs := []*v1.TaskRun{createHelloWorldTaskRunWithStatus(t, "test-pipeline-run-cancelled-run-finally-hello-world", "foo",
+	trs := []*v1.TaskRun{th.CreateHelloWorldTaskRunWithStatus(t, "test-pipeline-run-cancelled-run-finally-hello-world", "foo",
 		"test-pipeline-run-cancelled-run-finally", "test-pipeline", "my-pod-name",
 		apis.Condition{
 			Type:   apis.ConditionSucceeded,
@@ -2322,7 +2321,7 @@ status:
 			skippedTasks:          nil,
 		}, {
 			name:     "with completed task",
-			pipeline: helloWorldPipelineWithRunAfter(t),
+			pipeline: th.HelloWorldPipelineWithRunAfter(t),
 			taskRuns: []*v1.TaskRun{getTaskRun(
 				t,
 				"test-pipeline-run-stopped-run-finally-hello-world",
@@ -2476,7 +2475,7 @@ status:
 `)}
 	ts := []*v1.Task{simpleHelloWorldTask}
 
-	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout",
+	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, th.TaskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout",
 		"test-pipeline", "hello-world-1", false), `
 spec:
   serviceAccountName: test-sa
@@ -2578,7 +2577,7 @@ status:
 `)}
 			ts := []*v1.Task{simpleHelloWorldTask}
 
-			trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout",
+			trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, th.TaskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout",
 				"test-pipeline", "hello-world-1", false), `
 spec:
   serviceAccountName: test-sa
@@ -2678,14 +2677,14 @@ status:
 `)}
 	ts := []*v1.Task{simpleHelloWorldTask}
 
-	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout-disabled",
+	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, th.TaskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout-disabled",
 		"test-pipeline", "hello-world-1", false), `
 spec:
   serviceAccountName: test-sa
   taskRef:
     name: hello-world
     kind: Task
-`), parse.MustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-timeout-with-finally-hello-world-1", "foo", "test-pipeline-run-with-timeout-disabled",
+`), parse.MustParseTaskRunWithObjectMeta(t, th.TaskRunObjectMeta("test-pipeline-run-with-timeout-with-finally-hello-world-1", "foo", "test-pipeline-run-with-timeout-disabled",
 		"test-pipeline-with-finally", "hello-world-1", false), `
 spec:
   startTime: "2021-12-30T00:00:00Z"
@@ -2697,7 +2696,7 @@ spec:
   - lastTransitionTime: null
     status: "True"
     type: Succeeded
-`), parse.MustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-timeout-with-finally-hello-world-2", "foo", "test-pipeline-run-with-timeout-disabled",
+`), parse.MustParseTaskRunWithObjectMeta(t, th.TaskRunObjectMeta("test-pipeline-run-with-timeout-with-finally-hello-world-2", "foo", "test-pipeline-run-with-timeout-disabled",
 		"test-pipeline-with-finally", "hello-world-2", false), `
 spec:
   serviceAccountName: test-sa
@@ -2855,7 +2854,7 @@ status:
 `)}
 			ts := []*v1.Task{simpleHelloWorldTask}
 
-			trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout",
+			trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, th.TaskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout",
 				"test-pipeline", "hello-world-1", false), `
 spec:
   resources: {}
@@ -2956,7 +2955,7 @@ spec:
       name: hello-world
 `)}
 	ts := []*v1.Task{simpleHelloWorldTask}
-	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout",
+	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, th.TaskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout",
 		"test-pipeline", "hello-world-1", false), `
 spec:
   serviceAccountName: test-sa
@@ -3089,7 +3088,7 @@ spec:
 			"hello-world",
 			corev1.ConditionTrue,
 		),
-		parse.MustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-timeout-finaltask-1", "foo", "test-pipeline-run-with-timeout",
+		parse.MustParseTaskRunWithObjectMeta(t, th.TaskRunObjectMeta("test-pipeline-run-with-timeout-finaltask-1", "foo", "test-pipeline-run-with-timeout",
 			"test-pipeline", "finaltask-1", false), `
 spec:
   serviceAccountName: test-sa
@@ -3373,7 +3372,7 @@ status:
 				"hello-world",
 				corev1.ConditionTrue,
 			),
-			parse.MustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-finally-start-time-finaltask-1", "foo", prName,
+			parse.MustParseTaskRunWithObjectMeta(t, th.TaskRunObjectMeta("test-pipeline-run-with-finally-start-time-finaltask-1", "foo", prName,
 				"test-pipeline-with-finally", "finaltask-1", false), `
 spec:
   serviceAccountName: test-sa
@@ -3842,7 +3841,7 @@ spec:
 `)}
 	ts := []*v1.Task{simpleHelloWorldTask}
 
-	expectedObjectMeta := taskRunObjectMeta(trName, "foo", "test-pipeline-run-with-labels",
+	expectedObjectMeta := th.TaskRunObjectMeta(trName, "foo", "test-pipeline-run-with-labels",
 		"test-pipeline", "hello-world-1", false)
 	expectedObjectMeta.Labels["PipelineRunLabel"] = "PipelineRunValue"
 	expectedObjectMeta.Annotations["PipelineRunAnnotation"] = "PipelineRunValue"
@@ -3985,7 +3984,7 @@ metadata:
 
 	expectedTaskRuns := []*v1.TaskRun{
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta(taskRunNames[0], "foo", "test-pipeline-run-different-service-accs", "test-pipeline", "hello-world-0", false),
+			th.TaskRunObjectMeta(taskRunNames[0], "foo", "test-pipeline-run-different-service-accs", "test-pipeline", "hello-world-0", false),
 			`
 spec:
   serviceAccountName: test-sa-0
@@ -3994,7 +3993,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta(taskRunNames[1], "foo", "test-pipeline-run-different-service-accs", "test-pipeline", "hello-world-1", false),
+			th.TaskRunObjectMeta(taskRunNames[1], "foo", "test-pipeline-run-different-service-accs", "test-pipeline", "hello-world-1", false),
 			`
 spec:
   serviceAccountName: test-sa-1
@@ -4123,7 +4122,7 @@ spec:
 	validateTaskRunsCount(t, taskRuns, 1)
 
 	actual := getTaskRunByName(t, taskRuns, trName)
-	expectedTaskRunObjectMeta := taskRunObjectMeta(trName, namespace, prName, "test-pipeline", "hello-world-1", false)
+	expectedTaskRunObjectMeta := th.TaskRunObjectMeta(trName, namespace, prName, "test-pipeline", "hello-world-1", false)
 	expectedTaskRunObjectMeta.Annotations["PipelineRunAnnotation"] = "PipelineRunValue"
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t, expectedTaskRunObjectMeta, `
 spec:
@@ -4845,13 +4844,13 @@ spec:
     serviceAccountName: test-sa-0
 `)}
 	ts := []*v1.Task{
-		{ObjectMeta: baseObjectMeta("a-task", "foo")},
-		{ObjectMeta: baseObjectMeta("b-task", "foo")},
-		{ObjectMeta: baseObjectMeta("c-task", "foo")},
-		{ObjectMeta: baseObjectMeta("d-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("a-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("b-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("c-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("d-task", "foo")},
 	}
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-different-service-accs-a-task-xxyyy", "foo", "test-pipeline-run-different-service-accs",
+		th.TaskRunObjectMeta("test-pipeline-run-different-service-accs-a-task-xxyyy", "foo", "test-pipeline-run-different-service-accs",
 			"test-pipeline", "a-task", true),
 		`
 spec:
@@ -4886,7 +4885,7 @@ status:
 
 	expectedTaskRunName := "test-pipeline-run-different-service-accs-b-task"
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta(expectedTaskRunName, "foo", "test-pipeline-run-different-service-accs", "test-pipeline", "b-task", false),
+		th.TaskRunObjectMeta(expectedTaskRunName, "foo", "test-pipeline-run-different-service-accs", "test-pipeline", "b-task", false),
 		`
 spec:
   serviceAccountName: test-sa-0
@@ -5052,11 +5051,11 @@ spec:
   - description: a result
     name: aResult
 `),
-		{ObjectMeta: baseObjectMeta("b-task", "foo")},
-		{ObjectMeta: baseObjectMeta("c-task", "foo")},
-		{ObjectMeta: baseObjectMeta("d-task", "foo")},
-		{ObjectMeta: baseObjectMeta("e-task", "foo")},
-		{ObjectMeta: baseObjectMeta("f-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("b-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("c-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("d-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("e-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("f-task", "foo")},
 	}
 
 	d := test.Data{
@@ -5075,7 +5074,7 @@ spec:
 
 	taskRunExists := func(taskName string, taskRunName string) {
 		expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta(taskRunName, "foo", "test-pipeline-run-different-service-accs",
+			th.TaskRunObjectMeta(taskRunName, "foo", "test-pipeline-run-different-service-accs",
 				"test-pipeline", taskName, false),
 			fmt.Sprintf(`
 spec:
@@ -5202,11 +5201,11 @@ spec:
   - description: a result
     name: aResult
 `),
-		{ObjectMeta: baseObjectMeta("b-task", "foo")},
-		{ObjectMeta: baseObjectMeta("c-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("b-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("c-task", "foo")},
 	}
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-different-service-accs-a-task-xxyyy", "foo",
+		th.TaskRunObjectMeta("test-pipeline-run-different-service-accs-a-task-xxyyy", "foo",
 			"test-pipeline-run-different-service-accs", "test-pipeline", "a-task",
 			true),
 		`
@@ -5326,13 +5325,13 @@ spec:
     serviceAccountName: test-sa-0
 `)}
 	ts := []*v1.Task{
-		{ObjectMeta: baseObjectMeta("a-task", "foo")},
-		{ObjectMeta: baseObjectMeta("b-task", "foo")},
-		{ObjectMeta: baseObjectMeta("c-task", "foo")},
-		{ObjectMeta: baseObjectMeta("d-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("a-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("b-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("c-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("d-task", "foo")},
 	}
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-different-service-accs-a-task-xxyyy", "foo", "test-pipeline-run-different-service-accs",
+		th.TaskRunObjectMeta("test-pipeline-run-different-service-accs-a-task-xxyyy", "foo", "test-pipeline-run-different-service-accs",
 			"test-pipeline", "a-task", true),
 		`
 spec:
@@ -5374,7 +5373,7 @@ status:
 
 	expectedTaskRunName := "test-pipeline-run-different-service-accs-b-task"
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta(expectedTaskRunName, "foo", "test-pipeline-run-different-service-accs", "test-pipeline", "b-task", false),
+		th.TaskRunObjectMeta(expectedTaskRunName, "foo", "test-pipeline-run-different-service-accs", "test-pipeline", "b-task", false),
 		`
 spec:
   serviceAccountName: test-sa-0
@@ -5477,13 +5476,13 @@ spec:
     serviceAccountName: test-sa-0
 `)}
 	ts := []*v1.Task{
-		{ObjectMeta: baseObjectMeta("a-task", "foo")},
-		{ObjectMeta: baseObjectMeta("b-task", "foo")},
-		{ObjectMeta: baseObjectMeta("f-c-task", "foo")},
-		{ObjectMeta: baseObjectMeta("f-d-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("a-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("b-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("f-c-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("f-d-task", "foo")},
 	}
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-different-final-task-when-a-task-xxyyy", "foo", "test-pipeline-run-different-final-task-when",
+		th.TaskRunObjectMeta("test-pipeline-run-different-final-task-when-a-task-xxyyy", "foo", "test-pipeline-run-different-final-task-when",
 			"test-pipeline", "a-task", true),
 		`
 spec:
@@ -5499,7 +5498,7 @@ status:
   - name: aResult
     value: aResultValue
 `), parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-different-final-task-when-b-task-xxyyy", "foo", "test-pipeline-run-different-final-task-when",
+		th.TaskRunObjectMeta("test-pipeline-run-different-final-task-when-b-task-xxyyy", "foo", "test-pipeline-run-different-final-task-when",
 			"test-pipeline", "b-task", true),
 		`
 spec:
@@ -5538,7 +5537,7 @@ status:
 
 	expectedTaskRunName := "test-pipeline-run-different-final-task-when-f-c-task"
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta(expectedTaskRunName, "foo", "test-pipeline-run-different-final-task-when", "test-pipeline", "f-c-task", true),
+		th.TaskRunObjectMeta(expectedTaskRunName, "foo", "test-pipeline-run-different-final-task-when", "test-pipeline", "f-c-task", true),
 		`
 spec:
   serviceAccountName: test-sa-0
@@ -5630,7 +5629,7 @@ spec:
     serviceAccountName: test-sa-0
 `)}
 	ts := []*v1.Task{
-		{ObjectMeta: baseObjectMeta("a-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("a-task", "foo")},
 	}
 	cms := []*corev1.ConfigMap{
 		{
@@ -6559,7 +6558,7 @@ spec:
 `),
 	}
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-different-service-accs-a-task-xxyyy", "foo",
+		th.TaskRunObjectMeta("test-pipeline-run-different-service-accs-a-task-xxyyy", "foo",
 			"test-pipeline-run-different-service-accs", "test-pipeline", "a-task", true),
 		`
 spec:
@@ -6590,7 +6589,7 @@ status:
 
 	expectedTaskRunName := "test-pipeline-run-different-service-accs-b-task"
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-different-service-accs-b-task", "foo",
+		th.TaskRunObjectMeta("test-pipeline-run-different-service-accs-b-task", "foo",
 			"test-pipeline-run-different-service-accs", "test-pipeline", "b-task", false),
 		`
 spec:
@@ -6656,7 +6655,7 @@ spec:
 `),
 	}
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-variable-substitution-a-task-xxyyy", "foo",
+		th.TaskRunObjectMeta("test-pipeline-run-variable-substitution-a-task-xxyyy", "foo",
 			"test-pipeline-run-variable-substitution", "test-pipeline", "a-task", true),
 		`
 spec:
@@ -6697,7 +6696,7 @@ spec:
         claimName: $(tasks.a-task.results.aResult)
 `)},
 			expectedTr: parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMetaWithAnnotations("test-pipeline-run-variable-substitution-b-task", "foo",
+				th.TaskRunObjectMetaWithAnnotations("test-pipeline-run-variable-substitution-b-task", "foo",
 					"test-pipeline-run-variable-substitution", "test-pipeline", "b-task", false, map[string]string{
 						"pipeline.tekton.dev/affinity-assistant": "affinity-assistant-0358aabfa2",
 					}),
@@ -6728,7 +6727,7 @@ spec:
       subPath: $(tasks.a-task.results.aResult)
 `)},
 			expectedTr: parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
+				th.TaskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
 					"test-pipeline-run-variable-substitution", "test-pipeline", "b-task", false),
 				`spec:
   serviceAccountName: test-sa-0
@@ -6757,7 +6756,7 @@ spec:
         secretName: $(tasks.a-task.results.aResult)
 `)},
 			expectedTr: parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
+				th.TaskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
 					"test-pipeline-run-variable-substitution", "test-pipeline", "b-task", false),
 				`spec:
   serviceAccountName: test-sa-0
@@ -6789,7 +6788,7 @@ spec:
              name: $(tasks.a-task.results.aResult)
 `)},
 			expectedTr: parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
+				th.TaskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
 					"test-pipeline-run-variable-substitution", "test-pipeline", "b-task", false),
 				`spec:
   serviceAccountName: test-sa-0
@@ -6823,7 +6822,7 @@ spec:
              name: $(tasks.a-task.results.aResult)
 `)},
 			expectedTr: parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
+				th.TaskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
 					"test-pipeline-run-variable-substitution", "test-pipeline", "b-task", false),
 				`spec:
   serviceAccountName: test-sa-0
@@ -6860,7 +6859,7 @@ spec:
                  path: $(tasks.a-task.results.aResult)
 `)},
 			expectedTr: parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
+				th.TaskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
 					"test-pipeline-run-variable-substitution", "test-pipeline", "b-task", false),
 				`spec:
   serviceAccountName: test-sa-0
@@ -6895,7 +6894,7 @@ spec:
         driver: $(tasks.a-task.results.aResult)
 `)},
 			expectedTr: parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
+				th.TaskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
 					"test-pipeline-run-variable-substitution", "test-pipeline", "b-task", false),
 				`spec:
   serviceAccountName: test-sa-0
@@ -6926,7 +6925,7 @@ spec:
           name: $(tasks.a-task.results.aResult)
 `)},
 			expectedTr: parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
+				th.TaskRunObjectMeta("test-pipeline-run-variable-substitution-b-task", "foo",
 					"test-pipeline-run-variable-substitution", "test-pipeline", "b-task", false),
 				`spec:
   serviceAccountName: test-sa-0
@@ -7035,7 +7034,7 @@ spec:
 
 	// Since b-task is dependent on a-task, via the results, only a-task should run
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-different-service-accs-a-task", "foo",
+		th.TaskRunObjectMeta("test-pipeline-run-different-service-accs-a-task", "foo",
 			"test-pipeline-run-different-service-accs", "test-pipeline-run-different-service-accs", "a-task", false),
 		`
 spec:
@@ -7087,7 +7086,7 @@ spec:
         name: b-task
 `)}
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-finally-results-task-run-a", "foo",
+		th.TaskRunObjectMeta("test-pipeline-run-finally-results-task-run-a", "foo",
 			"test-pipeline-run-finally-results", "test-pipeline", "a-task", true),
 		`
 spec:
@@ -7101,7 +7100,7 @@ status:
   - name: a-Result
     value: aResultValue
 `), parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-finally-results-task-run-c", "foo",
+		th.TaskRunObjectMeta("test-pipeline-run-finally-results-task-run-c", "foo",
 			"test-pipeline-run-finally-results", "test-pipeline", "c-task", true),
 		`
 spec:
@@ -7113,7 +7112,7 @@ status:
     type: Succeeded
 `)}
 	crs := []*v1beta1.CustomRun{parse.MustParseCustomRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-finally-results-task-run-b", "foo",
+		th.TaskRunObjectMeta("test-pipeline-run-finally-results-task-run-b", "foo",
 			"test-pipeline-run-finally-results", "test-pipeline", "b-task", true),
 		`
 spec:
@@ -7268,7 +7267,7 @@ spec:
       name: a-task
 `)}
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-results-task-run-a", "foo",
+		th.TaskRunObjectMeta("test-pipeline-run-results-task-run-a", "foo",
 			"test-pipeline-run-results", "test-pipeline", "a-task", true),
 		`
 spec:
@@ -7283,7 +7282,7 @@ status:
     value: aResultValue
 `)}
 	rs := []*v1beta1.CustomRun{parse.MustParseCustomRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-results-task-run-b", "foo",
+		th.TaskRunObjectMeta("test-pipeline-run-results-task-run-b", "foo",
 			"test-pipeline-run-results", "test-pipeline", "b-task", true),
 		`
 spec:
@@ -7415,7 +7414,7 @@ spec:
       name: b-task
 `)}
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-failed-pr-with-task-results-a-task", "foo",
+		th.TaskRunObjectMeta("test-failed-pr-with-task-results-a-task", "foo",
 			"test-failed-pr-with-task-results", "test-pipeline", "a-task", true),
 		`
 spec:
@@ -7431,7 +7430,7 @@ status:
   - name: aResult
     value: aResultValue
 `), parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-failed-pr-with-task-results-b-task", "foo",
+		th.TaskRunObjectMeta("test-failed-pr-with-task-results-b-task", "foo",
 			"test-failed-pr-with-task-results", "test-pipeline", "b-task", true),
 		`
 spec:
@@ -7467,7 +7466,7 @@ status:
   startTime: "2021-12-31T00:00:00Z"
 `)}
 	ts := []*v1.Task{
-		{ObjectMeta: baseObjectMeta("a-task", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("a-task", "foo")},
 		parse.MustParseV1Task(t, `
 metadata:
   name: b-task
@@ -7710,7 +7709,7 @@ spec:
 
 	// This taskrun is in the pipelinerun status. It completed successfully.
 	taskRunDone := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-out-of-sync-hello-world-1", "foo", prOutOfSyncName, testPipeline.Name, "hello-world-1", false),
+		th.TaskRunObjectMeta("test-pipeline-run-out-of-sync-hello-world-1", "foo", prOutOfSyncName, testPipeline.Name, "hello-world-1", false),
 		`
 spec:
   taskRef:
@@ -7723,7 +7722,7 @@ status:
 
 	// This taskrun is *not* in the pipelinerun status. It's still running.
 	taskRunOrphaned := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-out-of-sync-hello-world-2", "foo", prOutOfSyncName, testPipeline.Name, "hello-world-2", false),
+		th.TaskRunObjectMeta("test-pipeline-run-out-of-sync-hello-world-2", "foo", prOutOfSyncName, testPipeline.Name, "hello-world-2", false),
 		`
 spec:
   taskRef:
@@ -7735,7 +7734,7 @@ status:
 `)
 
 	orphanedCustomRun := parse.MustParseCustomRunWithObjectMeta(t,
-		taskRunObjectMeta("test-pipeline-run-out-of-sync-hello-world-5", "foo", prOutOfSyncName, testPipeline.Name,
+		th.TaskRunObjectMeta("test-pipeline-run-out-of-sync-hello-world-5", "foo", prOutOfSyncName, testPipeline.Name,
 			"hello-world-5", true),
 		`
 spec:
@@ -8455,7 +8454,7 @@ func checkTaskRunStatusFromChildRefs(ctx context.Context, t *testing.T, namespac
 
 func getPipelineRun(pr, p string, status corev1.ConditionStatus, reason string, m string, tr map[string]string) []*v1.PipelineRun {
 	pRun := &v1.PipelineRun{
-		ObjectMeta: baseObjectMeta(pr, "foo"),
+		ObjectMeta: th.BaseObjectMeta(pr, "foo"),
 		Spec: v1.PipelineRunSpec{
 			PipelineRef: &v1.PipelineRef{Name: p},
 			TaskRunTemplate: v1.PipelineTaskRunTemplate{
@@ -8499,7 +8498,7 @@ func withOwnerReference(trs []*v1.TaskRun, prName string) {
 
 func getPipeline(p string, spec v1.PipelineSpec) []*v1.Pipeline {
 	ps := []*v1.Pipeline{{
-		ObjectMeta: baseObjectMeta(p, "foo"),
+		ObjectMeta: th.BaseObjectMeta(p, "foo"),
 		Spec:       spec,
 	}}
 	return ps
@@ -8507,7 +8506,7 @@ func getPipeline(p string, spec v1.PipelineSpec) []*v1.Pipeline {
 
 func getTaskRun(t *testing.T, tr, pr, p, tl string, status corev1.ConditionStatus) *v1.TaskRun {
 	t.Helper()
-	return createHelloWorldTaskRunWithStatusTaskLabel(t, tr, "foo", pr, p, "", tl,
+	return th.CreateHelloWorldTaskRunWithStatusTaskLabel(t, tr, "foo", pr, p, "", tl,
 		apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: status,
@@ -8659,7 +8658,7 @@ spec:
 `)}
 
 	ts := []*v1.Task{
-		{ObjectMeta: baseObjectMeta("mytask", "foo")},
+		{ObjectMeta: th.BaseObjectMeta("mytask", "foo")},
 		parse.MustParseV1Task(t, `
 metadata:
   name: finaltask
@@ -8672,7 +8671,7 @@ spec:
 	}
 
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta(pipelineRunName+"-task1-xxyy", "foo", pipelineRunName, pipelineName, "task1", false),
+		th.TaskRunObjectMeta(pipelineRunName+"-task1-xxyy", "foo", pipelineRunName, pipelineName, "task1", false),
 		`
 spec:
   serviceAccountName: test-sa
@@ -8698,7 +8697,7 @@ status:
 	_, clients := prt.reconcileRun("foo", pipelineRunName, []string{}, false)
 
 	expectedTaskRunName := pipelineRunName + "-finaltask"
-	expectedTaskRunObjectMeta := taskRunObjectMeta(expectedTaskRunName, "foo", pipelineRunName, pipelineName, "finaltask", false)
+	expectedTaskRunObjectMeta := th.TaskRunObjectMeta(expectedTaskRunName, "foo", pipelineRunName, pipelineName, "finaltask", false)
 	expectedTaskRunObjectMeta.Labels[pipeline.MemberOfLabelKey] = v1.PipelineFinallyTasks
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t, expectedTaskRunObjectMeta, `
 spec:
@@ -8840,7 +8839,7 @@ spec:
 
 	trs := []*v1.TaskRun{
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("test-pipeline-run-final-task-results-dag-task-1-xxyyy", "foo",
+			th.TaskRunObjectMeta("test-pipeline-run-final-task-results-dag-task-1-xxyyy", "foo",
 				"test-pipeline-run-final-task-results", "test-pipeline", "dag-task-1", false),
 			`
 spec:
@@ -8857,7 +8856,7 @@ status:
     value: aResultValue
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("test-pipeline-run-final-task-results-dag-task-2-xxyyy", "foo",
+			th.TaskRunObjectMeta("test-pipeline-run-final-task-results-dag-task-2-xxyyy", "foo",
 				"test-pipeline-run-final-task-results", "test-pipeline", "dag-task-2", false),
 			`
 spec:
@@ -8871,7 +8870,7 @@ status:
     type: Succeeded
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("test-pipeline-run-final-task-results-dag-task-3-xxyyy", "foo",
+			th.TaskRunObjectMeta("test-pipeline-run-final-task-results-dag-task-3-xxyyy", "foo",
 				"test-pipeline-run-final-task-results", "test-pipeline", "dag-task-3", false),
 			`
 spec:
@@ -8901,7 +8900,7 @@ status:
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-final-task-results", []string{}, false)
 
 	expectedTaskRunName := "test-pipeline-run-final-task-results-final-task-1"
-	expectedTaskRunObjectMeta := taskRunObjectMeta("test-pipeline-run-final-task-results-final-task-1", "foo",
+	expectedTaskRunObjectMeta := th.TaskRunObjectMeta("test-pipeline-run-final-task-results-final-task-1", "foo",
 		"test-pipeline-run-final-task-results", "test-pipeline", "final-task-1", true)
 	expectedTaskRunObjectMeta.Labels[pipeline.MemberOfLabelKey] = v1.PipelineFinallyTasks
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t, expectedTaskRunObjectMeta, `
@@ -8987,10 +8986,10 @@ spec:
     resolver: cluster
 `)}
 
-	ts := []*v1.Task{{ObjectMeta: baseObjectMeta("mytask", "foo")}}
+	ts := []*v1.Task{{ObjectMeta: th.BaseObjectMeta("mytask", "foo")}}
 
 	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta(pipelineRunName+"-task1-xxyy", "foo", pipelineRunName, pipelineName, "task1", false),
+		th.TaskRunObjectMeta(pipelineRunName+"-task1-xxyy", "foo", pipelineRunName, pipelineName, "task1", false),
 		`
 spec:
   serviceAccountName: test-sa
@@ -9151,7 +9150,7 @@ metadata:
 
 	actual := getTaskRunByName(t, taskRuns, trName)
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta(trName, namespace, prName,
+		th.TaskRunObjectMeta(trName, namespace, prName,
 			"test-pipeline", "unit-test-1", false), `
 spec:
   serviceAccountName: test-sa
@@ -9445,7 +9444,7 @@ spec:
 
 	actual := getTaskRunByName(t, taskRuns, trName)
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta(trName, namespace, prName,
+		th.TaskRunObjectMeta(trName, namespace, prName,
 			"test-pipeline-run-success", "unit-test-1", false),
 		`
 spec:
@@ -10023,7 +10022,7 @@ spec:
 }
 
 func getTaskRunWithTaskSpec(tr, pr, p, t string, labels, annotations map[string]string) *v1.TaskRun {
-	om := taskRunObjectMeta(tr, "foo", pr, p, t, false)
+	om := th.TaskRunObjectMeta(tr, "foo", pr, p, t, false)
 	for k, v := range labels {
 		om.Labels[k] = v
 	}
@@ -10041,129 +10040,6 @@ func getTaskRunWithTaskSpec(tr, pr, p, t string, labels, annotations map[string]
 			ServiceAccountName: config.DefaultServiceAccountValue,
 		},
 	}
-}
-
-func baseObjectMeta(name, ns string) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Name:        name,
-		Namespace:   ns,
-		Labels:      map[string]string{},
-		Annotations: map[string]string{},
-	}
-}
-
-func taskRunObjectMeta(trName, ns, prName, pipelineName, pipelineTaskName string, skipMemberOfLabel bool) metav1.ObjectMeta {
-	om := metav1.ObjectMeta{
-		Name:      trName,
-		Namespace: ns,
-		OwnerReferences: []metav1.OwnerReference{{
-			Kind:               "PipelineRun",
-			Name:               prName,
-			APIVersion:         "tekton.dev/v1",
-			Controller:         &trueb,
-			BlockOwnerDeletion: &trueb,
-			UID:                "",
-		}},
-		Labels: map[string]string{
-			pipeline.PipelineLabelKey:       pipelineName,
-			pipeline.PipelineRunLabelKey:    prName,
-			pipeline.PipelineTaskLabelKey:   pipelineTaskName,
-			pipeline.PipelineRunUIDLabelKey: "",
-		},
-		Annotations: map[string]string{},
-	}
-	if !skipMemberOfLabel {
-		om.Labels[pipeline.MemberOfLabelKey] = v1.PipelineTasks
-	}
-	return om
-}
-
-func taskRunObjectMetaWithAnnotations(trName, ns, prName, pipelineName, pipelineTaskName string, skipMemberOfLabel bool, annotations map[string]string) metav1.ObjectMeta {
-	om := taskRunObjectMeta(trName, ns, prName, pipelineName, pipelineTaskName, skipMemberOfLabel)
-	for k, v := range annotations {
-		om.Annotations[k] = v
-	}
-	return om
-}
-
-func createHelloWorldTaskRunWithStatus(
-	t *testing.T,
-	trName, ns, prName, pName, podName string,
-	condition apis.Condition,
-) *v1.TaskRun {
-	t.Helper()
-	p := createHelloWorldTaskRun(t, trName, ns, prName, pName)
-	p.Status = v1.TaskRunStatus{
-		Status: duckv1.Status{
-			Conditions: duckv1.Conditions{condition},
-		},
-		TaskRunStatusFields: v1.TaskRunStatusFields{
-			PodName: podName,
-		},
-	}
-	return p
-}
-
-func createHelloWorldTaskRunWithStatusTaskLabel(
-	t *testing.T,
-	trName, ns, prName, pName, podName, taskLabel string,
-	condition apis.Condition,
-) *v1.TaskRun {
-	t.Helper()
-	p := createHelloWorldTaskRunWithStatus(t, trName, ns, prName, pName, podName, condition)
-	p.Labels[pipeline.PipelineTaskLabelKey] = taskLabel
-
-	return p
-}
-
-func createHelloWorldTaskRun(t *testing.T, trName, ns, prName, pName string) *v1.TaskRun {
-	t.Helper()
-	return parse.MustParseV1TaskRun(t, fmt.Sprintf(`
-metadata:
-  name: %s
-  namespace: %s
-  labels:
-    %s: %s
-    %s: %s
-spec:
-  taskRef:
-    name: hello-world
-  serviceAccountName: test-sa
-`, trName, ns, pipeline.PipelineLabelKey, pName, pipeline.PipelineRunLabelKey, prName))
-}
-
-func createCancelledPipelineRun(t *testing.T, prName string, specStatus v1.PipelineRunSpecStatus) *v1.PipelineRun {
-	t.Helper()
-	return parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
-metadata:
-  name: %s
-  namespace: foo
-spec:
-  pipelineRef:
-    name: test-pipeline
-  serviceAccountName: test-sa
-  status: %s
-status:
-  startTime: %s`, prName, specStatus, now.Format(time.RFC3339)))
-}
-
-func helloWorldPipelineWithRunAfter(t *testing.T) *v1.Pipeline {
-	t.Helper()
-	return parse.MustParseV1Pipeline(t, `
-metadata:
-  name: test-pipeline
-  namespace: foo
-spec:
-  tasks:
-    - name: hello-world-1
-      taskRef:
-        name: hello-world
-    - name: hello-world-2
-      taskRef:
-        name: hello-world
-      runAfter:
-        - hello-world-1
-`)
 }
 
 func TestGetTaskrunWorkspaces_Failure(t *testing.T) {
@@ -10490,7 +10366,7 @@ spec:
 	validateTaskRunsCount(t, taskRuns, 1)
 
 	actual := getTaskRunByName(t, taskRuns, trName)
-	expectedTaskRunObjectMeta := taskRunObjectMeta(trName, namespace, prName, "test-pipeline", "hello-world-1", false)
+	expectedTaskRunObjectMeta := th.TaskRunObjectMeta(trName, namespace, prName, "test-pipeline", "hello-world-1", false)
 	expectedTaskRunObjectMeta.Labels["PipelineTaskRunSpecLabel"] = "PipelineTaskRunSpecValue"
 	expectedTaskRunObjectMeta.Annotations["PipelineTaskRunSpecAnnotation"] = "PipelineTaskRunSpecValue"
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t, expectedTaskRunObjectMeta, `
@@ -10567,7 +10443,7 @@ spec:
 	validateTaskRunsCount(t, taskRuns, 1)
 
 	actual := getTaskRunByName(t, taskRuns, trName)
-	expectedTaskRunObjectMeta := taskRunObjectMeta(trName, namespace, prName, "test-pipeline", "hello-world-1", false)
+	expectedTaskRunObjectMeta := th.TaskRunObjectMeta(trName, namespace, prName, "test-pipeline", "hello-world-1", false)
 	expectedTaskRunObjectMeta.Labels["TestPrecedenceLabel"] = "PipelineTaskRunSpecValue"
 	expectedTaskRunObjectMeta.Annotations["TestPrecedenceAnnotation"] = "PipelineTaskRunSpecValue"
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t, expectedTaskRunObjectMeta, `
@@ -10605,7 +10481,7 @@ spec:
 
 	expectedTaskRuns := []*v1.TaskRun{
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -10622,7 +10498,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -10639,7 +10515,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-2", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-2", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -10656,7 +10532,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-3", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-3", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -10673,7 +10549,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-4", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-4", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -10690,7 +10566,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-5", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-5", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -10707,7 +10583,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-6", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-6", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -10724,7 +10600,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-7", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-7", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -10741,7 +10617,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-8", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-8", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -10758,7 +10634,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-using-platforms", "foo",
+			th.TaskRunObjectMeta("pr-matrix-using-platforms", "foo",
 				"pr", "p", "matrix-using-platforms", false),
 			`
 spec:
@@ -10958,7 +10834,7 @@ spec:
           value: v0.33.0
 `, "p-finally")),
 		tr: parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-unmatrixed-pt", "foo",
+			th.TaskRunObjectMeta("pr-unmatrixed-pt", "foo",
 				"pr", "p-finally", "unmatrixed-pt", false),
 			`
 spec:
@@ -11340,7 +11216,7 @@ spec:
 			for i, trd := range expectedTaskRunsData {
 				trName := "pr-platforms-and-browsers-" + strconv.Itoa(i)
 				expectedTaskRuns = append(expectedTaskRuns, parse.MustParseTaskRunWithObjectMeta(t,
-					taskRunObjectMeta(trName, "foo", "pr", "p-dag", "platforms-and-browsers", false),
+					th.TaskRunObjectMeta(trName, "foo", "pr", "p-dag", "platforms-and-browsers", false),
 					fmt.Sprintf(`
 spec:
   params:
@@ -11407,7 +11283,7 @@ spec:
 
 	expectedTaskRuns := []*v1.TaskRun{
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-include-0", "foo",
+			th.TaskRunObjectMeta("pr-matrix-include-0", "foo",
 				"pr", "p", "matrix-include", false),
 			`
 spec:
@@ -11426,7 +11302,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-include-1", "foo",
+			th.TaskRunObjectMeta("pr-matrix-include-1", "foo",
 				"pr", "p", "matrix-include", false),
 			`
 spec:
@@ -11445,7 +11321,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-include-2", "foo",
+			th.TaskRunObjectMeta("pr-matrix-include-2", "foo",
 				"pr", "p", "matrix-include", false),
 			`
 spec:
@@ -11466,7 +11342,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-include-3", "foo",
+			th.TaskRunObjectMeta("pr-matrix-include-3", "foo",
 				"pr", "p", "matrix-include", false),
 			`
 spec:
@@ -11483,7 +11359,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-include-4", "foo",
+			th.TaskRunObjectMeta("pr-matrix-include-4", "foo",
 				"pr", "p", "matrix-include", false),
 			`
 spec:
@@ -11500,7 +11376,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-include-5", "foo",
+			th.TaskRunObjectMeta("pr-matrix-include-5", "foo",
 				"pr", "p", "matrix-include", false),
 			`
 spec:
@@ -11519,7 +11395,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-include-6", "foo",
+			th.TaskRunObjectMeta("pr-matrix-include-6", "foo",
 				"pr", "p", "matrix-include", false),
 			`
 spec:
@@ -11738,7 +11614,7 @@ spec:
               value: I-do-not-exist
 `, "p-finally")),
 		tr: parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-unmatrixed-pt", "foo",
+			th.TaskRunObjectMeta("pr-unmatrixed-pt", "foo",
 				"pr", "p-finally", "unmatrixed-pt", false),
 			`
 spec:
@@ -11957,7 +11833,7 @@ spec:
 
 	expectedTaskRuns := []*v1.TaskRun{
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-include-0", "foo",
+			th.TaskRunObjectMeta("pr-matrix-include-0", "foo",
 				"pr", "p", "matrix-include", false),
 			`
 spec:
@@ -11972,7 +11848,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-include-1", "foo",
+			th.TaskRunObjectMeta("pr-matrix-include-1", "foo",
 				"pr", "p", "matrix-include", false),
 			`
 spec:
@@ -11987,7 +11863,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-include-2", "foo",
+			th.TaskRunObjectMeta("pr-matrix-include-2", "foo",
 				"pr", "p", "matrix-include", false),
 			`
 spec:
@@ -12212,7 +12088,7 @@ spec:
 
 	expectedTaskRuns := []*v1.TaskRun{
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -12229,7 +12105,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -12246,7 +12122,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-2", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-2", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -12263,7 +12139,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-3", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-3", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -12280,7 +12156,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-4", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-4", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -12297,7 +12173,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-5", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-5", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -12314,7 +12190,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-6", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-6", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -12331,7 +12207,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-7", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-7", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -12348,7 +12224,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-8", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-8", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -12413,7 +12289,7 @@ spec:
           value: $(tasks.pt-with-result.results.version)
 `, "p-dag")),
 		tr: parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-pt-with-result", "foo",
+			th.TaskRunObjectMeta("pr-pt-with-result", "foo",
 				"pr", "p-dag", "pt-with-result", false),
 			`
 spec:
@@ -12577,7 +12453,7 @@ spec:
           value: $(tasks.pt-with-result.results.version)
 `, "p-finally")),
 		tr: parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-pt-with-result", "foo",
+			th.TaskRunObjectMeta("pr-pt-with-result", "foo",
 				"pr", "p-finally", "pt-with-result", false),
 			`
 spec:
@@ -12826,7 +12702,7 @@ spec:
         name: mytask
 `, "p-dag")),
 		tr: parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-pt-with-result", "foo",
+			th.TaskRunObjectMeta("pr-pt-with-result", "foo",
 				"pr", "p-dag", "pt-with-result", false),
 			`
 spec:
@@ -12848,7 +12724,7 @@ status:
 `),
 		expectedTaskRuns: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-echo-platforms", "foo",
+				th.TaskRunObjectMeta("pr-echo-platforms", "foo",
 					"pr", "p-dag", "echo-platforms", false),
 				`
 spec:
@@ -12941,7 +12817,7 @@ spec:
         name: mytask
 `, "p-dag-2")),
 		tr: parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-pt-with-result", "foo",
+			th.TaskRunObjectMeta("pr-pt-with-result", "foo",
 				"pr", "p-dag-2", "pt-with-result", false),
 			`
 spec:
@@ -12963,7 +12839,7 @@ status:
 `),
 		expectedTaskRuns: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-echo-platforms-0", "foo",
+				th.TaskRunObjectMeta("pr-echo-platforms-0", "foo",
 					"pr", "p-dag-2", "echo-platforms", false),
 				`
 spec:
@@ -12979,7 +12855,7 @@ labels:
     tekton.dev/pipeline: p-dag-2
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-echo-platforms-1", "foo",
+				th.TaskRunObjectMeta("pr-echo-platforms-1", "foo",
 					"pr", "p-dag-2", "echo-platforms", false),
 				`
 spec:
@@ -12995,7 +12871,7 @@ labels:
     tekton.dev/pipeline: p-dag-2
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-echo-platforms-2", "foo",
+				th.TaskRunObjectMeta("pr-echo-platforms-2", "foo",
 					"pr", "p-dag-2", "echo-platforms", false),
 				`
 spec:
@@ -13091,7 +12967,7 @@ spec:
         name: mytask
 `, "p-dag-3")),
 		tr: parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-pt-with-result", "foo",
+			th.TaskRunObjectMeta("pr-pt-with-result", "foo",
 				"pr", "p-dag-3", "pt-with-result", false),
 			`
 spec:
@@ -13113,7 +12989,7 @@ status:
 `),
 		expectedTaskRuns: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-echo-platforms-0", "foo",
+				th.TaskRunObjectMeta("pr-echo-platforms-0", "foo",
 					"pr", "p-dag-3", "echo-platforms", false),
 				`
 spec:
@@ -13129,7 +13005,7 @@ labels:
     tekton.dev/pipeline: p-dag-3
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-echo-platforms-1", "foo",
+				th.TaskRunObjectMeta("pr-echo-platforms-1", "foo",
 					"pr", "p-dag-3", "echo-platforms", false),
 				`
 spec:
@@ -13145,7 +13021,7 @@ labels:
     tekton.dev/pipeline: p-dag-3
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-echo-platforms-2", "foo",
+				th.TaskRunObjectMeta("pr-echo-platforms-2", "foo",
 					"pr", "p-dag-3", "echo-platforms", false),
 				`
 spec:
@@ -13277,7 +13153,7 @@ spec:
 `)
 	expectedCustomRuns := []*v1beta1.CustomRun{
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-pt-matrix-custom-task-0", "foo",
+			th.TaskRunObjectMeta("pr-pt-matrix-custom-task-0", "foo",
 				"pr", "p-dag", "pt-matrix-custom-task", false),
 			`
 spec:
@@ -13296,7 +13172,7 @@ spec:
     tekton.dev/pipeline: p-dag
 `),
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-pt-matrix-custom-task-1", "foo",
+			th.TaskRunObjectMeta("pr-pt-matrix-custom-task-1", "foo",
 				"pr", "p-dag", "pt-matrix-custom-task", false),
 			`
 spec:
@@ -13315,7 +13191,7 @@ spec:
     tekton.dev/pipeline: p-dag
 `),
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-pt-matrix-custom-task-2", "foo",
+			th.TaskRunObjectMeta("pr-pt-matrix-custom-task-2", "foo",
 				"pr", "p-dag", "pt-matrix-custom-task", false),
 			`
 spec:
@@ -13366,7 +13242,7 @@ spec:
         kind: Example
 `, "p-dag")),
 		tr: parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-pt-with-result", "foo",
+			th.TaskRunObjectMeta("pr-pt-with-result", "foo",
 				"pr", "p-dag", "pt-with-result", false),
 			`
 spec:
@@ -13520,7 +13396,7 @@ spec:
 		name: "matrixed pipelinetask with retries, where one taskrun has failed and another one is running",
 		trs: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
+				th.TaskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
 					"pr", "p", "platforms-and-browsers", false),
 				`
 spec:
@@ -13544,7 +13420,7 @@ status:
       type: Succeeded
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
+				th.TaskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
 					"pr", "p", "platforms-and-browsers", false),
 				`
 spec:
@@ -13654,7 +13530,7 @@ status:
 `),
 		expectedTaskRuns: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
+				th.TaskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
 					"pr", "p", "platforms-and-browsers", false),
 				`
 spec:
@@ -13678,7 +13554,7 @@ status:
       type: Succeeded
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
+				th.TaskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
 					"pr", "p", "platforms-and-browsers", false),
 				`
 spec:
@@ -13702,7 +13578,7 @@ status:
 		name: "matrixed pipelinetask with retries, where both taskruns have failed",
 		trs: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
+				th.TaskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
 					"pr", "p", "platforms-and-browsers", false),
 				`
 spec:
@@ -13726,7 +13602,7 @@ status:
       type: Succeeded
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
+				th.TaskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
 					"pr", "p", "platforms-and-browsers", false),
 				`
 spec:
@@ -13840,7 +13716,7 @@ status:
 `),
 		expectedTaskRuns: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
+				th.TaskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
 					"pr", "p", "platforms-and-browsers", false),
 				`
 spec:
@@ -13864,7 +13740,7 @@ status:
       type: Succeeded
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
+				th.TaskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
 					"pr", "p", "platforms-and-browsers", false),
 				`
 spec:
@@ -13958,7 +13834,7 @@ spec:
 
 	expectedCustomRuns := []*v1beta1.CustomRun{
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-0", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -13977,7 +13853,7 @@ spec:
     name: mytask
 `),
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-1", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -13996,7 +13872,7 @@ spec:
     name: mytask
 `),
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-2", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-2", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -14015,7 +13891,7 @@ spec:
     name: mytask
 `),
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-3", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-3", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -14034,7 +13910,7 @@ spec:
     name: mytask
 `),
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-4", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-4", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -14053,7 +13929,7 @@ spec:
     name: mytask
 `),
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-5", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-5", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -14072,7 +13948,7 @@ spec:
     name: mytask
 `),
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-6", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-6", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -14091,7 +13967,7 @@ spec:
     name: mytask
 `),
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-7", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-7", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -14110,7 +13986,7 @@ spec:
     name: mytask
 `),
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-platforms-and-browsers-8", "foo",
+			th.TaskRunObjectMeta("pr-platforms-and-browsers-8", "foo",
 				"pr", "p", "platforms-and-browsers", false),
 			`
 spec:
@@ -14284,7 +14160,7 @@ spec:
           value: v0.1
 `, "p-finally")),
 		tr: parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-unmatrixed-pt", "foo",
+			th.TaskRunObjectMeta("pr-unmatrixed-pt", "foo",
 				"pr", "p-finally", "unmatrixed-pt", false),
 			`
 spec:
@@ -14521,7 +14397,7 @@ spec:
         name: mytask
 `, "p-dag")),
 		tr: parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-pt-with-result", "foo",
+			th.TaskRunObjectMeta("pr-pt-with-result", "foo",
 				"pr", "p-dag", "pt-with-result", false),
 			`
 spec:
@@ -14599,7 +14475,7 @@ spec:
 
 	expectedTaskRuns := []*v1.TaskRun{
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-with-onerror-0", "foo",
+			th.TaskRunObjectMeta("pr-matrix-with-onerror-0", "foo",
 				"pr", "p", "matrix-with-onerror", false),
 			`
 spec:
@@ -14612,7 +14488,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-with-onerror-1", "foo",
+			th.TaskRunObjectMeta("pr-matrix-with-onerror-1", "foo",
 				"pr", "p", "matrix-with-onerror", false),
 			`
 spec:
@@ -14625,7 +14501,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-with-onerror-2", "foo",
+			th.TaskRunObjectMeta("pr-matrix-with-onerror-2", "foo",
 				"pr", "p", "matrix-with-onerror", false),
 			`
 spec:
@@ -14638,7 +14514,7 @@ spec:
     kind: Task
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-with-onerror-3", "foo",
+			th.TaskRunObjectMeta("pr-matrix-with-onerror-3", "foo",
 				"pr", "p", "matrix-with-onerror", false),
 			`
 spec:
@@ -14758,7 +14634,7 @@ spec:
               - "3"
 `, "p-finally")),
 		tr: parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-unmatrixed-pt", "foo",
+			th.TaskRunObjectMeta("pr-unmatrixed-pt", "foo",
 				"pr", "p-finally", "unmatrixed-pt", false),
 			`
 spec:
@@ -14978,7 +14854,7 @@ spec:
 `)
 	taskRuns := []*v1.TaskRun{
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-emitting-results-0", "foo",
+			th.TaskRunObjectMeta("pr-matrix-emitting-results-0", "foo",
 				"pr", "p", "matrix-emitting-results", false),
 			`
 spec:
@@ -15004,7 +14880,7 @@ status:
     value: image-1
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-emitting-results-1", "foo",
+			th.TaskRunObjectMeta("pr-matrix-emitting-results-1", "foo",
 				"pr", "p", "matrix-emitting-results", false),
 			`
 spec:
@@ -15030,7 +14906,7 @@ status:
     value: image-2
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-emitting-results-2", "foo",
+			th.TaskRunObjectMeta("pr-matrix-emitting-results-2", "foo",
 				"pr", "p", "matrix-emitting-results", false),
 			`
 spec:
@@ -15116,7 +14992,7 @@ spec:
 `, "p-consuming-results")),
 		expectedTaskRuns: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrix-task-consuming-results-0", "foo",
+				th.TaskRunObjectMeta("pr-matrix-task-consuming-results-0", "foo",
 					"pr", "p", "matrix-task-consuming-results", false),
 				`
 spec:
@@ -15129,7 +15005,7 @@ spec:
     kind: Task
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrix-task-consuming-results-1", "foo",
+				th.TaskRunObjectMeta("pr-matrix-task-consuming-results-1", "foo",
 					"pr", "p", "matrix-task-consuming-results", false),
 				`
 spec:
@@ -15142,7 +15018,7 @@ spec:
     kind: Task
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrix-task-consuming-results-2", "foo",
+				th.TaskRunObjectMeta("pr-matrix-task-consuming-results-2", "foo",
 					"pr", "p", "matrix-task-consuming-results", false),
 				`
 spec:
@@ -15155,7 +15031,7 @@ spec:
     kind: Task
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-task-consuming-results", "foo",
+				th.TaskRunObjectMeta("pr-task-consuming-results", "foo",
 					"pr", "p", "task-consuming-results", false),
 				`
 spec:
@@ -15320,7 +15196,7 @@ spec:
 `, "p-matrix-context-vars")),
 		expectedTaskRuns: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrixed-echo-length", "foo",
+				th.TaskRunObjectMeta("pr-matrixed-echo-length", "foo",
 					"pr", "p", "matrixed-echo-length", false),
 				`
 spec:
@@ -15333,7 +15209,7 @@ spec:
     kind: Task
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrixed-echo-results-length", "foo",
+				th.TaskRunObjectMeta("pr-matrixed-echo-results-length", "foo",
 					"pr", "p", "matrixed-echo-results-length", false),
 				`
 spec:
@@ -15481,7 +15357,7 @@ spec:
 
 		expectedTaskRuns: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrixed-echo-length", "foo",
+				th.TaskRunObjectMeta("pr-matrixed-echo-length", "foo",
 					"pr", "p-finally", "matrixed-echo-length", false),
 				`
 spec:
@@ -15494,7 +15370,7 @@ spec:
     kind: Task
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrixed-echo-results-length", "foo",
+				th.TaskRunObjectMeta("pr-matrixed-echo-results-length", "foo",
 					"pr", "p-finally", "matrixed-echo-results-length", false),
 				`
 spec:
@@ -15696,7 +15572,7 @@ spec:
 `)
 	trs := []*v1.TaskRun{
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-emitting-results-0", "foo",
+			th.TaskRunObjectMeta("pr-matrix-emitting-results-0", "foo",
 				"pr", "p", "matrix-emitting-results", false),
 			`
 spec:
@@ -15718,7 +15594,7 @@ status:
     value: https://api.example/get-report/linux-chrome
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-emitting-results-1", "foo",
+			th.TaskRunObjectMeta("pr-matrix-emitting-results-1", "foo",
 				"pr", "p", "matrix-emitting-results", false),
 			`
 spec:
@@ -15740,7 +15616,7 @@ status:
     value: https://api.example/get-report/mac-chrome
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-emitting-results-2", "foo",
+			th.TaskRunObjectMeta("pr-matrix-emitting-results-2", "foo",
 				"pr", "p", "matrix-emitting-results", false),
 			`
 spec:
@@ -15762,7 +15638,7 @@ status:
     value: https://api.example/get-report/linux-safari
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-matrix-emitting-results-3", "foo",
+			th.TaskRunObjectMeta("pr-matrix-emitting-results-3", "foo",
 				"pr", "p", "matrix-emitting-results", false),
 			`
 spec:
@@ -15825,7 +15701,7 @@ spec:
 `, "p-task-consuming-results")),
 		expectedTaskRuns: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-task-consuming-results", "foo",
+				th.TaskRunObjectMeta("pr-task-consuming-results", "foo",
 					"pr", "p", "task-consuming-results", false),
 				`
 spec:
@@ -15939,7 +15815,7 @@ spec:
 `, "p-matrix-consuming-results")),
 		expectedTaskRuns: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrix-consuming-results-0", "foo",
+				th.TaskRunObjectMeta("pr-matrix-consuming-results-0", "foo",
 					"pr", "p", "matrix-consuming-results", false),
 				`
 spec:
@@ -15952,7 +15828,7 @@ spec:
     kind: Task
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrix-consuming-results-1", "foo",
+				th.TaskRunObjectMeta("pr-matrix-consuming-results-1", "foo",
 					"pr", "p", "matrix-consuming-results", false),
 				`
 spec:
@@ -15965,7 +15841,7 @@ spec:
     kind: Task
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrix-consuming-results-2", "foo",
+				th.TaskRunObjectMeta("pr-matrix-consuming-results-2", "foo",
 					"pr", "p", "matrix-consuming-results", false),
 				`
 spec:
@@ -15978,7 +15854,7 @@ spec:
     kind: Task
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrix-consuming-results-3", "foo",
+				th.TaskRunObjectMeta("pr-matrix-consuming-results-3", "foo",
 					"pr", "p", "matrix-consuming-results", false),
 				`
 spec:
@@ -16159,7 +16035,7 @@ spec:
 
 	expectedCustomRuns := []*v1beta1.CustomRun{
 		parse.MustParseCustomRunWithObjectMeta(t,
-			taskRunObjectMeta("pr-task-consuming-results", "foo",
+			th.TaskRunObjectMeta("pr-task-consuming-results", "foo",
 				"pr", "p-task-consuming-results", "task-consuming-results", false),
 			`
 spec:
@@ -16219,7 +16095,7 @@ spec:
 `, "p-task-consuming-results")),
 		trs: []*v1.TaskRun{
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrix-emitting-results-0", "foo",
+				th.TaskRunObjectMeta("pr-matrix-emitting-results-0", "foo",
 					"pr", "p-task-consuming-results", "matrix-emitting-results", false),
 				`
 spec:
@@ -16241,7 +16117,7 @@ status:
     value: https://api.example/get-report/linux-chrome
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrix-emitting-results-1", "foo",
+				th.TaskRunObjectMeta("pr-matrix-emitting-results-1", "foo",
 					"pr", "p-task-consuming-results", "matrix-emitting-results", false),
 				`
 spec:
@@ -16263,7 +16139,7 @@ status:
     value: https://api.example/get-report/mac-chrome
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrix-emitting-results-2", "foo",
+				th.TaskRunObjectMeta("pr-matrix-emitting-results-2", "foo",
 					"pr", "p-task-consuming-results", "matrix-emitting-results", false),
 				`
 spec:
@@ -16285,7 +16161,7 @@ status:
     value: https://api.example/get-report/linux-safari
 `),
 			parse.MustParseTaskRunWithObjectMeta(t,
-				taskRunObjectMeta("pr-matrix-emitting-results-3", "foo",
+				th.TaskRunObjectMeta("pr-matrix-emitting-results-3", "foo",
 					"pr", "p-task-consuming-results", "matrix-emitting-results", false),
 				`
 spec:
@@ -16509,7 +16385,7 @@ spec:
 
 	actual := getTaskRunByName(t, taskRuns, trName)
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta(trName, namespace, prName,
+		th.TaskRunObjectMeta(trName, namespace, prName,
 			"test-pipeline", "unit-test-1", false),
 		`
 spec:
@@ -17812,7 +17688,7 @@ status:
 `)}
 	ts := []*v1.Task{simpleHelloWorldTask}
 
-	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, taskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout",
+	trs := []*v1.TaskRun{parse.MustParseTaskRunWithObjectMeta(t, th.TaskRunObjectMeta("test-pipeline-run-with-timeout-hello-world-1", "foo", "test-pipeline-run-with-timeout",
 		"test-pipeline", "hello-world-1", false), `
 spec:
   serviceAccountName: test-sa
@@ -17934,7 +17810,7 @@ status:
 
 	trs := []*v1.TaskRun{
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta(
+			th.TaskRunObjectMeta(
 				"7103-reproducer-run-7jp4w-task1",
 				"foo", "7103-reproducer-run-7jp4w",
 				"7103-reproducer", "task1", false), `
@@ -17954,7 +17830,7 @@ status:
   startTime: "2023-10-03T10:55:12Z"
 `),
 		parse.MustParseTaskRunWithObjectMeta(t,
-			taskRunObjectMeta(
+			th.TaskRunObjectMeta(
 				"7103-reproducer-run-7jp4w-task2",
 				"foo", "7103-reproducer-run-7jp4w",
 				"7103-reproducer", "task2", false), `
@@ -18029,7 +17905,7 @@ status:
 	// The TaskRun for task3 is not reconciled (no status), but it must created with
 	// resolved parameters
 	expectedTaskRun := parse.MustParseTaskRunWithObjectMeta(t,
-		taskRunObjectMeta(
+		th.TaskRunObjectMeta(
 			"7103-reproducer-run-7jp4w-task3",
 			"foo", "7103-reproducer-run-7jp4w",
 			"7103-reproducer", "task3", false), `
@@ -19283,7 +19159,7 @@ func TestReconcile_DeferFailureWhenTaskRunRecoveredInAPIServer(t *testing.T) {
 	trName := "test-pipeline-run-defer-failure-hello-world-1"
 
 	// TaskRun in informer cache is Failed due to pod eviction
-	trs := []*v1.TaskRun{createHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
+	trs := []*v1.TaskRun{th.CreateHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
 		prName, "test-pipeline", "", "hello-world-1",
 		apis.Condition{
 			Type:    apis.ConditionSucceeded,
@@ -19364,7 +19240,7 @@ func TestReconcile_ConfirmFailureWhenTaskRunFailedInAPIServer(t *testing.T) {
 	trName := "test-pipeline-run-confirm-failure-hello-world-1"
 
 	// TaskRun is Failed due to pod eviction in informer cache
-	trs := []*v1.TaskRun{createHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
+	trs := []*v1.TaskRun{th.CreateHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
 		prName, "test-pipeline", "", "hello-world-1",
 		apis.Condition{
 			Type:    apis.ConditionSucceeded,
@@ -19432,7 +19308,7 @@ func TestReconcile_APIServerErrorReturnsError(t *testing.T) {
 	trName := "test-pipeline-run-api-error-hello-world-1"
 
 	// TaskRun is Failed due to pod eviction in informer cache
-	trs := []*v1.TaskRun{createHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
+	trs := []*v1.TaskRun{th.CreateHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
 		prName, "test-pipeline", "", "hello-world-1",
 		apis.Condition{
 			Type:    apis.ConditionSucceeded,
@@ -19507,7 +19383,7 @@ func TestReconcile_TaskRunNotFoundFallsBackToCache(t *testing.T) {
 	trName := "test-pipeline-run-notfound-hello-world-1"
 
 	// TaskRun is Failed due to pod eviction in informer cache
-	trs := []*v1.TaskRun{createHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
+	trs := []*v1.TaskRun{th.CreateHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
 		prName, "test-pipeline", "", "hello-world-1",
 		apis.Condition{
 			Type:    apis.ConditionSucceeded,
@@ -19583,7 +19459,7 @@ func TestReconcile_CancelledTaskRunNoFalsePositive(t *testing.T) {
 	trName := "test-pipeline-run-cancelled-tr-hello-world-1"
 
 	// TaskRun is Failed with reason TaskRunCancelled in informer cache
-	trs := []*v1.TaskRun{createHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
+	trs := []*v1.TaskRun{th.CreateHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
 		prName, "test-pipeline", "", "hello-world-1",
 		apis.Condition{
 			Type:    apis.ConditionSucceeded,
@@ -19651,7 +19527,7 @@ func TestReconcile_TimedOutTaskRunNoFalsePositive(t *testing.T) {
 	trName := "test-pipeline-run-timedout-tr-hello-world-1"
 
 	// TaskRun is Failed with reason TaskRunTimeout in informer cache
-	trs := []*v1.TaskRun{createHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
+	trs := []*v1.TaskRun{th.CreateHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
 		prName, "test-pipeline", "", "hello-world-1",
 		apis.Condition{
 			Type:    apis.ConditionSucceeded,
@@ -19720,7 +19596,7 @@ func TestReconcile_GenericFailedTaskRunSkipsAPIVerification(t *testing.T) {
 	trName := "test-pipeline-run-generic-failed-hello-world-1"
 
 	// TaskRun is Failed with generic "Failed" reason in informer cache
-	trs := []*v1.TaskRun{createHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
+	trs := []*v1.TaskRun{th.CreateHelloWorldTaskRunWithStatusTaskLabel(t, trName, namespace,
 		prName, "test-pipeline", "", "hello-world-1",
 		apis.Condition{
 			Type:    apis.ConditionSucceeded,

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -3,12 +3,15 @@ package testing
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/parse"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -1035,4 +1038,143 @@ spec:
 	}
 
 	return parentPipeline, resolvedChild, parentPipelineRun, expectedChildPipelineRun
+}
+
+// BaseObjectMeta returns an ObjectMeta with the given name and namespace and
+// empty (non-nil) labels and annotations.
+func BaseObjectMeta(name, ns string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:        name,
+		Namespace:   ns,
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	}
+}
+
+// TaskRunObjectMeta returns the ObjectMeta for a TaskRun owned by a PipelineRun,
+// including the standard Tekton labels and owner reference.
+func TaskRunObjectMeta(trName, ns, prName, pipelineName, pipelineTaskName string, skipMemberOfLabel bool) metav1.ObjectMeta {
+	om := metav1.ObjectMeta{
+		Name:      trName,
+		Namespace: ns,
+		OwnerReferences: []metav1.OwnerReference{{
+			Kind:               "PipelineRun",
+			Name:               prName,
+			APIVersion:         "tekton.dev/v1",
+			Controller:         &trueb,
+			BlockOwnerDeletion: &trueb,
+			UID:                "",
+		}},
+		Labels: map[string]string{
+			pipeline.PipelineLabelKey:       pipelineName,
+			pipeline.PipelineRunLabelKey:    prName,
+			pipeline.PipelineTaskLabelKey:   pipelineTaskName,
+			pipeline.PipelineRunUIDLabelKey: "",
+		},
+		Annotations: map[string]string{},
+	}
+	if !skipMemberOfLabel {
+		om.Labels[pipeline.MemberOfLabelKey] = v1.PipelineTasks
+	}
+	return om
+}
+
+// TaskRunObjectMetaWithAnnotations is TaskRunObjectMeta with the given
+// annotations merged in.
+func TaskRunObjectMetaWithAnnotations(trName, ns, prName, pipelineName, pipelineTaskName string, skipMemberOfLabel bool, annotations map[string]string) metav1.ObjectMeta {
+	om := TaskRunObjectMeta(trName, ns, prName, pipelineName, pipelineTaskName, skipMemberOfLabel)
+	for k, v := range annotations {
+		om.Annotations[k] = v
+	}
+	return om
+}
+
+// CreateHelloWorldTaskRunWithStatus creates a hello-world TaskRun with the
+// given pod name and condition set on its status.
+func CreateHelloWorldTaskRunWithStatus(
+	t *testing.T,
+	trName, ns, prName, pName, podName string,
+	condition apis.Condition,
+) *v1.TaskRun {
+	t.Helper()
+	p := CreateHelloWorldTaskRun(t, trName, ns, prName, pName)
+	p.Status = v1.TaskRunStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{condition},
+		},
+		TaskRunStatusFields: v1.TaskRunStatusFields{
+			PodName: podName,
+		},
+	}
+	return p
+}
+
+// CreateHelloWorldTaskRunWithStatusTaskLabel is CreateHelloWorldTaskRunWithStatus
+// with the pipeline task label set to taskLabel.
+func CreateHelloWorldTaskRunWithStatusTaskLabel(
+	t *testing.T,
+	trName, ns, prName, pName, podName, taskLabel string,
+	condition apis.Condition,
+) *v1.TaskRun {
+	t.Helper()
+	p := CreateHelloWorldTaskRunWithStatus(t, trName, ns, prName, pName, podName, condition)
+	p.Labels[pipeline.PipelineTaskLabelKey] = taskLabel
+
+	return p
+}
+
+// CreateHelloWorldTaskRun creates a TaskRun referencing the hello-world Task,
+// labeled with the given Pipeline and PipelineRun names.
+func CreateHelloWorldTaskRun(t *testing.T, trName, ns, prName, pName string) *v1.TaskRun {
+	t.Helper()
+	return parse.MustParseV1TaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    %s: %s
+    %s: %s
+spec:
+  taskRef:
+    name: hello-world
+  serviceAccountName: test-sa
+`, trName, ns, pipeline.PipelineLabelKey, pName, pipeline.PipelineRunLabelKey, prName))
+}
+
+// CreateCancelledPipelineRun creates a PipelineRun in namespace foo with the
+// given spec status and the given start time set on its status.
+func CreateCancelledPipelineRun(t *testing.T, prName string, specStatus v1.PipelineRunSpecStatus, startTime time.Time) *v1.PipelineRun {
+	t.Helper()
+	return parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  serviceAccountName: test-sa
+  status: %s
+status:
+  startTime: %s`, prName, specStatus, startTime.Format(time.RFC3339)))
+}
+
+// HelloWorldPipelineWithRunAfter creates a two-task Pipeline where
+// hello-world-2 runs after hello-world-1.
+func HelloWorldPipelineWithRunAfter(t *testing.T) *v1.Pipeline {
+	t.Helper()
+	return parse.MustParseV1Pipeline(t, `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  tasks:
+    - name: hello-world-1
+      taskRef:
+        name: hello-world
+    - name: hello-world-2
+      taskRef:
+        name: hello-world
+      runAfter:
+        - hello-world-1
+`)
 }


### PR DESCRIPTION
# Changes

`pipelinerun_test.go` builds its expected TaskRuns and test PipelineRuns
with local helpers (`TaskRunObjectMeta`, `CreateHelloWorldTaskRun`, etc.).

This PR moves them to the shared `pkg/reconciler/testing/factory.go` so
other reconciler tests can use them too.

Test-only change. No change in behavior.

Part of #8906. Follows #10589 and #10606.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

Co-authored-by: Claude
