### PR TITLE
Use a literal here-string to place Windows scripts

### DIFF
--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -179,9 +179,15 @@ func placeScriptInContainer(script, scriptFile string, c *corev1.Container, init
 	// script file in a known location in the scripts volume.
 	if requiresWindows {
 		command, args, script, scriptFile := extractWindowsScriptComponents(script, scriptFile)
-		initContainer.Args[1] += fmt.Sprintf(`@"
+		// A literal here-string (@'...'@) is the PowerShell equivalent of the
+		// single-quoted heredoc used for Linux below: the script is written out
+		// verbatim, with no variable expansion, and only a line consisting of
+		// '@ ends it. An expandable here-string (@"..."@) would both expand the
+		// script's own variables and let a line of "@ end it early, leaving the
+		// rest of the script to run as commands in the init container.
+		initContainer.Args[1] += fmt.Sprintf(`@'
 %s
-"@ | Out-File -FilePath %s
+'@ | Out-File -FilePath %s
 `, script, scriptFile)
 
 		c.Command = command

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -781,17 +782,17 @@ no-shebang`,
 		Name:    "place-scripts",
 		Image:   images.ShellImageWin,
 		Command: []string{"pwsh"},
-		Args: []string{"-Command", `@"
+		Args: []string{"-Command", `@'
 #!win pwsh -File
 script-1
-"@ | Out-File -FilePath /tekton/scripts/script-0-9l9zj
-@"
+'@ | Out-File -FilePath /tekton/scripts/script-0-9l9zj
+@'
 #!win powershell -File
 script-3
-"@ | Out-File -FilePath /tekton/scripts/script-2-mz4c7.ps1
-@"
+'@ | Out-File -FilePath /tekton/scripts/script-2-mz4c7.ps1
+@'
 no-shebang
-"@ | Out-File -FilePath /tekton/scripts/script-3-mssqb.cmd
+'@ | Out-File -FilePath /tekton/scripts/script-3-mssqb.cmd
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		SecurityContext: WindowsSecurityContext,
@@ -830,6 +831,42 @@ no-shebang
 	}
 }
 
+// A script that contains a line of "@ must not be able to end the here-string
+// that carries it. With an expandable here-string the rest of the script would
+// have run as PowerShell in the place-scripts init container.
+func TestConvertScripts_Windows_ScriptCannotEndHereString(t *testing.T) {
+	names.TestingSeed()
+
+	script := `#!win pwsh -File
+"@
+Write-Output "injected"
+@"`
+
+	gotInit, _, _ := convertScripts(images.ShellImage, images.ShellImageWin, []v1.Step{{
+		Script: script,
+		Image:  "step-1",
+	}}, []v1.Sidecar{}, nil, SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true})
+
+	got := gotInit.Args[1]
+
+	wantBody := `@'
+#!win pwsh -File
+"@
+Write-Output "injected"
+@"
+'@ | Out-File -FilePath /tekton/scripts/script-0-9l9zj
+`
+	if got != wantBody {
+		t.Errorf("Init container args %s", diff.PrintWantGot(cmp.Diff(wantBody, got)))
+	}
+
+	// The literal here-string is only ended by a line of '@, which appears once,
+	// after the script body.
+	if n := strings.Count(got, "\n'@"); n != 1 {
+		t.Errorf("expected the here-string to be terminated exactly once, got %d terminators in:\n%s", n, got)
+	}
+}
+
 func TestConvertScripts_Windows_WithSidecar(t *testing.T) {
 	names.TestingSeed()
 
@@ -863,18 +900,18 @@ sidecar-1`,
 		Name:    "place-scripts",
 		Image:   images.ShellImageWin,
 		Command: []string{"pwsh"},
-		Args: []string{"-Command", `@"
+		Args: []string{"-Command", `@'
 #!win pwsh -File
 script-1
-"@ | Out-File -FilePath /tekton/scripts/script-0-9l9zj
-@"
+'@ | Out-File -FilePath /tekton/scripts/script-0-9l9zj
+@'
 #!win powershell -File
 script-3
-"@ | Out-File -FilePath /tekton/scripts/script-2-mz4c7.ps1
-@"
+'@ | Out-File -FilePath /tekton/scripts/script-2-mz4c7.ps1
+@'
 #!win pwsh -File
 sidecar-1
-"@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-mssqb
+'@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-mssqb
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		SecurityContext: WindowsSecurityContext,
@@ -933,10 +970,10 @@ sidecar-1`,
 		Name:    "place-scripts",
 		Image:   images.ShellImageWin,
 		Command: []string{"pwsh"},
-		Args: []string{"-Command", `@"
+		Args: []string{"-Command", `@'
 #!win python
 sidecar-1
-"@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-9l9zj
+'@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-9l9zj
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		SecurityContext: WindowsSecurityContext,


### PR DESCRIPTION
# Changes

Fixes #10632

The `place-scripts` init container wrote Windows scripts inside an expandable here-string, so a line of `"@` in the script ended it early and the rest ran as PowerShell in the init container. It also expanded any variables in the script before writing it out.

This switches to a literal here-string (`@'...'@`), the PowerShell equivalent of the single-quoted heredoc already used for Linux. Content is written verbatim and only a line of `'@ ` ends it.

Linux is unaffected: there the script is base64 encoded before being embedded, so the heredoc marker can't appear in the content at all.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Windows step scripts are now placed using a PowerShell literal here-string, so script content is written verbatim and a line of `"@` in a script can no longer end the here-string early.
```

# Testing

`TestConvertScripts_Windows_ScriptCannotEndHereString` covers a script containing `"@` on its own line. It fails on `main` and passes with this change. The three existing Windows expectations were updated for the new delimiters, and `go test ./pkg/...` passes.
