### PR TITLE
fix: validate non-optional child Pipeline workspaces in the parent PipelineRun

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1231,7 +1231,9 @@ func (c *Reconciler) createChildPipelineRun(
 
 // getChildPipelineRunWorkspaces resolves workspace bindings from the parent PipelineRun
 // for the given PipelineTask that references a child Pipeline. It reuses the same volume
-// source handling as TaskRun workspaces.
+// source handling as TaskRun workspaces, and fails with a permanent error if a
+// non-optional workspace declared by the child Pipeline has no matching binding on
+// the parent, mirroring the validation done for TaskRun workspaces in getTaskrunWorkspaces.
 func (c *Reconciler) getChildPipelineRunWorkspaces(ctx context.Context, pr *v1.PipelineRun, rpt *resources.ResolvedPipelineTask) ([]v1.WorkspaceBinding, error) {
 	if len(rpt.PipelineTask.Workspaces) == 0 {
 		return nil, nil
@@ -1254,10 +1256,19 @@ func (c *Reconciler) getChildPipelineRunWorkspaces(ctx context.Context, pr *v1.P
 		}
 		b, hasBinding := parentWorkspaces[parentName]
 		if !hasBinding {
-			// Tracking parent-side validation of non-optional child workspaces:
-			// https://github.com/tektoncd/pipeline/issues/9924 (TEP-0056).
-			// Today, missing non-optional child workspaces fail the child PipelineRun
-			// rather than the parent.
+			workspaceIsOptional := false
+			if rpt.ResolvedPipeline.PipelineSpec != nil {
+				for _, pipelineWorkspaceDeclaration := range rpt.ResolvedPipeline.PipelineSpec.Workspaces {
+					if pipelineWorkspaceDeclaration.Name == childPipelineWorkspaceName && pipelineWorkspaceDeclaration.Optional {
+						workspaceIsOptional = true
+						break
+					}
+				}
+			}
+			if !workspaceIsOptional {
+				err := fmt.Errorf("expected workspace %q to be provided by pipelinerun for pipeline task %q", parentName, rpt.PipelineTask.Name)
+				return nil, controller.NewPermanentError(err)
+			}
 			continue
 		}
 		if b.PersistentVolumeClaim != nil || b.VolumeClaimTemplate != nil {

--- a/pkg/reconciler/pipelinerun/pipelinerun_pinp_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_pinp_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ktesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/controller"
 )
 
 // TestReconcile_ChildPipelineRunPipelineSpec verifies the reconciliation logic for PipelineRuns that create child
@@ -779,10 +780,11 @@ func TestReconcile_ChildPipelineRunPipelineRefWhenSkipped(t *testing.T) {
 // direct table-driven style of the sibling TestGetTaskrunWorkspaces_Success.
 func TestGetChildPipelineRunWorkspaces_Success(t *testing.T) {
 	tests := []struct {
-		name             string
-		parentWorkspaces []v1.WorkspaceBinding
-		childWorkspaces  []v1.WorkspacePipelineTaskBinding
-		want             []v1.WorkspaceBinding
+		name               string
+		parentWorkspaces   []v1.WorkspaceBinding
+		childWorkspaces    []v1.WorkspacePipelineTaskBinding
+		pipelineWorkspaces []v1.PipelineWorkspaceDeclaration
+		want               []v1.WorkspaceBinding
 	}{{
 		name:            "no workspaces returns nil",
 		childWorkspaces: nil,
@@ -812,13 +814,14 @@ func TestGetChildPipelineRunWorkspaces_Success(t *testing.T) {
 		childWorkspaces:  []v1.WorkspacePipelineTaskBinding{{Name: "shared"}},
 		want:             []v1.WorkspaceBinding{{Name: "shared", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 	}, {
-		name:             "unbound workspace is skipped",
+		name:             "unbound optional workspace is skipped",
 		parentWorkspaces: []v1.WorkspaceBinding{{Name: "data", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		childWorkspaces: []v1.WorkspacePipelineTaskBinding{
 			{Name: "data", Workspace: "data"},
 			{Name: "missing", Workspace: "does-not-exist"},
 		},
-		want: []v1.WorkspaceBinding{{Name: "data", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		pipelineWorkspaces: []v1.PipelineWorkspaceDeclaration{{Name: "missing", Optional: true}},
+		want:               []v1.WorkspaceBinding{{Name: "data", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 	}, {
 		name:             "PVC-source workspace",
 		parentWorkspaces: []v1.WorkspaceBinding{{Name: "pvc-ws", PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}}},
@@ -855,18 +858,23 @@ func TestGetChildPipelineRunWorkspaces_Success(t *testing.T) {
 			{Name: "cache", PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}},
 		},
 	}, {
-		name:             "no child workspace name matches any parent workspace",
+		name:             "no child workspace name matches any parent workspace, but both are optional",
 		parentWorkspaces: []v1.WorkspaceBinding{{Name: "data", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		childWorkspaces: []v1.WorkspacePipelineTaskBinding{
 			{Name: "src"},
 			{Name: "artifacts"},
 		},
+		pipelineWorkspaces: []v1.PipelineWorkspaceDeclaration{
+			{Name: "src", Optional: true},
+			{Name: "artifacts", Optional: true},
+		},
 		want: nil,
 	}, {
-		name:             "parent PipelineRun has no workspaces",
-		parentWorkspaces: nil,
-		childWorkspaces:  []v1.WorkspacePipelineTaskBinding{{Name: "source", Workspace: "shared-vol"}},
-		want:             nil,
+		name:               "parent PipelineRun has no workspaces, child workspace is optional",
+		parentWorkspaces:   nil,
+		childWorkspaces:    []v1.WorkspacePipelineTaskBinding{{Name: "source", Workspace: "shared-vol"}},
+		pipelineWorkspaces: []v1.PipelineWorkspaceDeclaration{{Name: "source", Optional: true}},
+		want:               nil,
 	}}
 
 	c := Reconciler{}
@@ -877,7 +885,8 @@ func TestGetChildPipelineRunWorkspaces_Success(t *testing.T) {
 				Spec:       v1.PipelineRunSpec{Workspaces: tt.parentWorkspaces},
 			}
 			rpt := &resources.ResolvedPipelineTask{
-				PipelineTask: &v1.PipelineTask{Name: "child-task", Workspaces: tt.childWorkspaces},
+				PipelineTask:     &v1.PipelineTask{Name: "child-task", Workspaces: tt.childWorkspaces},
+				ResolvedPipeline: resources.ResolvedPipeline{PipelineSpec: &v1.PipelineSpec{Workspaces: tt.pipelineWorkspaces}},
 			}
 
 			got, err := c.getChildPipelineRunWorkspaces(t.Context(), pr, rpt)
@@ -886,6 +895,59 @@ func TestGetChildPipelineRunWorkspaces_Success(t *testing.T) {
 			}
 			if d := cmp.Diff(tt.want, got); d != "" {
 				t.Errorf("getChildPipelineRunWorkspaces() bindings diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+// TestGetChildPipelineRunWorkspaces_MissingNonOptionalWorkspace verifies that a
+// non-optional workspace declared by the child Pipeline with no matching binding
+// on the parent PipelineRun fails the parent up front with a permanent error,
+// mirroring the validation already done for TaskRun workspaces in
+// TestGetTaskrunWorkspaces_Failure.
+func TestGetChildPipelineRunWorkspaces_MissingNonOptionalWorkspace(t *testing.T) {
+	tests := []struct {
+		name             string
+		resolvedPipeline resources.ResolvedPipeline
+	}{{
+		name: "workspace declared as required",
+		resolvedPipeline: resources.ResolvedPipeline{
+			PipelineSpec: &v1.PipelineSpec{
+				Workspaces: []v1.PipelineWorkspaceDeclaration{{Name: "missing"}},
+			},
+		},
+	}, {
+		name:             "resolved child pipeline spec is unavailable",
+		resolvedPipeline: resources.ResolvedPipeline{},
+	}}
+
+	c := Reconciler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr := &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "parent-pr", Namespace: "foo"},
+				Spec: v1.PipelineRunSpec{
+					Workspaces: []v1.WorkspaceBinding{{Name: "data", EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				},
+			}
+			rpt := &resources.ResolvedPipelineTask{
+				PipelineTask: &v1.PipelineTask{
+					Name:       "child-task",
+					Workspaces: []v1.WorkspacePipelineTaskBinding{{Name: "missing", Workspace: "missing"}},
+				},
+				ResolvedPipeline: tt.resolvedPipeline,
+			}
+
+			_, err := c.getChildPipelineRunWorkspaces(t.Context(), pr, rpt)
+			if err == nil {
+				t.Fatalf("getChildPipelineRunWorkspaces() expected an error for a missing non-optional workspace, got nil")
+			}
+			expectedError := `expected workspace "missing" to be provided by pipelinerun for pipeline task "child-task"`
+			if err.Error() != expectedError {
+				t.Errorf("getChildPipelineRunWorkspaces() error = %q, want %q", err.Error(), expectedError)
+			}
+			if !controller.IsPermanentError(err) {
+				t.Errorf("getChildPipelineRunWorkspaces() did not return a permanent error for a missing non-optional workspace")
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

With `pipelineRef` support in `PipelineTask` (TEP-0056), a child `Pipeline` may
declare workspaces that the parent `PipelineRun` does not bind. Previously,
`getChildPipelineRunWorkspaces` silently skipped any child workspace with no
matching parent binding, regardless of whether that workspace was optional.
This let a child `PipelineRun` be created even though it declared a required
workspace with no source, so the failure only surfaced later on the child
`PipelineRun` instead of failing the parent `PipelineTask` up front.

This mirrors the validation `TaskRun` workspaces already get in
`getTaskrunWorkspaces`, which returns a permanent error for a missing
non-optional workspace instead of creating a `TaskRun` that can never
succeed.

`getChildPipelineRunWorkspaces` now checks the resolved child Pipeline's
`Workspaces` declarations when a workspace has no parent binding. If the
declaration marks the workspace `Optional`, the workspace is skipped as
before. Otherwise it returns the same
`expected workspace %q to be provided by pipelinerun for pipeline task %q`
permanent error used by the `TaskRun` path, failing the parent `PipelineRun`
immediately instead of creating a child `PipelineRun` that can never
succeed. This is a fail-fast change only: behavior for optional workspaces
and for workspaces with a matching parent binding is unchanged.

Validation:
- `go build ./...`
- `go test ./pkg/reconciler/pipelinerun/...` (all packages pass, ~35s),
  including the pre-existing pipeline-in-pipeline reconcile tests and the
  updated/added `getChildPipelineRunWorkspaces` unit tests
  (`TestGetChildPipelineRunWorkspaces_Success`,
  `TestGetChildPipelineRunWorkspaces_MissingNonOptionalWorkspace`,
  `TestGetChildPipelineRunWorkspaces_Failure`)
- `gofmt -l` on the changed files (no output)
- `golangci-lint run --new-from-merge-base=upstream/main --timeout=5m ./pkg/reconciler/pipelinerun/...`
  (v2.12.2, matching CI): 0 issues
- No API/type changes, so codegen verification is not applicable

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fail a parent `PipelineRun` immediately with a clear error when a `PipelineTask`'s `pipelineRef` child `Pipeline` declares a non-optional workspace with no matching parent binding, instead of creating a child `PipelineRun` that can never succeed.
```

Fixes #9924