### PR TITLE
fix(status): only match internal RunResult keys by their ResultType

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -83,6 +83,14 @@ const (
 
 	// timeFormat is RFC3339 with millisecond
 	timeFormat = "2006-01-02T15:04:05.000Z07:00"
+
+	// internalResultKeyStartedAt is the RunResult key entrypointer uses for the
+	// internal bookkeeping entry that records a Step's start time.
+	internalResultKeyStartedAt = "StartedAt"
+
+	// internalResultKeyExitCode is the RunResult key entrypointer uses for the
+	// internal bookkeeping entry that records a Step's exit code.
+	internalResultKeyExitCode = "ExitCode"
 )
 
 const (
@@ -556,11 +564,11 @@ func removeDuplicateResults(taskRunResult []v1.TaskRunResult) []v1.TaskRunResult
 }
 
 func extractStartedAtTimeFromResults(results []result.RunResult) (*metav1.Time, error) {
-	for _, result := range results {
-		if result.Key == "StartedAt" {
-			t, err := time.Parse(timeFormat, result.Value)
+	for _, r := range results {
+		if r.ResultType == result.InternalTektonResultType && r.Key == internalResultKeyStartedAt {
+			t, err := time.Parse(timeFormat, r.Value)
 			if err != nil {
-				return nil, fmt.Errorf("could not parse time value %q in StartedAt field: %w", result.Value, err)
+				return nil, fmt.Errorf("could not parse time value %q in StartedAt field: %w", r.Value, err)
 			}
 			startedAt := metav1.NewTime(t)
 			return &startedAt, nil
@@ -570,12 +578,12 @@ func extractStartedAtTimeFromResults(results []result.RunResult) (*metav1.Time, 
 }
 
 func extractExitCodeFromResults(results []result.RunResult) (*int32, error) {
-	for _, result := range results {
-		if result.Key == "ExitCode" {
+	for _, r := range results {
+		if r.ResultType == result.InternalTektonResultType && r.Key == internalResultKeyExitCode {
 			// We could just pass the string through but this provides extra validation
-			i, err := strconv.ParseInt(result.Value, 10, 32)
+			i, err := strconv.ParseInt(r.Value, 10, 32)
 			if err != nil {
-				return nil, fmt.Errorf("could not parse int value %q in ExitCode field: %w", result.Value, err)
+				return nil, fmt.Errorf("could not parse int value %q in ExitCode field: %w", r.Value, err)
 			}
 			exitCode := int32(i) // #nosec G115: ParseInt was called with bit size 32, so this is safe
 			return &exitCode, nil

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -4520,3 +4520,48 @@ func Test_getFailureMessage_consistent_with_reason(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractStartedAtTimeFromResults_IgnoresNonInternalResults verifies that a
+// user-declared Step result named "StartedAt" is not mistaken for the internal
+// bookkeeping entry entrypointer writes with the same key.
+func TestExtractStartedAtTimeFromResults_IgnoresNonInternalResults(t *testing.T) {
+	wantTime := "2022-01-01T00:00:00.000Z"
+	results := []result.RunResult{
+		{Key: internalResultKeyStartedAt, Value: "not-a-time", ResultType: result.StepResultType},
+		{Key: internalResultKeyStartedAt, Value: wantTime, ResultType: result.InternalTektonResultType},
+	}
+	got, err := extractStartedAtTimeFromResults(results)
+	if err != nil {
+		t.Fatalf("extractStartedAtTimeFromResults() returned unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("extractStartedAtTimeFromResults() = nil, want a parsed time")
+	}
+	wantParsed, err := time.Parse(timeFormat, wantTime)
+	if err != nil {
+		t.Fatalf("failed to parse want time: %v", err)
+	}
+	if !got.Time.Equal(wantParsed) {
+		t.Errorf("extractStartedAtTimeFromResults() = %v, want %v", got.Time, wantParsed)
+	}
+}
+
+// TestExtractExitCodeFromResults_IgnoresNonInternalResults verifies that a
+// user-declared Step result named "ExitCode" is not mistaken for the internal
+// bookkeeping entry entrypointer writes with the same key.
+func TestExtractExitCodeFromResults_IgnoresNonInternalResults(t *testing.T) {
+	results := []result.RunResult{
+		{Key: internalResultKeyExitCode, Value: "not-a-number", ResultType: result.StepResultType},
+		{Key: internalResultKeyExitCode, Value: "17", ResultType: result.InternalTektonResultType},
+	}
+	got, err := extractExitCodeFromResults(results)
+	if err != nil {
+		t.Fatalf("extractExitCodeFromResults() returned unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("extractExitCodeFromResults() = nil, want a parsed exit code")
+	}
+	if *got != 17 {
+		t.Errorf("extractExitCodeFromResults() = %d, want 17", *got)
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`entrypointer` writes internal bookkeeping entries (`Key: "StartedAt"`, `"ExitCode"`, `"Reason"`, `ResultType: InternalTektonResultType`) into a Step's termination-message array alongside user-declared Task/Step results, distinguished only by `ResultType`. If a Task or Step author declares a result literally named `StartedAt` or `ExitCode`, that user entry ends up earlier in the parsed results array than the real internal one (task/step results are flushed to the termination message before the internal bookkeeping entries are appended). This is self-inflicted confusion scoped to the Task author's own results — not a cross-tenant or security issue.

`extractStartedAtTimeFromResults` and `extractExitCodeFromResults` in `pkg/pod/status.go` matched on `RunResult.Key` alone, so they picked up the colliding user entry first. If that value fails to parse as a time/integer, the function returns an error immediately and never finds the correct internal entry afterwards, so the Step's real `StartedAt`/`ExitCode` is dropped from status. Their sibling `extractTerminationReasonFromResults` already guarded against exactly this by also checking `ResultType == InternalTektonResultType`.

This PR makes `extractStartedAtTimeFromResults` and `extractExitCodeFromResults` also require `ResultType == InternalTektonResultType`, matching the existing `extractTerminationReasonFromResults` pattern. Two unexported constants were added for the `"StartedAt"`/`"ExitCode"` keys to avoid a new `golangci-lint` `goconst` finding from the added comparison.

Added `TestExtractStartedAtTimeFromResults_IgnoresNonInternalResults` and `TestExtractExitCodeFromResults_IgnoresNonInternalResults`, each with a results slice containing a colliding non-internal entry with a garbage value ahead of the real internal entry. Verified both tests fail against the pre-fix code with exactly the expected parse errors (confirmed by temporarily reverting the `status.go` change while keeping the tests), and pass after the fix.

Ran `go build ./pkg/pod/...`, `go vet ./pkg/pod/...`, `go test ./pkg/pod/...`, and `golangci-lint run ./pkg/pod/...` — all pass, with `golangci-lint` reporting the same pre-existing `goconst`/`contextcheck` issues as on `main` (no new findings). Could not run a full `go build ./...` in this environment: the local disk is nearly full (unrelated pre-existing environment issue, confirmed via `df -h`), so linking steps for unrelated binaries fail with "no space left on device." The affected package itself builds, vets, tests, and lints cleanly in isolation.

Fixes #10631

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind bug`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed a bug where a Task or Step declaring a result named `StartedAt` or `ExitCode` could cause the Step's actual start time or exit code to be dropped from its status.
```