### PR TITLE
docs: clarify set-security-context scope and rollback

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -104,9 +104,11 @@ data:
   # This flag is optional and only associated with the previous flag, results-from
   # When results-from is set to "sidecar-logs", this flag can be used to configure the upper limit of a task result
   # max-result-size: "4096"
-  # Setting this flag to "true" will limit privileges for containers injected by Tekton into TaskRuns.
-  # This allows TaskRuns to run in namespaces with "restricted" pod security standards.
-  # Not all Kubernetes implementations support this option.
+  # Setting this flag to "true" limits privileges for containers injected by Tekton into
+  # TaskRuns and Affinity Assistants. Security contexts on user-defined Steps and Sidecars
+  # are unchanged and must independently meet the namespace's pod security requirements.
+  # Set it to "false" if the generated security contexts are incompatible with the injected
+  # images or Kubernetes implementation.
   set-security-context: "true"
   # Setting this flag to "true" will set readOnlyRootFilesystem in securityContext for all containers used in TaskRuns and AffinityAssistant.
   set-security-context-read-only-root-filesystem: "false"

--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -447,8 +447,11 @@ Defaults to "ignore".
   set to `"sidecar-logs"` since sidecar logs bypass the termination message entirely. This is an
   alpha feature gated behind `enable-api-fields: "alpha"` or the per-feature flag. Defaults to `"false"`.
 
-- `set-security-context`: Set this flag to `true` to set a security context for containers injected by Tekton that will allow TaskRun pods
-to run in namespaces with `restricted` pod security admission. By default, this is set to `true`.
+- `set-security-context`: By default, Tekton applies a security context intended to satisfy
+  `restricted` pod security admission to containers it injects into TaskRuns and to Affinity
+  Assistant containers. It does not modify the security contexts of user-defined Steps or
+  Sidecars; those containers must independently satisfy the namespace's pod security requirements. Set this flag to
+  `false` to disable the generated security contexts.
 
 - `set-security-context-read-only-root-filesystem`: Set this flag to `true` to enable `readOnlyRootFilesystem` in the
   security context for containers injected by Tekton. This makes the root filesystem of the container read-only,
@@ -554,10 +557,20 @@ Out-of-the-box, Tekton Pipelines Controller is configured for relatively small-s
 
 ## Running TaskRuns and PipelineRuns with restricted pod security standards
 
-To allow TaskRuns and PipelineRuns to run in namespaces with [restricted pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/),
-set the "set-security-context" feature flag to "true" in the [feature-flags configMap](#customizing-the-pipelines-controller-behavior). This configuration option applies a [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-to any containers injected into TaskRuns by the Pipelines controller. If the [Affinity Assistants](affinityassistants.md) feature is enabled, the SecurityContext is also applied to those containers.
-This SecurityContext may not be supported in all Kubernetes implementations (for example, OpenShift).
+The `set-security-context` feature flag defaults to `"true"`. It applies a
+[SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+to containers injected into TaskRuns by the Pipelines controller and to
+[Affinity Assistant](affinityassistants.md) containers. It does not modify security contexts on
+user-defined Steps or Sidecars; those containers must independently meet the namespace's
+[restricted pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+
+Some injected images and Kubernetes implementations (for example, OpenShift) may not
+support the generated security context. Disable it with:
+
+```shell
+kubectl patch configmap feature-flags -n tekton-pipelines --type merge \
+  -p '{"data":{"set-security-context":"false"}}'
+```
 
 **Note**: running TaskRuns and PipelineRuns in the "tekton-pipelines" namespace is discouraged.
 

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2068,8 +2068,8 @@ _EOF_
 			},
 		},
 		{
-			desc:         "sidecar logs enabled with step results, artifacts not enabled",
-			featureFlags: map[string]string{"results-from": "sidecar-logs"},
+			desc:         "sidecar logs enabled with step results and security context disabled",
+			featureFlags: map[string]string{"results-from": "sidecar-logs", "set-security-context": "false"},
 			ts: v1.TaskSpec{
 				Results: []v1.TaskResult{{
 					Name: "foo",
@@ -2088,7 +2088,7 @@ _EOF_
 			want: &corev1.PodSpec{
 				RestartPolicy: corev1.RestartPolicyNever,
 				InitContainers: []corev1.Container{
-					entrypointInitContainer(images.EntrypointImage, []v1.Step{{Name: "name"}}, SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: false}, false /* windows */),
+					entrypointInitContainer(images.EntrypointImage, []v1.Step{{Name: "name"}}, SecurityContextConfig{SetSecurityContext: false, SetReadOnlyRootFilesystem: false}, false /* windows */),
 				},
 				Containers: []corev1.Container{{
 					Name:    "step-name",
@@ -2137,8 +2137,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
-					SecurityContext: SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: false}.GetSecurityContext(false),
-					Env:             []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
+					Env: []corev1.EnvVar{{Name: "SIDECAR_LOG_POLLING_INTERVAL", Value: "100ms"}},
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Clarify that `set-security-context` applies to Tekton-injected TaskRun containers and Affinity Assistants, not user-defined Steps or Sidecars. Document the `set-security-context: "false"` rollback and add regression coverage for the explicit opt-out.

Fixes #10679

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required: `set-security-context` now defaults to `true` and applies only to Tekton-injected TaskRun containers and Affinity Assistants. User-defined Steps and Sidecars must supply their own restricted-compatible security contexts. If the generated security contexts are incompatible with your images or Kubernetes implementation, set `set-security-context` to `"false"`.
```
