### PR TITLE
Fix critical libcurl CVEs in resolvers base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -5,4 +5,4 @@ baseImageOverrides:
   github.com/tektoncd/pipeline/cmd/entrypoint: ghcr.io/tektoncd/pipeline/github.com/tektoncd/pipeline/combined-base-image:latest
   github.com/tektoncd/pipeline/cmd/nop: ghcr.io/tektoncd/pipeline/github.com/tektoncd/pipeline/combined-base-image:latest
   github.com/tektoncd/pipeline/cmd/workingdirinit: ghcr.io/tektoncd/pipeline/github.com/tektoncd/pipeline/combined-base-image:latest
-  github.com/tektoncd/pipeline/cmd/resolvers: ghcr.io/tektoncd/plumbing/tini-git@sha256:0d94afa14df4cbef3ecf007ab83f4bdc55bf7762c5f132dfa106225dd63a32eb
+  github.com/tektoncd/pipeline/cmd/resolvers: ghcr.io/tektoncd/plumbing/tini-git@sha256:6faeb2d1f5f43133e90a55ecb34ea1e93a82a1fbe8a2ee3592f275f550ebe3f9

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -5,4 +5,4 @@ baseImageOverrides:
   github.com/tektoncd/pipeline/cmd/entrypoint: ghcr.io/tektoncd/pipeline/github.com/tektoncd/pipeline/combined-base-image:latest
   github.com/tektoncd/pipeline/cmd/nop: ghcr.io/tektoncd/pipeline/github.com/tektoncd/pipeline/combined-base-image:latest
   github.com/tektoncd/pipeline/cmd/workingdirinit: ghcr.io/tektoncd/pipeline/github.com/tektoncd/pipeline/combined-base-image:latest
-  github.com/tektoncd/pipeline/cmd/resolvers: ghcr.io/tektoncd/plumbing/tini-git@sha256:2c18f0b3ed4394e27068b5c70bb55419797e8fc743d8ea9e0c2766001b36b5b4
+  github.com/tektoncd/pipeline/cmd/resolvers: ghcr.io/tektoncd/plumbing/tini-git@sha256:0d94afa14df4cbef3ecf007ab83f4bdc55bf7762c5f132dfa106225dd63a32eb


### PR DESCRIPTION
## Summary

The `resolvers` container image uses `ghcr.io/tektoncd/plumbing/tini-git` as its base image (via `.ko.yaml`). That image was built on `alpine:3.22` which ships `libcurl 8.14.1-r3`. Several libcurl security advisories apply to this version:

- CVE-2026-8927 — proxy auth credentials not cleared across sequential transfers
- CVE-2026-8926 — `.netrc` credentials exposed when URL contains a bare username
- CVE-2026-11856 — Digest auth credentials reused across origins
- CVE-2026-9079 — proxy credentials not cleared

Severity ratings are as published by the curl project (Low–Medium).

Note: CVE-2026-8925 (GSASL double-free) was introduced in curl 8.15.0 and does **not** affect `libcurl 8.14.1`.

## Change

Updates `.ko.yaml` to reference the new `tini-git` digest (`sha-0da9276`) built from tektoncd/plumbing#3610, which upgrades the base from `alpine:3.22` to `alpine:3.24`. Alpine 3.24 ships `libcurl 8.21.0-r0` and resolves all applicable advisories.

## Related

- tektoncd/plumbing#3610 (merged) — upgraded `tini-git` base to Alpine 3.24

```release-note
Fix libcurl CVEs (CVE-2026-8927, CVE-2026-8926, CVE-2026-11856, CVE-2026-9079) in the resolvers base image by updating the tini-git digest to Alpine 3.24.
```