### PR TITLE
fix: exclude generated and non-library code from codecov coverage

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -50,7 +50,11 @@ jobs:
       - name: Generate coverage
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/pipeline
         run: |
-          go test -coverprofile=coverage.out -covermode=atomic ./... || true
+          PACKAGES=$(go list ./... | grep -vE '/cmd(/|$)|/vendor(/|$)|/hack(/|$)|/test(/|$)|/fake(/|$)|/pkg/client(/|$)|/examples(/|$)|/tekton(/|$)')
+          COVERPKG=$(echo $PACKAGES | tr ' ' ',')
+          go test -coverprofile=coverage_raw.out -covermode=atomic -coverpkg="$COVERPKG" $PACKAGES || true
+          grep -vE 'zz_generated\.deepcopy\.go|openapi_generated\.go' coverage_raw.out > coverage.out
+          rm -f coverage_raw.out
           echo "Generated coverage profile"
 
       - name: Archive coverage results
@@ -101,3 +105,4 @@ jobs:
           flags: unit-tests
           use_oidc: true
           fail_ci_if_error: false
+          disable_search: true

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           PACKAGES=$(go list ./... | grep -vE '/cmd(/|$)|/vendor(/|$)|/hack(/|$)|/test(/|$)|/fake(/|$)|/pkg/client(/|$)|/examples(/|$)|/tekton(/|$)')
           COVERPKG=$(echo $PACKAGES | tr ' ' ',')
-          go test -coverprofile=coverage_raw.out -covermode=atomic -coverpkg="$COVERPKG" $PACKAGES || true
+          go test -coverprofile=coverage_raw.out -covermode=atomic -coverpkg="$COVERPKG" $PACKAGES
           grep -vE 'zz_generated\.deepcopy\.go|openapi_generated\.go' coverage_raw.out > coverage.out
           rm -f coverage_raw.out
           echo "Generated coverage profile"
@@ -73,7 +73,6 @@ jobs:
 
   codecov-upload:
     name: Upload coverage to Codecov
-    if: github.event_name != 'pull_request'
     needs: go-coverage
     runs-on: ubuntu-24.04
     permissions:

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,10 +8,18 @@ coverage:
       default: false
 
 ignore:
-- "pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go"
-- "pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go"
-- "**/fake/**"
-- "hack/**"
-- "test/**"
-- "pkg/client/**"
-- "vendor/**"
+  # Entry-point binaries — not unit-testable.
+  - "cmd"
+  # Auto-generated client code.
+  - "pkg/client/"
+  # Auto-generated deepcopy/openapi code.
+  - "**/zz_generated.deepcopy.go"
+  - "**/openapi_generated.go"
+  - "**/fake/**"
+  - "examples"
+  - "hack"
+  - "test"
+  - "config"
+  - "tekton"
+  - "docs"
+  - "vendor"


### PR DESCRIPTION
Codecov reports ~51% because it includes auto-generated client code, CLI entry points, and test infrastructure in the denominator. Filter these out so coverage reflects actual library code. Mirrors the approach proven in tektoncd/triggers#2101.

- Replace bare `go test ./...` with filtered package list + `-coverpkg`
- Strip zz_generated.deepcopy.go and openapi_generated.go from profile
- Add `disable_search: true` to codecov upload step
- Expand codecov.yml ignore patterns: cmd, pkg/client/, generic globs for generated files, and bare directory names for examples, hack, test, config, tekton, docs, vendor

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
