### PR TITLE
fix: preserve Step SecurityContext when StepAction leaves it unset

### DIFF
--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -142,9 +142,14 @@ func resolveStepRef(ctx context.Context, taskSpec v1.TaskSpec, taskRun *v1.TaskR
 		return nil, nil, err
 	}
 
-	// Merge fields from the resolved StepAction into the step
+	// Merge fields from the resolved StepAction into the step.
+	// Only overwrite fields that the StepAction actually set, so a
+	// StepAction that leaves e.g. SecurityContext unset does not wipe
+	// the one the Step already had.
 	resolvedStep.Image = stepFromStepAction.Image
-	resolvedStep.SecurityContext = stepFromStepAction.SecurityContext
+	if stepFromStepAction.SecurityContext != nil {
+		resolvedStep.SecurityContext = stepFromStepAction.SecurityContext
+	}
 	if len(stepFromStepAction.Command) > 0 {
 		resolvedStep.Command = stepFromStepAction.Command
 	}

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -983,6 +983,7 @@ spec:
 func TestGetStepActionsData(t *testing.T) {
 	taskRunUser := int64(1001)
 	stepActionUser := int64(1000)
+	trueVal := true
 	tests := []struct {
 		name        string
 		tr          *v1.TaskRun
@@ -1261,6 +1262,43 @@ func TestGetStepActionsData(t *testing.T) {
 			Command:         []string{"ls"},
 			Args:            []string{"-lh"},
 			SecurityContext: &corev1.SecurityContext{RunAsUser: &stepActionUser},
+		}},
+	}, {
+		// When the StepAction does not set SecurityContext, the Step's
+		// own SecurityContext must be preserved rather than cleared to nil.
+		name: "step-action-with-unset-security-context-preserved",
+		tr: &v1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mytaskrun",
+				Namespace: "default",
+			},
+			Spec: v1.TaskRunSpec{
+				TaskSpec: &v1.TaskSpec{
+					Steps: []v1.Step{{
+						Ref: &v1.Ref{
+							Name: "stepAction",
+						},
+						SecurityContext: &corev1.SecurityContext{RunAsUser: &taskRunUser, RunAsNonRoot: &trueVal},
+					}},
+				},
+			},
+		},
+		stepActions: []*v1beta1.StepAction{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stepAction",
+				Namespace: "default",
+			},
+			Spec: v1beta1.StepActionSpec{
+				Image:   "myimage",
+				Command: []string{"ls"},
+				Args:    []string{"-lh"},
+			},
+		}},
+		want: []v1.Step{{
+			Image:           "myimage",
+			Command:         []string{"ls"},
+			Args:            []string{"-lh"},
+			SecurityContext: &corev1.SecurityContext{RunAsUser: &taskRunUser, RunAsNonRoot: &trueVal},
 		}},
 	}, {
 		name: "params propagated from taskrun",


### PR DESCRIPTION
When a Step references a StepAction that does not set SecurityContext, the merge step unconditionally overwrites the Step's SecurityContext with nil, clearing the user's settings. Guard the assignment with a nil check so only explicitly-set StepAction fields overwrite the Step, matching the existing pattern used for Command, Args, Script, and Env.

Fixes tektoncd/pipeline#10657