### PR TITLE
Keep the Step SecurityContext when the StepAction has none

### DIFF
--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -144,7 +144,9 @@ func resolveStepRef(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.TaskR
 
 	// Merge fields from the resolved StepAction into the step
 	resolvedStep.Image = stepFromStepAction.Image
-	resolvedStep.SecurityContext = stepFromStepAction.SecurityContext
+	if stepFromStepAction.SecurityContext != nil {
+		resolvedStep.SecurityContext = stepFromStepAction.SecurityContext
+	}
 	if len(stepFromStepAction.Command) > 0 {
 		resolvedStep.Command = stepFromStepAction.Command
 	}

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -983,6 +983,8 @@ spec:
 func TestGetStepActionsData(t *testing.T) {
 	taskRunUser := int64(1001)
 	stepActionUser := int64(1000)
+	nonRoot := true
+	readOnlyRootFS := true
 	tests := []struct {
 		name        string
 		tr          *v1.TaskRun
@@ -1261,6 +1263,49 @@ func TestGetStepActionsData(t *testing.T) {
 			Command:         []string{"ls"},
 			Args:            []string{"-lh"},
 			SecurityContext: &corev1.SecurityContext{RunAsUser: &stepActionUser},
+		}},
+	}, {
+		name: "step-action-without-security-context-keeps-the-step-one",
+		tr: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mytaskrun",
+				Namespace: "default",
+			},
+			Spec: v1.TaskRunSpec{
+				TaskSpec: &v1.TaskSpec{
+					Steps: []v1.Step{{
+						Ref: &v1.Ref{
+							Name: "stepAction",
+						},
+						SecurityContext: &corev1.SecurityContext{
+							RunAsUser:              &taskRunUser,
+							RunAsNonRoot:           &nonRoot,
+							ReadOnlyRootFilesystem: &readOnlyRootFS,
+						},
+					}},
+				},
+			},
+		},
+		stepActions: []*v1beta1.StepAction{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stepAction",
+				Namespace: "default",
+			},
+			Spec: v1beta1.StepActionSpec{
+				Image:   "myimage",
+				Command: []string{"ls"},
+				Args:    []string{"-lh"},
+			},
+		}},
+		want: []v1.Step{{
+			Image:   "myimage",
+			Command: []string{"ls"},
+			Args:    []string{"-lh"},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:              &taskRunUser,
+				RunAsNonRoot:           &nonRoot,
+				ReadOnlyRootFilesystem: &readOnlyRootFS,
+			},
 		}},
 	}, {
 		name: "params propagated from taskrun",


### PR DESCRIPTION
# Changes

`resolveStepRef` merges a resolved StepAction into the Step that referenced it, and every field is guarded so the StepAction only wins where it actually set something. `SecurityContext` is the exception:

```go
resolvedStep.SecurityContext = stepFromStepAction.SecurityContext
```

A StepAction that leaves `securityContext` unset therefore overwrites the Step's with nil. `StepActionSpec.SetDefaults` only walks `Params` and `Results`, so nothing fills it in before the merge and the nil really does reach the assignment.

This guards it the same way `Command`, `Args`, `Script`, `Env`, `VolumeMounts` and `Results` already are.

Fixes #10634

/kind bug
/area api

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

Existing coverage kept the "StepAction sets a securityContext" direction (`step-action-with-security-context-overwritten`); the new case is its sibling for the unset direction, with `runAsUser`, `runAsNonRoot` and `readOnlyRootFilesystem` on the Step. Without the guard it fails:

```
- SecurityContext: s"&SecurityContext{...RunAsUser:*1001,RunAsNonRoot:*true,ReadOnlyRootFilesystem:*true,...}"
+ SecurityContext: nil
```

`go build ./...`, `go vet` and `go test ./pkg/reconciler/taskrun/...` are clean.

# Release Notes

```release-note
Fixed a bug where referencing a StepAction that does not set `securityContext` cleared the `securityContext` set on the Step.
```
