### PR TITLE
Dedupe feature-flag ConfigMap setup in reconciler tests

### DIFF
--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -33,6 +33,7 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	aa "github.com/tektoncd/pipeline/pkg/internal/affinityassistant"
 	pipelinePod "github.com/tektoncd/pipeline/pkg/pod"
+	th "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	"github.com/tektoncd/pipeline/pkg/workspace"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -49,7 +50,6 @@ import (
 	testing2 "k8s.io/client-go/testing"
 	"knative.dev/pkg/kmeta"
 	logtesting "knative.dev/pkg/logging/testing"
-	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
 )
 
@@ -1611,12 +1611,9 @@ func TestCleanupAffinityAssistantsAndPVCs_Failure(t *testing.T) {
 
 // TestThatCleanupIsAvoidedtests that cleanup of Affinity Assistants is omitted
 func TestThatCleanupIsAvoided(t *testing.T) {
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-		Data: map[string]string{
-			"coschedule": "disabled",
-		},
-	}
+	configMap := th.NewFeatureFlagsConfigMapWithData(map[string]string{
+		"coschedule": "disabled",
+	})
 
 	fakeClientSet := fakek8s.NewSimpleClientset(
 		configMap,

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -5348,14 +5348,9 @@ status:
   - name: aResult
     value: aResultValue
 `)}
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"enable-cel-in-whenexpression": "true",
-			},
-		},
-	}
+	cms := th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+		"enable-cel-in-whenexpression": "true",
+	})
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
@@ -5512,14 +5507,9 @@ status:
   - status: "False"
     type: Succeeded
 `)}
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"enable-cel-in-whenexpression": "true",
-			},
-		},
-	}
+	cms := th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+		"enable-cel-in-whenexpression": "true",
+	})
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
@@ -5632,14 +5622,9 @@ spec:
 	ts := []*v1.Task{
 		{ObjectMeta: baseObjectMeta("a-task", "foo")},
 	}
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"enable-cel-in-whenexpression": "true",
-			},
-		},
-	}
+	cms := th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+		"enable-cel-in-whenexpression": "true",
+	})
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
@@ -5726,14 +5711,9 @@ spec:
   pipelineRef:
     name: test-pipeline-level-enum
 `)}
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"enable-param-enum": "true",
-			},
-		},
-	}
+	cms := th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+		"enable-param-enum": "true",
+	})
 	d := test.Data{
 		Tasks:        refTasks,
 		PipelineRuns: prs,
@@ -5784,14 +5764,9 @@ spec:
   pipelineRef:
     name: test-pipeline-level-enum
 `)}
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"enable-param-enum": "true",
-			},
-		},
-	}
+	cms := th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+		"enable-param-enum": "true",
+	})
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
@@ -5847,14 +5822,9 @@ spec:
     enum: ["v3", "v4"]
 `)}
 
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"enable-param-enum": "true",
-			},
-		},
-	}
+	cms := th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+		"enable-param-enum": "true",
+	})
 	d := test.Data{
 		Tasks:        refTasks,
 		PipelineRuns: prs,
@@ -9125,14 +9095,9 @@ metadata:
 		ServiceAccounts: []*corev1.ServiceAccount{{
 			ObjectMeta: metav1.ObjectMeta{Name: prs[0].Spec.TaskRunTemplate.ServiceAccountName, Namespace: namespace},
 		}},
-		ConfigMaps: []*corev1.ConfigMap{
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-				Data: map[string]string{
-					"enable-api-fields": "beta",
-				},
-			},
-		},
+		ConfigMaps: th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+			"enable-api-fields": "beta",
+		}),
 		ResolutionRequests: []*resolutionv1beta1.ResolutionRequest{&taskReq, &pipelineReq},
 	}
 
@@ -9225,14 +9190,9 @@ spec:
 		// Unlike the tests above, we do *not* locally define our pipeline or unit-test task.
 		d := test.Data{
 			PipelineRuns: prs,
-			ConfigMaps: []*corev1.ConfigMap{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-					Data: map[string]string{
-						"enable-api-fields": "beta",
-					},
-				},
-			},
+			ConfigMaps: th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+				"enable-api-fields": "beta",
+			}),
 			ResolutionRequests: []*resolutionv1beta1.ResolutionRequest{&pipelineReq},
 		}
 		testAssets, cancel := getPipelineRunController(t, d)
@@ -9348,14 +9308,9 @@ metadata:
 			ServiceAccounts: []*corev1.ServiceAccount{{
 				ObjectMeta: metav1.ObjectMeta{Name: prs[0].Spec.TaskRunTemplate.ServiceAccountName, Namespace: namespace},
 			}},
-			ConfigMaps: []*corev1.ConfigMap{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-					Data: map[string]string{
-						"enable-api-fields": "beta",
-					},
-				},
-			},
+			ConfigMaps: th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+				"enable-api-fields": "beta",
+			}),
 			ResolutionRequests: []*resolutionv1beta1.ResolutionRequest{&tc.taskReq, &tc.pipelineReq},
 		}
 
@@ -16927,14 +16882,9 @@ spec:
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cms := []*corev1.ConfigMap{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-					Data: map[string]string{
-						"trusted-resources-verification-no-match-policy": tc.noMatchPolicy,
-					},
-				},
-			}
+			cms := th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+				"trusted-resources-verification-no-match-policy": tc.noMatchPolicy,
+			})
 
 			pipelineReq := getResolvedResolutionRequest(t, resolverName, signedPipelineBytes, prs.Namespace, prs.Name)
 			taskReq := getResolvedResolutionRequest(t, resolverName, signedTaskBytes, prs.Namespace, prs.Name+"-"+ps.Spec.Tasks[0].Name)
@@ -17070,15 +17020,10 @@ spec:
 		t.Fatal("fail to marshal task", err)
 	}
 
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"trusted-resources-verification-no-match-policy": config.FailNoMatchPolicy,
-				"enable-tekton-oci-bundles":                      "true",
-			},
-		},
-	}
+	cms := th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+		"trusted-resources-verification-no-match-policy": config.FailNoMatchPolicy,
+		"enable-tekton-oci-bundles":                      "true",
+	})
 
 	pr := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
 metadata:
@@ -17264,15 +17209,10 @@ spec:
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cms := []*corev1.ConfigMap{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-					Data: map[string]string{
-						"trusted-resources-verification-no-match-policy": tc.noMatchPolicy,
-						"enable-api-fields": config.BetaAPIFields,
-					},
-				},
-			}
+			cms := th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+				"trusted-resources-verification-no-match-policy": tc.noMatchPolicy,
+				"enable-api-fields": config.BetaAPIFields,
+			})
 
 			pipelineReq := getResolvedResolutionRequest(t, resolverName, signedPipelineBytes, prs.Namespace, prs.Name)
 			taskReq := getResolvedResolutionRequest(t, resolverName, signedTaskBytes, prs.Namespace, prs.Name+"-"+ps.Spec.Tasks[0].Name)
@@ -17408,15 +17348,10 @@ spec:
 		t.Fatal("fail to marshal task", err)
 	}
 
-	cms := []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"trusted-resources-verification-no-match-policy": config.FailNoMatchPolicy,
-				"enable-api-fields": config.BetaAPIFields,
-			},
-		},
-	}
+	cms := th.NewFeatureFlagsConfigMapWithDataInSlice(map[string]string{
+		"trusted-resources-verification-no-match-policy": config.FailNoMatchPolicy,
+		"enable-api-fields": config.BetaAPIFields,
+	})
 
 	pr := parse.MustParseV1PipelineRun(t, fmt.Sprintf(`
 metadata:
@@ -18725,12 +18660,9 @@ spec:
 	trs := []*v1.TaskRun{}
 
 	// Create feature flags config with exponential backoff enabled
-	featureFlagsConfig := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: system.Namespace(), Name: config.GetFeatureFlagsConfigName()},
-		Data: map[string]string{
-			"enable-wait-exponential-backoff": "true",
-		},
-	}
+	featureFlagsConfig := th.NewFeatureFlagsConfigMapWithData(map[string]string{
+		"enable-wait-exponential-backoff": "true",
+	})
 
 	// Create wait exponential backoff config
 	waitExponentialBackoffConfig := &corev1.ConfigMap{
@@ -18888,12 +18820,9 @@ spec:
 	crs := []*v1beta1.CustomRun{}
 
 	// Create feature flags config with exponential backoff enabled
-	featureFlagsConfig := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: system.Namespace(), Name: config.GetFeatureFlagsConfigName()},
-		Data: map[string]string{
-			"enable-wait-exponential-backoff": "true",
-		},
-	}
+	featureFlagsConfig := th.NewFeatureFlagsConfigMapWithData(map[string]string{
+		"enable-wait-exponential-backoff": "true",
+	})
 
 	// Create wait exponential backoff config
 	waitExponentialBackoffConfig := &corev1.ConfigMap{

--- a/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest_test.go
@@ -176,7 +176,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := test.Data{
 				ResolutionRequests: []*v1beta1.ResolutionRequest{tc.input},
-				ConfigMaps:         th.NewDefaultsCofigMapInSlice(),
+				ConfigMaps:         th.NewDefaultsConfigMapInSlice(),
 			}
 
 			testAssets, cancel := getResolutionRequestController(t, d)
@@ -209,7 +209,7 @@ func TestReconcileWrapsLifecycleStatusError(t *testing.T) {
 	}
 	d := test.Data{
 		ResolutionRequests: []*v1beta1.ResolutionRequest{input},
-		ConfigMaps:         th.NewDefaultsCofigMapInSlice(),
+		ConfigMaps:         th.NewDefaultsConfigMapInSlice(),
 	}
 	testAssets, cancel := getResolutionRequestController(t, d)
 	defer cancel()
@@ -276,7 +276,7 @@ func TestReconcilePreservesResolverStatusOnConflict(t *testing.T) {
 			}
 			d := test.Data{
 				ResolutionRequests: []*v1beta1.ResolutionRequest{input},
-				ConfigMaps:         th.NewDefaultsCofigMapInSlice(),
+				ConfigMaps:         th.NewDefaultsConfigMapInSlice(),
 			}
 			testAssets, cancel := getResolutionRequestController(t, d)
 			defer cancel()

--- a/pkg/reconciler/testing/configmap.go
+++ b/pkg/reconciler/testing/configmap.go
@@ -69,6 +69,22 @@ func newFeatureFlagsConfigMap() *corev1.ConfigMap {
 	}
 }
 
+// NewFeatureFlagsConfigMapWithData creates a feature-flags ConfigMap with the
+// given data entries set.
+func NewFeatureFlagsConfigMapWithData(data map[string]string) *corev1.ConfigMap {
+	cm := newFeatureFlagsConfigMap()
+	for k, v := range data {
+		cm.Data[k] = v
+	}
+	return cm
+}
+
+// NewFeatureFlagsConfigMapWithDataInSlice creates a slice containing a single
+// feature-flags ConfigMap with the given data entries set.
+func NewFeatureFlagsConfigMapWithDataInSlice(data map[string]string) []*corev1.ConfigMap {
+	return []*corev1.ConfigMap{NewFeatureFlagsConfigMapWithData(data)}
+}
+
 func NewAlphaFeatureFlagsConfigMapInSlice() []*corev1.ConfigMap {
 	return []*corev1.ConfigMap{withEnabledAlphaAPIFields(newFeatureFlagsConfigMap())}
 }
@@ -109,6 +125,6 @@ func NewAlphaFeatureFlagsConfigMapWithMatrixInSlice(count int) []*corev1.ConfigM
 	)
 }
 
-func NewDefaultsCofigMapInSlice() []*corev1.ConfigMap {
+func NewDefaultsConfigMapInSlice() []*corev1.ConfigMap {
 	return []*corev1.ConfigMap{newDefaultsConfigMap()}
 }


### PR DESCRIPTION
# Changes

Many reconciler tests built the feature-flags ConfigMap by hand. This PR
removes that copy-paste and uses the shared helpers in
`pkg/reconciler/testing/configmap.go` instead:

- extended the helpers to support typed values and per-test overrides
- updated `pipelinerun_test.go`, `affinity_assistant_test.go` and
  `resolutionrequest_test.go` to use them
- deleted the inline ConfigMap literals (net −58 lines)

Test-only change. No change in behavior.

Part of #8906. Follows #10589, #10606 and #10607.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

Co-authored-by: Claude
