### PR TITLE
docs: clarify config-tracing and config-observability are separate tracing paths

### DIFF
--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -52,6 +52,13 @@ data:
     metrics-export-interval: ""
 
     # OpenTelemetry Tracing Configuration
+    #
+    # NOTE: these keys configure the global OpenTelemetry tracer provider used by the
+    # notification and cloud event reconcilers only. The TaskRun and PipelineRun
+    # reconcilers instead use their own tracer, configured separately via config-tracing
+    # (see docs/developers/tracing.md). Setting these keys does not affect TaskRun/PipelineRun
+    # tracing, and vice versa.
+    #
     # Protocol for tracing export (grpc, http/protobuf, none, stdout)
     # Default: none
     tracing-protocol: none

--- a/config/config-tracing.yaml
+++ b/config/config-tracing.yaml
@@ -15,6 +15,11 @@
 # NOTE: Exported traces may include Kubernetes resource identifiers (e.g. TaskRun/PipelineRun
 # names and namespaces) as span attributes. Treat the trace backend as a trusted observability
 # system. See docs/developers/tracing.md for details.
+#
+# NOTE: This only configures tracing for the TaskRun and PipelineRun reconcilers. It is
+# independent of the tracing-protocol/tracing-endpoint/tracing-sampling-rate keys in
+# config-observability, which configure a separate tracer used by the notification and
+# cloud event reconcilers. Enabling one does not enable the other.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/docs/developers/tracing.md
+++ b/docs/developers/tracing.md
@@ -32,6 +32,12 @@ The configmap `config/config-tracing.yaml` contains the configuration for tracin
 * endpoint: API endpoint for jaeger collector to send the traces. By default the endpoint is configured to be `http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces`.
 * credentialsSecret: Name of the secret which contains `username` and `password` to authenticate against the endpoint
 
+This configmap only controls the `TaskRun` and `PipelineRun` reconcilers, which build their own
+tracer from these values (see `pkg/tracing`). It is a separate configuration path from the
+`tracing-protocol`/`tracing-endpoint`/`tracing-sampling-rate` keys in `config-observability`,
+which configure the global OpenTelemetry tracer provider used by the notification and cloud
+event reconcilers instead. Enabling one does not enable the other.
+
 ## Security considerations for multi-tenant environments
 
 Exported spans from the TaskRun and PipelineRun reconciliation paths include


### PR DESCRIPTION
Fixes #10276 (documentation portion, option 1 from the issue discussion).

`config-tracing` only drives the TaskRun and PipelineRun reconcilers' own tracer (`pkg/tracing`). `config-observability`'s `tracing-protocol`, `tracing-endpoint` and `tracing-sampling-rate` keys instead configure the global OpenTelemetry provider used by the notification and cloud event reconcilers via `otel.GetTracerProvider()`. Neither reads the other's configuration, and that split wasn't documented anywhere, which is what led to the confusion in the issue.

No behavior change, comments and docs only:
- `config/config-tracing.yaml`: note that it only covers TaskRun/PipelineRun tracing
- `config/config-observability.yaml`: note that its tracing keys only cover notification/cloud event tracing
- `docs/developers/tracing.md`: same clarification in prose

Traced through the actual call sites to confirm before writing this up:
- `pkg/reconciler/pipelinerun/controller.go` and `pkg/reconciler/taskrun/controller.go` both build their tracer via `pkg/tracing`, which reads `config-tracing`
- `pkg/reconciler/notifications/*` and `pkg/reconciler/events/cloudevent` call `otel.GetTracerProvider()` directly, which only gets configured by `config-observability`'s keys through the vendored `knative.dev/pkg/observability/tracing`

Left as a follow-up per @vdemeester's comment on the issue: whether to actually unify the two tracing paths is a bigger design question (the `credentialsSecret` auth option in `config-tracing` has no equivalent in the global provider yet), tracked separately from this docs fix.

# Release Notes

```release-note
NONE
```
