### PR TITLE
Use partial, sparse clone in the git resolver

### DIFF
--- a/pkg/resolution/resolver/git/repository.go
+++ b/pkg/resolution/resolver/git/repository.go
@@ -23,8 +23,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
+
+	"knative.dev/pkg/logging"
 )
 
 type cmdExecutor = func(context.Context, string, ...string) *exec.Cmd
@@ -33,6 +36,7 @@ type remote struct {
 	url         string
 	username    string
 	password    string
+	pathInRepo  string
 	cmdExecutor cmdExecutor
 }
 
@@ -48,31 +52,124 @@ func (r remote) clone(ctx context.Context) (*repository, func(), error) {
 	}
 
 	repo := &repository{
-		url:       r.url,
-		username:  r.username,
-		password:  r.password,
-		directory: tmpDir,
-		executor:  r.cmdExecutor,
+		url:        r.url,
+		username:   r.username,
+		password:   r.password,
+		pathInRepo: r.pathInRepo,
+		directory:  tmpDir,
+		executor:   r.cmdExecutor,
 	}
 
-	// The "--" separator ensures that repo.url is always interpreted as
-	// a repository path, never as a flag — even if it starts with "-".
-	_, err = repo.execGit(ctx, "clone", "--depth=1", "--no-checkout", "--", repo.url, tmpDir)
-	if err != nil {
-		if strings.Contains(err.Error(), "could not read Username") {
-			err = errors.New("clone error: authentication required")
-		}
+	err = repo.clonePartialWithRetry(ctx)
+	if err == nil {
+		logging.FromContext(ctx).Debugf("git resolver: used partial, sparse clone for %q", r.url)
+		return repo, cleanupFunc, nil
+	}
+	logging.FromContext(ctx).Debugf("git resolver: partial clone failed after retry (%v), falling back to a full clone", err)
+
+	if err := repo.cloneFull(ctx); err != nil {
 		return nil, cleanupFunc, err
 	}
 	return repo, cleanupFunc, nil
 }
 
+// filteredOperationAttempts bounds the retries in clonePartialWithRetry and
+// fetchAndCheckoutWithRetry. A single transient network failure — as
+// distinct from a genuine capability rejection by the server — should not
+// immediately escalate to a full, unfiltered clone of what may be a very
+// large repository: retrying the same cheap filtered operation once is
+// strictly better for that case, and no worse for the "server doesn't
+// support this at all" case, which fails the same way on both attempts.
+// Deliberately not configurable yet — see local-validation.md and TODO.md
+// for the open question of whether upstream wants this tunable.
+const filteredOperationAttempts = 2
+
+// clonePartialWithRetry attempts a partial, sparse clone that fetches only
+// the directory containing pathInRepo instead of the whole commit, retrying
+// once (see filteredOperationAttempts) before giving up. This requires the
+// server to support uploadpack.allowFilter; any failure here — which is not
+// limited to that case — is left for the caller to fall back from. git's
+// error text is not a stable interface, so it is never pattern-matched to
+// decide whether to retry or fall back.
+func (repo *repository) clonePartialWithRetry(ctx context.Context) error {
+	var err error
+	for attempt := 1; attempt <= filteredOperationAttempts; attempt++ {
+		if err = repo.clonePartial(ctx); err == nil {
+			return nil
+		}
+		if attempt < filteredOperationAttempts {
+			logging.FromContext(ctx).Debugf("git resolver: partial clone attempt %d/%d failed (%v), retrying", attempt, filteredOperationAttempts, err)
+			if resetErr := repo.resetDirectory(); resetErr != nil {
+				return resetErr
+			}
+		}
+	}
+	return err
+}
+
+// resetDirectory removes and recreates repo.directory so a fresh clone
+// attempt has the empty target directory "git clone" requires, and marks
+// repo.partial false as soon as the previous clone's content is gone —
+// even if the subsequent MkdirAll fails, repo.partial must not claim a
+// partial clone that no longer exists on disk.
+func (repo *repository) resetDirectory() error {
+	if err := os.RemoveAll(repo.directory); err != nil {
+		return err
+	}
+	repo.partial = false
+	return os.MkdirAll(repo.directory, 0o755)
+}
+
+// cloneFull resets repo.directory and performs the original, unfiltered
+// clone sequence. It is the fallback target both when the initial partial
+// clone fails and — via checkout() — when a filtered fetch fails after an
+// otherwise-successful partial clone: the two are separate git invocations
+// against separate connections, so a server (or network) that tolerates
+// --filter at clone time is not guaranteed to at fetch time either.
+func (repo *repository) cloneFull(ctx context.Context) error {
+	if err := repo.resetDirectory(); err != nil {
+		return err
+	}
+
+	// The "--" separator ensures that repo.url is always interpreted as
+	// a repository path, never as a flag — even if it starts with "-".
+	_, err := repo.execGit(ctx, "clone", "--depth=1", "--no-checkout", "--", repo.url, repo.directory)
+	if err != nil {
+		if strings.Contains(err.Error(), "could not read Username") {
+			err = errors.New("clone error: authentication required")
+		}
+		return err
+	}
+	return nil
+}
+
+// clonePartial performs one attempt of the filtered, sparse clone. See
+// clonePartialWithRetry, its only caller.
+func (repo *repository) clonePartial(ctx context.Context) error {
+	if _, err := repo.execGit(ctx, "clone", "--depth=1", "--no-checkout", "--filter=blob:none", "--sparse", "--", repo.url, repo.directory); err != nil {
+		return err
+	}
+
+	// A root-level pathInRepo needs no cone at all: "--sparse" alone
+	// already materialises root-level files in cone mode.
+	if dir := path.Dir(repo.pathInRepo); dir != "." {
+		if _, err := repo.execGit(ctx, "sparse-checkout", "set", "--", dir); err != nil {
+			return err
+		}
+	}
+
+	repo.partial = true
+	return nil
+}
+
 type repository struct {
-	url       string
-	username  string
-	password  string
-	directory string
-	executor  cmdExecutor
+	url        string
+	username   string
+	password   string
+	pathInRepo string
+	partial    bool
+	directory  string
+	executor   cmdExecutor
 }
 
 func (repo *repository) currentRevision(ctx context.Context) (string, error) {
@@ -84,11 +181,54 @@ func (repo *repository) currentRevision(ctx context.Context) (string, error) {
 }
 
 func (repo *repository) checkout(ctx context.Context, revision string) error {
+	err := repo.fetchAndCheckoutWithRetry(ctx, revision)
+	if err == nil {
+		return nil
+	}
+	if !repo.partial {
+		// Already on the unfiltered sequence — nothing left to fall back to.
+		return err
+	}
+	logging.FromContext(ctx).Debugf("git resolver: filtered fetch/checkout failed after retry (%v), falling back to a full clone", err)
+
+	if fallbackErr := repo.cloneFull(ctx); fallbackErr != nil {
+		return fallbackErr
+	}
+	return repo.fetchAndCheckoutWithRetry(ctx, revision)
+}
+
+// fetchAndCheckoutWithRetry retries a failed fetch/checkout once (see
+// filteredOperationAttempts) before returning control to checkout(), which
+// decides whether to escalate to a full unfiltered clone. Retrying applies
+// whether or not repo.partial is set, since a flaky connection can affect
+// the unfiltered fetch (after a fallback, or when the clone itself already
+// used the unfiltered path) just as much as the filtered one.
+func (repo *repository) fetchAndCheckoutWithRetry(ctx context.Context, revision string) error {
+	var err error
+	for attempt := 1; attempt <= filteredOperationAttempts; attempt++ {
+		if err = repo.fetchAndCheckout(ctx, revision); err == nil {
+			return nil
+		}
+		if attempt < filteredOperationAttempts {
+			logging.FromContext(ctx).Debugf("git resolver: fetch/checkout attempt %d/%d failed (%v), retrying", attempt, filteredOperationAttempts, err)
+		}
+	}
+	return err
+}
+
+// fetchAndCheckout performs one attempt of the fetch and checkout. See
+// fetchAndCheckoutWithRetry, its only caller.
+func (repo *repository) fetchAndCheckout(ctx context.Context, revision string) error {
+	fetchArgs := []string{"origin", "--depth=1"}
+	if repo.partial {
+		fetchArgs = append(fetchArgs, "--filter=blob:none")
+	}
 	// The "--" separator ensures that 'revision' is always interpreted as
 	// a refspec, never as a flag. Without it, a revision like
 	// "--upload-pack=/path/to/binary" would be parsed as the
 	// --upload-pack flag by git, enabling argument injection.
-	_, err := repo.execGit(ctx, "fetch", "origin", "--depth=1", "--", revision)
+	fetchArgs = append(fetchArgs, "--", revision)
+	_, err := repo.execGit(ctx, "fetch", fetchArgs...)
 	if err != nil {
 		return err
 	}

--- a/pkg/resolution/resolver/git/repository_test.go
+++ b/pkg/resolution/resolver/git/repository_test.go
@@ -75,7 +75,7 @@ func TestClone(t *testing.T) {
 				expectedCmd = append(expectedCmd, "--config-env", "http.extraHeader=GIT_AUTH_HEADER")
 				expectedEnv = append(expectedEnv, "GIT_AUTH_HEADER=Authorization: Basic "+token)
 			}
-			expectedCmd = append(expectedCmd, "clone", "--depth=1", "--no-checkout", "--", test.url, repo.directory)
+			expectedCmd = append(expectedCmd, "clone", "--depth=1", "--no-checkout", "--filter=blob:none", "--sparse", "--", test.url, repo.directory)
 
 			if len(executions) != 1 {
 				t.Fatalf("Expected 1 command execution during cloning, got %d: %v", len(executions), executions)
@@ -475,6 +475,375 @@ func TestGetFileContent_SymlinkEscape_RealGitRepo(t *testing.T) {
 				t.Fatalf("symlink escape was NOT blocked — read %d bytes: %q", len(content), string(content))
 			}
 		})
+	}
+}
+
+// TestClonePartial_ArgumentStructure uses a mock executor to verify the
+// exact git argv for the filtered, sparse clone path: the cone derived
+// from pathInRepo, and that a root-level path skips "sparse-checkout set"
+// entirely since "--sparse" alone already materialises root-level files.
+func TestClonePartial_ArgumentStructure(t *testing.T) {
+	testCases := []struct {
+		name            string
+		pathInRepo      string
+		expectSparseSet bool
+		expectedDir     string
+	}{
+		{name: "nested path", pathInRepo: ".tekton/pipeline.yaml", expectSparseSet: true, expectedDir: ".tekton"},
+		{name: "deeply nested path", pathInRepo: "a/b/c/pipeline.yaml", expectSparseSet: true, expectedDir: "a/b/c"},
+		{name: "root-level path", pathInRepo: "pipeline.yaml", expectSparseSet: false},
+		{name: "empty path", pathInRepo: "", expectSparseSet: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var invocations [][]string
+			executor := func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				invocation := append([]string{name}, args...)
+				invocations = append(invocations, invocation)
+				return exec.CommandContext(ctx, "echo", invocation...)
+			}
+
+			r := remote{url: "https://example.invalid/repo.git", pathInRepo: tc.pathInRepo, cmdExecutor: executor}
+			repo, cleanup, err := r.clone(t.Context())
+			defer cleanup()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !repo.partial {
+				t.Fatal("expected the partial, sparse clone to have succeeded")
+			}
+
+			cloneArgs := invocations[0]
+			for _, want := range []string{"--filter=blob:none", "--sparse"} {
+				if !slices.Contains(cloneArgs, want) {
+					t.Fatalf("expected clone args to contain %q, got %v", want, cloneArgs)
+				}
+			}
+
+			sawSparseSet := false
+			for _, inv := range invocations[1:] {
+				if !slices.Contains(inv, "sparse-checkout") {
+					continue
+				}
+				sawSparseSet = true
+				sepIdx, dirIdx := -1, -1
+				for i, a := range inv {
+					if a == "--" {
+						sepIdx = i
+					}
+					if a == tc.expectedDir {
+						dirIdx = i
+					}
+				}
+				if sepIdx == -1 {
+					t.Fatalf("expected '--' separator in sparse-checkout set args: %v", inv)
+				}
+				if dirIdx == -1 || dirIdx < sepIdx {
+					t.Fatalf("expected dir %q after the '--' separator in sparse-checkout set args: %v", tc.expectedDir, inv)
+				}
+			}
+			if sawSparseSet != tc.expectSparseSet {
+				t.Fatalf("expected sparse-checkout set invoked=%v, got %v (invocations: %v)", tc.expectSparseSet, sawSparseSet, invocations)
+			}
+		})
+	}
+}
+
+// TestClonePartial_FallbackOnFailure verifies that when the filtered,
+// sparse clone attempt fails for any reason, clone() retries once using
+// the original unfiltered sequence instead of failing the resolution.
+// This is R2's highest-risk path: a server without uploadpack.allowFilter
+// must keep working, not break.
+func TestClonePartial_FallbackOnFailure(t *testing.T) {
+	var invocations [][]string
+	filteredAttempts := 0
+	executor := func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		invocation := append([]string{name}, args...)
+		invocations = append(invocations, invocation)
+		if slices.Contains(invocation, "clone") && slices.Contains(invocation, "--filter=blob:none") {
+			filteredAttempts++
+			// Simulate a server that rejects the filtered clone, every
+			// time. Exit non-zero without touching the target directory,
+			// exactly like a real failed git-clone would.
+			return exec.CommandContext(ctx, "false")
+		}
+		return exec.CommandContext(ctx, "echo", invocation...)
+	}
+
+	r := remote{url: "https://example.invalid/repo.git", pathInRepo: "sub/dir/file.yaml", cmdExecutor: executor}
+	repo, cleanup, err := r.clone(t.Context())
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("expected clone to succeed via fallback, got error: %v", err)
+	}
+	if repo.partial {
+		t.Fatal("expected repo.partial to be false after falling back to the unfiltered clone")
+	}
+	if filteredAttempts != filteredOperationAttempts {
+		t.Fatalf("expected %d filtered clone attempts before falling back, got %d", filteredOperationAttempts, filteredAttempts)
+	}
+
+	cloneInvocations := 0
+	for _, inv := range invocations {
+		if slices.Contains(inv, "clone") {
+			cloneInvocations++
+		}
+		if slices.Contains(inv, "sparse-checkout") {
+			t.Fatalf("did not expect sparse-checkout set to run when every filtered clone attempt failed: %v", invocations)
+		}
+	}
+	if cloneInvocations != filteredOperationAttempts+1 {
+		t.Fatalf("expected %d clone invocations (%d failed filtered attempts + fallback), got %d: %v", filteredOperationAttempts+1, filteredOperationAttempts, cloneInvocations, invocations)
+	}
+
+	fallbackArgs := invocations[len(invocations)-1]
+	for _, unwanted := range []string{"--filter=blob:none", "--sparse"} {
+		if slices.Contains(fallbackArgs, unwanted) {
+			t.Fatalf("fallback clone must not include %q, got %v", unwanted, fallbackArgs)
+		}
+	}
+}
+
+// TestClonePartial_RetriesBeforeFallback verifies that a single transient
+// failure of the filtered clone does not immediately escalate to an
+// expensive full clone: the same filtered attempt is retried once first,
+// and if that retry succeeds, no fallback happens at all. This is the
+// large-repo-on-a-flaky-connection case: a one-off network blip should not
+// guarantee the costly unfiltered path that this change exists to avoid.
+func TestClonePartial_RetriesBeforeFallback(t *testing.T) {
+	var invocations [][]string
+	filteredAttempts := 0
+	executor := func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		invocation := append([]string{name}, args...)
+		invocations = append(invocations, invocation)
+		if slices.Contains(invocation, "clone") && slices.Contains(invocation, "--filter=blob:none") {
+			filteredAttempts++
+			if filteredAttempts == 1 {
+				// First attempt fails transiently; every later attempt
+				// (including sparse-checkout set) succeeds.
+				return exec.CommandContext(ctx, "false")
+			}
+		}
+		return exec.CommandContext(ctx, "echo", invocation...)
+	}
+
+	r := remote{url: "https://example.invalid/repo.git", cmdExecutor: executor}
+	repo, cleanup, err := r.clone(t.Context())
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("expected the retried partial clone to succeed, got error: %v", err)
+	}
+	if !repo.partial {
+		t.Fatal("expected repo.partial to remain true — the retry should have avoided any fallback")
+	}
+	if filteredAttempts != 2 {
+		t.Fatalf("expected exactly 2 filtered clone attempts (1 failed + 1 retry), got %d", filteredAttempts)
+	}
+
+	cloneInvocations := 0
+	for _, inv := range invocations {
+		if slices.Contains(inv, "clone") {
+			cloneInvocations++
+			if !slices.Contains(inv, "--filter=blob:none") || !slices.Contains(inv, "--sparse") {
+				t.Fatalf("expected every clone invocation to still be filtered — no fallback should have occurred: %v", inv)
+			}
+		}
+	}
+	if cloneInvocations != 2 {
+		t.Fatalf("expected exactly 2 clone invocations (no fallback clone), got %d: %v", cloneInvocations, invocations)
+	}
+}
+
+// TestCheckout_FallbackOnFilteredFetchFailure verifies that a failure in
+// the filtered fetch — not just the initial filtered clone — also triggers
+// the fallback to an unfiltered sequence. clone() and checkout() are
+// separate git invocations against separate connections, so a server (or
+// network) that tolerates --filter at clone time is not guaranteed to at
+// fetch time too; checkout() must not simply propagate that failure.
+func TestCheckout_FallbackOnFilteredFetchFailure(t *testing.T) {
+	var invocations [][]string
+	filteredFetchAttempts := 0
+	executor := func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		invocation := append([]string{name}, args...)
+		invocations = append(invocations, invocation)
+		if slices.Contains(invocation, "fetch") && slices.Contains(invocation, "--filter=blob:none") {
+			filteredFetchAttempts++
+			// Simulate a server that accepted the filtered clone but
+			// rejects (or fails) the filtered fetch, every time — a
+			// distinct connection/negotiation from the clone.
+			return exec.CommandContext(ctx, "false")
+		}
+		return exec.CommandContext(ctx, "echo", invocation...)
+	}
+
+	r := remote{url: "https://example.invalid/repo.git", pathInRepo: "sub/dir/file.yaml", cmdExecutor: executor}
+	repo, cleanup, err := r.clone(t.Context())
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("expected the initial partial clone to succeed, got error: %v", err)
+	}
+	if !repo.partial {
+		t.Fatal("expected repo.partial to be true after a successful partial clone")
+	}
+
+	if err := repo.checkout(t.Context(), "main"); err != nil {
+		t.Fatalf("expected checkout to succeed via fallback, got error: %v", err)
+	}
+	if repo.partial {
+		t.Fatal("expected repo.partial to be false after falling back to an unfiltered clone/fetch")
+	}
+	if filteredFetchAttempts != filteredOperationAttempts {
+		t.Fatalf("expected %d filtered fetch attempts before falling back, got %d", filteredOperationAttempts, filteredFetchAttempts)
+	}
+
+	var cloneInvocations, fetchInvocations [][]string
+	for _, inv := range invocations {
+		if slices.Contains(inv, "clone") {
+			cloneInvocations = append(cloneInvocations, inv)
+		}
+		if slices.Contains(inv, "fetch") {
+			fetchInvocations = append(fetchInvocations, inv)
+		}
+	}
+	if len(cloneInvocations) != 2 {
+		t.Fatalf("expected 2 clone invocations (initial partial clone + fallback reclone), got %d: %v", len(cloneInvocations), invocations)
+	}
+	if len(fetchInvocations) != filteredOperationAttempts+1 {
+		t.Fatalf("expected %d fetch invocations (%d failed filtered fetch attempts + unfiltered fallback), got %d: %v", filteredOperationAttempts+1, filteredOperationAttempts, len(fetchInvocations), invocations)
+	}
+
+	// The fallback reclone (second clone invocation) must be the plain,
+	// unfiltered sequence — not a repeat of the filtered attempt.
+	fallbackCloneArgs := cloneInvocations[1]
+	for _, unwanted := range []string{"--filter=blob:none", "--sparse"} {
+		if slices.Contains(fallbackCloneArgs, unwanted) {
+			t.Fatalf("fallback reclone must not include %q, got %v", unwanted, fallbackCloneArgs)
+		}
+	}
+
+	fallbackFetchArgs := fetchInvocations[len(fetchInvocations)-1]
+	if slices.Contains(fallbackFetchArgs, "--filter=blob:none") {
+		t.Fatalf("fallback fetch must not include --filter=blob:none, got %v", fallbackFetchArgs)
+	}
+}
+
+// TestCheckout_RetriesFetchBeforeFallback mirrors
+// TestClonePartial_RetriesBeforeFallback for the fetch stage: a single
+// transient failure of the filtered fetch is retried once before checkout()
+// escalates to a full, unfiltered clone.
+func TestCheckout_RetriesFetchBeforeFallback(t *testing.T) {
+	var invocations [][]string
+	filteredFetchAttempts := 0
+	executor := func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		invocation := append([]string{name}, args...)
+		invocations = append(invocations, invocation)
+		if slices.Contains(invocation, "fetch") && slices.Contains(invocation, "--filter=blob:none") {
+			filteredFetchAttempts++
+			if filteredFetchAttempts == 1 {
+				return exec.CommandContext(ctx, "false")
+			}
+		}
+		return exec.CommandContext(ctx, "echo", invocation...)
+	}
+
+	r := remote{url: "https://example.invalid/repo.git", cmdExecutor: executor}
+	repo, cleanup, err := r.clone(t.Context())
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("failed to clone: %v", err)
+	}
+
+	if err := repo.checkout(t.Context(), "main"); err != nil {
+		t.Fatalf("expected the retried fetch to succeed, got error: %v", err)
+	}
+	if !repo.partial {
+		t.Fatal("expected repo.partial to remain true — the retry should have avoided any fallback")
+	}
+	if filteredFetchAttempts != 2 {
+		t.Fatalf("expected exactly 2 filtered fetch attempts (1 failed + 1 retry), got %d", filteredFetchAttempts)
+	}
+
+	cloneInvocations := 0
+	for _, inv := range invocations {
+		if slices.Contains(inv, "clone") {
+			cloneInvocations++
+		}
+	}
+	if cloneInvocations != 1 {
+		t.Fatalf("expected exactly 1 clone invocation (no fallback reclone), got %d: %v", cloneInvocations, invocations)
+	}
+}
+
+// TestClonePartial_SparseCheckoutRestrictsTree exercises the real git
+// binary (via a file:// remote, which — unlike a plain local path — goes
+// through the same upload-pack negotiation as a network clone) and
+// verifies that a sibling directory outside pathInRepo's cone is never
+// materialised, while root-level files still are.
+func TestClonePartial_SparseCheckoutRestrictsTree(t *testing.T) {
+	repoDir, _ := createTestRepo(t, []commitForRepo{
+		{Dir: "tasks", Filename: "example.yaml", Content: "wanted"},
+		{Dir: "other", Filename: "big.bin", Content: "not wanted"},
+	})
+
+	ctx := t.Context()
+	repo, cleanup, err := remote{url: "file://" + repoDir, pathInRepo: "tasks/example.yaml"}.clone(ctx)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("failed to clone: %v", err)
+	}
+	if !repo.partial {
+		t.Fatal("expected the file:// clone to take the partial path")
+	}
+	if err := repo.checkout(ctx, "main"); err != nil {
+		t.Fatalf("failed to checkout: %v", err)
+	}
+
+	content, err := repo.getFileContent("tasks/example.yaml")
+	if err != nil {
+		t.Fatalf("expected the requested file to be present: %v", err)
+	}
+	if string(content) != "wanted" {
+		t.Fatalf("expected content %q, got %q", "wanted", string(content))
+	}
+	if _, err := repo.getFileContent("README"); err != nil {
+		t.Fatalf("expected root-level files to still be present in cone mode: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo.directory, "other")); !os.IsNotExist(err) {
+		t.Fatalf("expected sibling directory 'other' to be absent from the working tree, stat returned: %v", err)
+	}
+}
+
+// TestGetFileContent_ErrorParity_MissingSparseDirectory verifies that when
+// pathInRepo names a directory that doesn't exist in the repository,
+// resolution still fails with the same "file does not exist" error as
+// before this change. "git sparse-checkout set" succeeds silently on a
+// missing cone and yields an empty working tree, so this isn't automatic —
+// it depends on getFileContent's existing os.ErrNotExist handling.
+func TestGetFileContent_ErrorParity_MissingSparseDirectory(t *testing.T) {
+	repoDir, _ := createTestRepo(t, []commitForRepo{
+		{Dir: "tasks", Filename: "example.yaml", Content: "valid content"},
+	})
+
+	ctx := t.Context()
+	repo, cleanup, err := remote{url: "file://" + repoDir, pathInRepo: "does-not-exist/pipeline.yaml"}.clone(ctx)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("failed to clone: %v", err)
+	}
+	if !repo.partial {
+		t.Fatal("expected the file:// clone to take the partial path")
+	}
+	if err := repo.checkout(ctx, "main"); err != nil {
+		t.Fatalf("failed to checkout: %v", err)
+	}
+
+	_, err = repo.getFileContent("does-not-exist/pipeline.yaml")
+	if err == nil {
+		t.Fatal("expected an error resolving a file under a missing sparse directory, got nil")
+	}
+	if err.Error() != "file does not exist" {
+		t.Fatalf("expected error %q, got %q", "file does not exist", err.Error())
 	}
 }
 

--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -276,7 +276,7 @@ func (g *GitResolver) ResolveGitClone(ctx context.Context) (framework.ResolvedRe
 
 	path := g.Params[PathParam]
 
-	repo, cleanupFunc, err := remote{url: repoURL, username: username, password: password}.clone(ctx)
+	repo, cleanupFunc, err := remote{url: repoURL, username: username, password: password, pathInRepo: path}.clone(ctx)
 	defer cleanupFunc()
 	if err != nil {
 		return nil, fmt.Errorf("error resolving repository: %w", err)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The git resolver clones the whole repository to read one file. For a 300MB
repo this costs 601MB of resolver disk and 46s per resolution, and the
resolver's `/tmp` emptyDir is capped at 4Gi, so a handful of concurrent
large-repo resolutions risk evicting the resolver pod and stalling every
build in the cluster.

Since #8677 replaced go-git with the native git binary, the resolver can use
git's own partial + sparse clone support directly (`--filter=blob:none
--sparse`), deriving the sparse cone from the existing `pathInRepo` param
rather than adding a new resolver parameter. Sparse checkout alone is not
enough — the transfer, not the checkout, is the cost (measured 301MB/44s
without `--filter`, against 1MB/<1s with it, same commit, same repo).

Resolves #6176.

## Fallback and reliability

Falls back to today's exact unfiltered clone sequence whenever the filtered
clone or the subsequent filtered fetch fails, without pattern-matching git's
error text. Verified this fallback engages for real, not only in a mock:
live against Forgejo with partial clone explicitly disabled
(`DISABLE_PARTIAL_CLONE`), against a raw `git daemon` with direct control
over `uploadpack.allowFilter`/`allowAnySHA1InWant`, and against a genuine
auth/network failure through the patched resolver in a running cluster.

A single transient failure of the filtered clone or fetch is retried once
before escalating to the more expensive unfiltered fallback, so a flaky
connection does not by itself force a full clone of what may be a very
large repository.

**Open question for maintainers**: the retry count (currently a fixed 1
retry) and whether it should use the resolver's existing `backoff-*` config
instead of an immediate retry are not resolved here — raising this
explicitly rather than assuming an answer. If configurability is wanted,
`resolvers-feature-flags`/`git-resolver-config` (used already for
`enable-git-resolver`, `backoff-*`, etc.) looks like the natural place, as
an operator-facing setting rather than a resolver param.

## Scope

Applies to both anonymous and `gitToken`-authenticated clones — the cost is
identical and it's the same code path. Issue #6176 titles this "for
anonymous git resolutions"; restricting the fix to anonymous clones would
leave private repositories, arguably the case that motivates it most in
practice, paying full price.

Out of scope: the resolver's authenticated **API mode** (`org`/`repo` +
`token`), which already fetches only the file; the resolver cache contract
(cache keys are untouched — this changes only how a file is fetched, never
what's returned); and the stale docs line claiming clone mode "clones the
entire repository in memory" (true of the old go-git implementation, false
since #8677) — worth a separate one-line docs PR.

# Submitter Checklist

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The git resolver now uses a partial, sparse clone (`--filter=blob:none --sparse`) instead of a full clone, fetching only the directory containing the requested file. This significantly reduces resolver disk usage and resolution time for large repositories. Falls back automatically to the previous full-clone behavior if the server or a transient failure prevents the filtered clone/fetch from succeeding. No user action is required.
```

---

This contribution was substantially AI-assisted (Claude Sonnet 5), disclosed per [Tekton's AI contribution policy](https://github.com/tektoncd/community/blob/main/ai-contribution-policy.md) and via the `Assisted-by:` commit trailer. I've read and understand the change; happy to answer questions about any part of it.
