### PR TITLE
Bump github/codeql-action to v4.37.7

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -99,4 +99,4 @@ jobs:
         make -j 4 all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7


### PR DESCRIPTION
Bumps `github/codeql-action` `init`, `analyze` and `upload-sarif` to `v4.37.7` (`ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd`) in a single change.

Dependabot opened these as three separate PRs (#10636 for `analyze`, #10638 for `upload-sarif`, #10640 for `init`). CodeQL requires the `init` and `analyze` steps to use the *same* version, so #10636 and #10640 each fail their own CodeQL check — a circular dependency where neither can merge first.

This PR supersedes #10636, #10638 and #10640.

/kind misc

<!-- Release notes -->
```release-note
NONE
```
