### PR TITLE
fix(CI): group github/codeql-action/* dependabot updates

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -130,6 +130,13 @@ ecosystems:
       - dependencies
       - release-note-none
       - kind/misc
+    # All github/codeql-action/* sub-actions must be bumped together: the CodeQL
+    # bundle refuses to run when init and analyze come from different versions.
+    groups:
+      codeql-action:
+        patterns:
+          - github/codeql-action
+          - github/codeql-action/*
     cooldown:
       default-days: 7
   - package-ecosystem: docker

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,6 +112,11 @@ updates:
         - dependencies
         - release-note-none
         - kind/misc
+      groups:
+        codeql-action:
+            patterns:
+                - github/codeql-action
+                - github/codeql-action/*
       cooldown:
         default-days: 7
     - package-ecosystem: docker
@@ -278,6 +283,11 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        codeql-action:
+            patterns:
+                - github/codeql-action
+                - github/codeql-action/*
       cooldown:
         default-days: 7
     - package-ecosystem: docker
@@ -460,6 +470,11 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        codeql-action:
+            patterns:
+                - github/codeql-action
+                - github/codeql-action/*
       cooldown:
         default-days: 7
     - package-ecosystem: docker
@@ -642,6 +657,11 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        codeql-action:
+            patterns:
+                - github/codeql-action
+                - github/codeql-action/*
       cooldown:
         default-days: 7
     - package-ecosystem: docker
@@ -824,6 +844,11 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        codeql-action:
+            patterns:
+                - github/codeql-action
+                - github/codeql-action/*
       cooldown:
         default-days: 7
     - package-ecosystem: docker


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Dependabot treats each `github/codeql-action/<sub-action>` as a separate dependency and opens one PR per sub-action. Those PRs merge independently, so `main` regularly ends up with mismatched pins — e.g. `init@v4.37.7` together with `analyze@v4.37.5` — which fails the `Analyze (go)` job with:

```
Loaded a configuration file for version '4.37.7', but running version '4.37.5'
```

This already had to be hand-fixed once in df6cb1da4350 ("fix(ci): bump codeql-action/analyze to match init"), and it recurred just now (#10636).

This PR adds a `codeql-action` group to the `github-actions` package ecosystem so `init`, `analyze` and `upload-sarif` are always bumped together in a single PR, and the failure mode cannot recur.

- `.github/dependabot.config.yml`: add the group (patterns `github/codeql-action` and `github/codeql-action/*`) to the `github-actions` ecosystem.
- `.github/dependabot.yml`: regenerated with `./hack/generate-dependabot.sh`. Release-branch entries are generated from the same ecosystem definition, so the group also applies to `release-v1.15.x`, `release-v1.12.x`, `release-v1.9.x` and `release-v1.6.x` — backport PRs stay in sync too.

Config only — no workflow files are touched. `codeql-analysis.yml` is left as-is (currently being fixed by #10636).

Ref: [Dependabot `groups` option](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--)

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
