### PR TITLE
feat(tracing): tag TaskRun ReconcileKind span on cancel/timeout

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -215,6 +215,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) (reconci
 
 	// If the TaskRun is cancelled, kill resources and update status
 	if tr.IsCancelled() {
+		span.SetAttributes(attribute.String("reason", "Cancelled"))
 		message := fmt.Sprintf("TaskRun %q was cancelled. %s", tr.Name, tr.Spec.StatusMessage)
 		message = appendPreviousConditionContext(before, message)
 		err := c.failTaskRun(ctx, tr, v1.TaskRunReasonCancelled, message)
@@ -230,6 +231,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1.TaskRun) (reconci
 	// Check if the TaskRun has timed out; if it is, this will set its status
 	// accordingly.
 	if tr.HasTimedOut(ctx, c.Clock) {
+		span.SetAttributes(attribute.String("reason", "TimedOut"))
 		// Before failing the TaskRun, ensure step statuses are populated from the pod
 		// This prevents a race condition where the timeout occurs before pod status is fetched
 		if err := c.updateStepStatusesFromPod(ctx, tr); err != nil {


### PR DESCRIPTION
# Changes

Part of #9701. This is the TaskRun-side piece of #9783 (the PipelineRun side was delivered in #10269): tags the existing `ReconcileKind` span with a `reason` attribute (`Cancelled` / `TimedOut`) when the TaskRun reconciler stops because of cancellation or timeout, matching the implementation hint on #9783.

TaskRun doesn't have separate `cancel.go`/`timeout.go` files like PipelineRun does — the `IsCancelled()`/`HasTimedOut()` branches live inline in `ReconcileKind`, already inside that function's span, so this only needed the attribute call, no new span.

No new spans are created, no behavior changes — this is metadata-only.

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

### On testing

No dedicated new test: the existing cancel/timeout reconcile tests (`TestReconcileOnCancelledTaskRun`, `TestReconcileTimeouts`) exercise these exact branches and pass unchanged with the added `SetAttributes` call. Wiring a span recorder into the full `ReconcileKind` test harness would mean plumbing a custom `tracerProvider` through `NewController`'s test setup, which felt disproportionate for a two-line, no-new-span, metadata-only change on top of an already-covered code path. Happy to add that if a maintainer would rather have it explicit.

# Release Notes

```release-note
NONE
```