### PR TITLE
feat(tracing): add TLS CA cert configuration for OTLP exporter

### DIFF
--- a/config/config-tracing.yaml
+++ b/config/config-tracing.yaml
@@ -47,3 +47,14 @@ data:
     endpoint: "http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces"
     # (optional) Name of the k8s secret which contains basic auth credentials
     credentialsSecret: "jaeger-creds"
+    #
+    # (optional) CA certificate for verifying the tracing endpoint over HTTPS.
+    # Can be a path to a mounted PEM bundle or inline PEM.
+    # When cacert is a file path, the file is read at tracing provider startup or
+    # when this ConfigMap changes. Rotated CA bundles at the same path are not
+    # picked up until config-tracing is updated or the controller is restarted.
+    # cacert: "/var/run/secrets/.../service-ca.crt"
+    # cacert: |
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----

--- a/docs/developers/tracing.md
+++ b/docs/developers/tracing.md
@@ -31,6 +31,9 @@ The configmap `config/config-tracing.yaml` contains the configuration for tracin
 * enabled: Set this to true to enable tracing
 * endpoint: API endpoint for jaeger collector to send the traces. By default the endpoint is configured to be `http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces`.
 * credentialsSecret: Name of the secret which contains `username` and `password` to authenticate against the endpoint
+* cacert: (optional) CA certificate for verifying the tracing endpoint over HTTPS. Can be a path to a mounted PEM bundle or inline PEM. Required when the collector uses a certificate signed by a custom CA (for example, OpenShift service-ca or cert-manager).
+
+When `cacert` is a file path, the file is read when the tracing provider is initialized (on controller startup or when `config-tracing` changes). If the CA bundle is rotated in place at the same path without a ConfigMap update, the controller continues using the previous certificate until `config-tracing` is updated or the controller is restarted.
 
 ## Security considerations for multi-tenant environments
 

--- a/pkg/apis/config/testdata/config-tracing-cacert.yaml
+++ b/pkg/apis/config/testdata/config-tracing-cacert.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-tracing
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  enabled: "true"
+  endpoint: "https://collector.example.svc:4318/v1/traces"
+  cacert: "/etc/ssl/certs/service-ca.crt"

--- a/pkg/apis/config/tracing.go
+++ b/pkg/apis/config/tracing.go
@@ -35,6 +35,9 @@ const (
 
 	// DefaultEndpoint is the default destination for sending traces
 	DefaultEndpoint = "http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces"
+
+	// tracingCACertKey is the configmap key for tracing CA certificate
+	tracingCACertKey = "cacert"
 )
 
 // DefaultTracing holds all the default configurations for tracing
@@ -46,6 +49,7 @@ type Tracing struct {
 	Enabled           bool
 	Endpoint          string
 	CredentialsSecret string
+	CACert            string
 }
 
 // Equals returns true if two Configs are identical
@@ -60,7 +64,8 @@ func (cfg *Tracing) Equals(other *Tracing) bool {
 
 	return other.Enabled == cfg.Enabled &&
 		other.Endpoint == cfg.Endpoint &&
-		other.CredentialsSecret == cfg.CredentialsSecret
+		other.CredentialsSecret == cfg.CredentialsSecret &&
+		other.CACert == cfg.CACert
 }
 
 // GetTracingConfigName returns the name of the configmap containing all
@@ -85,6 +90,10 @@ func newTracingFromMap(config map[string]string) (*Tracing, error) {
 
 	if secret, ok := config[tracingCredentialsSecretKey]; ok {
 		t.CredentialsSecret = secret
+	}
+
+	if ca, ok := config[tracingCACertKey]; ok {
+		t.CACert = ca
 	}
 
 	if enabled, ok := config[tracingEnabledKey]; ok {

--- a/pkg/apis/config/tracing_test.go
+++ b/pkg/apis/config/tracing_test.go
@@ -47,6 +47,15 @@ func TestNewTracingFromConfigMap(t *testing.T) {
 			},
 			fileName: "config-tracing-enabled",
 		},
+		{
+			name: "enabled with cacert",
+			want: &config.Tracing{
+				Enabled:  true,
+				Endpoint: "https://collector.example.svc:4318/v1/traces",
+				CACert:   "/etc/ssl/certs/service-ca.crt",
+			},
+			fileName: "config-tracing-cacert",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cm := test.ConfigMapFromTestFile(t, tc.fileName)
@@ -128,11 +137,39 @@ func TestTracingEquals(t *testing.T) {
 				Enabled:           true,
 				Endpoint:          "a",
 				CredentialsSecret: "b",
+				CACert:            "c",
 			},
 			right: &config.Tracing{
 				Enabled:           true,
 				Endpoint:          "a",
 				CredentialsSecret: "b",
+				CACert:            "c",
+			},
+			expected: true,
+		},
+		{
+			name: "different CACert",
+			left: &config.Tracing{
+				CACert: "a",
+			},
+			right: &config.Tracing{
+				CACert: "b",
+			},
+			expected: false,
+		},
+		{
+			name: "same all fields including CACert",
+			left: &config.Tracing{
+				Enabled:           true,
+				Endpoint:          "a",
+				CredentialsSecret: "b",
+				CACert:            "c",
+			},
+			right: &config.Tracing{
+				Enabled:           true,
+				Endpoint:          "a",
+				CredentialsSecret: "b",
+				CACert:            "c",
 			},
 			expected: true,
 		},

--- a/pkg/tracing/cacert.go
+++ b/pkg/tracing/cacert.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"crypto/x509"
+	"strings"
+
+	"k8s.io/client-go/util/cert"
+)
+
+func certPoolFromCACert(cacert string) (*x509.CertPool, error) {
+	cacert = strings.TrimSpace(cacert)
+	if strings.Contains(cacert, "-----BEGIN") {
+		return cert.NewPoolFromBytes([]byte(cacert))
+	}
+	return cert.NewPool(cacert)
+}

--- a/pkg/tracing/cacert_test.go
+++ b/pkg/tracing/cacert_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"k8s.io/client-go/util/cert"
+)
+
+func TestCertPoolFromCACertInlinePEM(t *testing.T) {
+	pemBytes, _, err := cert.GenerateSelfSignedCertKey("test", nil, nil)
+	if err != nil {
+		t.Fatalf("failed to generate test cert: %v", err)
+	}
+
+	pool, err := certPoolFromCACert(string(pemBytes))
+	if err != nil {
+		t.Fatalf("certPoolFromCACert() error = %v", err)
+	}
+	if pool == nil {
+		t.Fatal("expected non-nil cert pool")
+	}
+}
+
+func TestCertPoolFromCACertFilePath(t *testing.T) {
+	pemBytes, _, err := cert.GenerateSelfSignedCertKey("test", nil, nil)
+	if err != nil {
+		t.Fatalf("failed to generate test cert: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ca.crt")
+	if err := os.WriteFile(path, pemBytes, 0o644); err != nil {
+		t.Fatalf("failed to write cert file: %v", err)
+	}
+
+	pool, err := certPoolFromCACert(path)
+	if err != nil {
+		t.Fatalf("certPoolFromCACert() error = %v", err)
+	}
+	if pool == nil {
+		t.Fatal("expected non-nil cert pool")
+	}
+}
+
+func TestCertPoolFromCACertInvalid(t *testing.T) {
+	_, err := certPoolFromCACert("not-a-valid-cert")
+	if err == nil {
+		t.Fatal("expected error for invalid cert, got nil")
+	}
+}
+
+func TestCreateTracerProviderTLSExport(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/traces" {
+			t.Errorf("expected path /v1/traces, got %s", r.URL.Path)
+		}
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	endpoint := server.URL + "/v1/traces"
+
+	t.Run("succeeds with CA", func(t *testing.T) {
+		requests.Store(0)
+
+		tp, err := createTracerProvider("test-service", &config.Tracing{
+			Enabled:  true,
+			Endpoint: endpoint,
+			CACert:   string(certPEM),
+		}, "", "")
+		if err != nil {
+			t.Fatalf("createTracerProvider() error = %v", err)
+		}
+		t.Cleanup(func() {
+			if err := tp.(*tracesdk.TracerProvider).Shutdown(context.Background()); err != nil {
+				t.Errorf("Shutdown() error = %v", err)
+			}
+		})
+
+		ctx := context.Background()
+		_, span := tp.Tracer("test").Start(ctx, "test-span")
+		span.End()
+
+		if err := tp.(*tracesdk.TracerProvider).ForceFlush(ctx); err != nil {
+			t.Fatalf("ForceFlush() error = %v", err)
+		}
+		if got := requests.Load(); got != 1 {
+			t.Fatalf("expected 1 export request, got %d", got)
+		}
+	})
+
+	t.Run("fails without CA", func(t *testing.T) {
+		requests.Store(0)
+
+		tp, err := createTracerProvider("test-service", &config.Tracing{
+			Enabled:  true,
+			Endpoint: endpoint,
+		}, "", "")
+		if err != nil {
+			t.Fatalf("createTracerProvider() error = %v", err)
+		}
+		t.Cleanup(func() {
+			if err := tp.(*tracesdk.TracerProvider).Shutdown(context.Background()); err != nil {
+				t.Errorf("Shutdown() error = %v", err)
+			}
+		})
+
+		ctx := context.Background()
+		_, span := tp.Tracer("test").Start(ctx, "test-span")
+		span.End()
+
+		_ = tp.(*tracesdk.TracerProvider).ForceFlush(ctx)
+		if got := requests.Load(); got != 0 {
+			t.Fatalf("expected export to fail without CA cert, got %d requests", got)
+		}
+	})
+}
+
+func TestCreateTracerProviderWithInvalidCACert(t *testing.T) {
+	cfg := &config.Tracing{
+		Enabled:  true,
+		Endpoint: "https://collector.example.svc:4318/v1/traces",
+		CACert:   "not-a-valid-cert",
+	}
+
+	_, err := createTracerProvider("test-service", cfg, "", "")
+	if err == nil {
+		t.Fatal("expected error for invalid CA cert, got nil")
+	}
+}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -18,6 +18,7 @@ package tracing
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -161,6 +162,16 @@ func createTracerProvider(service string, cfg *config.Tracing, user, pass string
 	opts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpoint(u.Host),
 		otlptracehttp.WithURLPath(u.Path),
+	}
+
+	if u.Scheme == "https" && cfg.CACert != "" {
+		pool, err := certPoolFromCACert(cfg.CACert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load tracing CA cert: %w", err)
+		}
+		opts = append(opts, otlptracehttp.WithTLSClientConfig(&tls.Config{
+			RootCAs: pool,
+		}))
 	}
 
 	if u.Scheme == "http" {


### PR DESCRIPTION
Fixes #9799

Part of the tracing improvements tracked in #9701.

# Context

In-cluster OTLP collectors often use HTTPS with certificates signed by a custom CA (for example, OpenShift service-ca or cert-manager). The tracing exporter currently only trusts the system CA bundle, so TLS verification fails when connecting to those collectors over HTTPS.

This PR adds an optional `cacert` field to the `config-tracing` ConfigMap. Operators can set it to a mounted PEM file path or inline PEM. When tracing is enabled with an `https` endpoint, the OTLP HTTP exporter uses that CA via `otlptracehttp.WithTLSClientConfig`.

Downstream, the OpenShift operator is expected to mount the service-ca bundle and set `cacert` in `config-tracing`.

# Changes

Add an optional `cacert` field to `config-tracing` so the OTLP HTTP exporter can verify HTTPS collectors signed by custom CAs (e.g. OpenShift service-ca).

The value may be a path to a mounted PEM bundle or inline PEM. When set for an `https` endpoint, the exporter uses the configured CA as `RootCAs` for TLS.

- Parse `cacert` in `pkg/apis/config/tracing.go`
- Load inline PEM or file path and configure TLS in `pkg/tracing/`
- Document the new field in `config/config-tracing.yaml` and `docs/developers/tracing.md`
- Add config and tracing unit tests

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release *(not applicable — no action required)*

# Release Notes

```release-note
Added an optional `cacert` field to the `config-tracing` ConfigMap. When tracing is enabled with an `https` endpoint, operators can set `cacert` to a PEM file path or inline PEM so the OTLP exporter trusts custom CA certificates.
```