### PR TITLE
fix: submit all remote references before requeue

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -404,6 +404,7 @@ func (c *Reconciler) resolvePipelineState(
 	}
 
 	// Resolve each pipeline task individually because they each could have a different reference context (remote or local).
+	requestInProgress := false
 	for _, pipelineTask := range pipelineTasks {
 		// We need the TaskRun name to ensure that we don't perform an additional remote resolution request for a PipelineTask
 		// in the TaskRun reconciler.
@@ -500,7 +501,8 @@ func (c *Reconciler) resolvePipelineState(
 				return nil, err
 			}
 			if errors.Is(err, remote.ErrRequestInProgress) {
-				return nil, err
+				requestInProgress = true
+				continue
 			}
 			var nfErr *resources.TaskNotFoundError
 			var pnfErr *resources.PipelineNotFoundError
@@ -539,6 +541,9 @@ func (c *Reconciler) resolvePipelineState(
 		pst = append(pst, resolvedTask)
 	}
 
+	if requestInProgress {
+		return pst, remote.ErrRequestInProgress
+	}
 	return pst, nil
 }
 
@@ -749,26 +754,24 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1.PipelineRun, getPipel
 
 	// First iteration
 	pipelineRunState, err := c.resolvePipelineState(ctx, ranOrRunningTasks, pipelineMeta.ObjectMeta, pr, resources.PipelineRunState{})
-	switch {
-	case errors.Is(err, remote.ErrRequestInProgress):
-		message := fmt.Sprintf("PipelineRun %s/%s awaiting remote resource", pr.Namespace, pr.Name)
-		pr.Status.MarkRunning(v1.TaskRunReasonResolvingTaskRef, message)
-		return controller.NewRequeueAfter(remoteResolutionRequeueAfter)
-	case err != nil:
+	requestInProgress := errors.Is(err, remote.ErrRequestInProgress)
+	if err != nil && !requestInProgress {
 		return err
-	default:
 	}
 
 	// Second iteration
 	pipelineRunState, err = c.resolvePipelineState(ctx, notStartedTasks, pipelineMeta.ObjectMeta, pr, pipelineRunState)
 	switch {
 	case errors.Is(err, remote.ErrRequestInProgress):
+		requestInProgress = true
+	case err != nil:
+		return err
+	}
+
+	if requestInProgress {
 		message := fmt.Sprintf("PipelineRun %s/%s awaiting remote resource", pr.Namespace, pr.Name)
 		pr.Status.MarkRunning(v1.TaskRunReasonResolvingTaskRef, message)
 		return controller.NewRequeueAfter(remoteResolutionRequeueAfter)
-	case err != nil:
-		return err
-	default:
 	}
 
 	// Build PipelineRunFacts with a list of resolved pipeline tasks,

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -9996,6 +9996,81 @@ metadata:
 	}
 }
 
+func TestReconcileSubmitsAllTaskResolutionRequests(t *testing.T) {
+	pr := parse.MustParseV1PipelineRun(t, `
+metadata:
+  name: pr
+  namespace: default
+spec:
+  pipelineSpec:
+    tasks:
+    - name: remote-a
+      taskRef:
+        resolver: foobar
+        params:
+        - name: name
+          value: task-a
+    - name: remote-b
+      taskRef:
+        resolver: foobar
+        params:
+        - name: name
+          value: task-b
+    - name: remote-c
+      taskRef:
+        resolver: foobar
+        params:
+        - name: name
+          value: task-c
+  taskRunTemplate:
+    serviceAccountName: default
+`)
+	// Put one task in the ran-or-running partition to ensure a pending request
+	// there does not prevent requests for not-started tasks.
+	pr.Status.ChildReferences = []v1.ChildStatusReference{{
+		TypeMeta: runtime.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       pipeline.TaskRunControllerName,
+		},
+		Name:             "pr-remote-a",
+		PipelineTaskName: "remote-a",
+	}}
+
+	d := test.Data{
+		PipelineRuns: []*v1.PipelineRun{pr},
+		ServiceAccounts: []*corev1.ServiceAccount{{
+			ObjectMeta: metav1.ObjectMeta{Name: pr.Spec.TaskRunTemplate.ServiceAccountName, Namespace: pr.Namespace},
+		}},
+		ConfigMaps: th.NewAlphaFeatureFlagsConfigMapInSlice(),
+	}
+
+	prt := newPipelineRunTest(t, d)
+	defer prt.Cancel()
+
+	reconcileError := prt.TestAssets.Controller.Reconciler.Reconcile(prt.TestAssets.Ctx, pr.Namespace+"/"+pr.Name)
+	if ok, duration := controller.IsRequeueKey(reconcileError); !ok {
+		t.Fatalf("expected requeue while awaiting remote TaskRef resolution, got: %v", reconcileError)
+	} else if duration != remoteResolutionRequeueAfter {
+		t.Fatalf("expected requeue after %v, got %v", remoteResolutionRequeueAfter, duration)
+	}
+
+	resolutionRequests, err := prt.TestAssets.Clients.ResolutionRequests.ResolutionV1beta1().ResolutionRequests(pr.Namespace).List(prt.TestAssets.Ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("listing ResolutionRequests: %v", err)
+	}
+	if len(resolutionRequests.Items) != 3 {
+		t.Fatalf("expected 3 ResolutionRequests, got %d", len(resolutionRequests.Items))
+	}
+
+	taskRuns, err := prt.TestAssets.Clients.Pipeline.TektonV1().TaskRuns(pr.Namespace).List(prt.TestAssets.Ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("listing TaskRuns: %v", err)
+	}
+	if len(taskRuns.Items) != 0 {
+		t.Errorf("expected no TaskRuns while resolution is pending, got %d", len(taskRuns.Items))
+	}
+}
+
 // TestReconcileWithTaskResolver checks that a PipelineRun with a populated Resolver
 // field for a Task creates a ResolutionRequest object for that Resolver's type, and
 // that when the request is successfully resolved the PipelineRun begins running.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When a PipelineTask's remote reference is still resolving, continue attempting the remaining PipelineTask references before returning one delayed requeue. This allows independent ResolutionRequests to make progress together across both ran/running and not-started task partitions while keeping TaskRun scheduling blocked until all required references resolve.

The regression test verifies that three independent remote TaskRefs create three ResolutionRequests in one reconciliation and create no new TaskRuns while resolution remains pending.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
PipelineRuns now submit independent remote PipelineTask references without waiting for earlier ResolutionRequests to complete.
```
