### PR TITLE
fix(pod): scope entrypoint cache by namespace and service account

### DIFF
--- a/pkg/pod/entrypoint_lookup_impl.go
+++ b/pkg/pod/entrypoint_lookup_impl.go
@@ -59,7 +59,7 @@ func NewEntrypointCache(kubeclient kubernetes.Interface) (EntrypointCache, error
 func (e *entrypointCache) get(ctx context.Context, ref name.Reference, namespace, serviceAccountName string, imagePullSecrets []corev1.LocalObjectReference, hasArgs bool) (*imageData, error) {
 	// If image is specified by digest, check the local cache.
 	if digest, ok := ref.(name.Digest); ok {
-		if id, ok := e.lru.Get(digest.String()); ok {
+		if id, ok := e.lru.Get(cacheKey(namespace, serviceAccountName, digest.String())); ok {
 			return id.(*imageData), nil
 		}
 	}
@@ -87,7 +87,8 @@ func (e *entrypointCache) get(ctx context.Context, ref name.Reference, namespace
 	// This saves looking up each constinuent image's commands if we've seen
 	// the multi-platform image before.
 	refByDigest := ref.Context().Digest(desc.Digest.String()).String()
-	if id, ok := e.lru.Get(refByDigest); ok {
+	key := cacheKey(namespace, serviceAccountName, refByDigest)
+	if id, ok := e.lru.Get(key); ok {
 		return id.(*imageData), nil
 	}
 
@@ -120,9 +121,18 @@ func (e *entrypointCache) get(ctx context.Context, ref name.Reference, namespace
 	}
 
 	// Cache the digest->commands for future lookup.
-	e.lru.Add(refByDigest, id)
+	e.lru.Add(key, id)
 
 	return id, nil
+}
+
+// cacheKey scopes a cache entry to the namespace and service account whose
+// credentials were used to resolve it, so that a cache hit is only served to
+// TaskRuns using the same credential context. Without this, an entrypoint
+// resolved using one namespace's pull credentials could be served to another
+// namespace that doesn't have access to the same image.
+func cacheKey(namespace, serviceAccountName, digest string) string {
+	return fmt.Sprintf("%s/%s/%s", namespace, serviceAccountName, digest)
 }
 
 func buildCommandMap(idx v1.ImageIndex, hasArgs bool) (map[string][]string, error) {

--- a/pkg/pod/entrypoint_lookup_impl_test.go
+++ b/pkg/pod/entrypoint_lookup_impl_test.go
@@ -183,6 +183,79 @@ func TestGetImageWithImagePullSecrets(t *testing.T) {
 	}
 }
 
+func TestGetImageCacheScopedByNamespace(t *testing.T) {
+	// Regression test for https://github.com/tektoncd/pipeline/issues/10633
+	//
+	// The entrypoint cache must not serve a cache hit populated using one
+	// namespace's credentials to a TaskRun in a different namespace, even
+	// when both reference the same image digest. Otherwise a tenant without
+	// pull credentials for an image could learn its Entrypoint/Cmd by
+	// piggybacking on another tenant's earlier, authenticated lookup.
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	ftp := newfakeHTTP()
+	s := httptest.NewServer(&ftp)
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatalf("parsing url: %v", err)
+	}
+
+	task := &pipelinev1.Task{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1",
+			Kind:       "Task",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-create-image",
+		},
+	}
+
+	ref, err := remotetest.CreateImageWithAnnotations(u.Host+"/task/test-cross-namespace-image", remotetest.DefaultObjectAnnotationMapper, task)
+	if err != nil {
+		t.Fatalf("uploading image failed unexpectedly with an error: %v", err)
+	}
+
+	imgRef, err := name.ParseReference(ref)
+	if err != nil {
+		t.Fatalf("digest %s is not a valid reference: %v", ref, err)
+	}
+
+	const (
+		tenantA = "tenant-a"
+		tenantB = "tenant-b"
+	)
+
+	tenantASecret := generateSecret(u.Host, username, password)
+	tenantASecret.Namespace = tenantA
+
+	client := fakeclient.NewSimpleClientset(
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: tenantA}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: tenantB}},
+		tenantASecret,
+	)
+
+	entrypointCache, err := NewEntrypointCache(client)
+	if err != nil {
+		t.Fatalf("creating entrypointCache: %v", err)
+	}
+
+	// tenant-a has valid pull credentials for the image and should succeed,
+	// populating the cache.
+	if _, err := entrypointCache.get(ctx, imgRef, tenantA, "", []corev1.LocalObjectReference{{Name: imagePullSecretsName}}, true); err != nil {
+		t.Fatalf("get() for tenant-a: unexpected error: %v", err)
+	}
+
+	// tenant-b has no pull credentials for the same digest. It must not be
+	// served tenant-a's cached result.
+	if _, err := entrypointCache.get(ctx, imgRef, tenantB, "", nil, true); err == nil {
+		t.Fatalf("get() for tenant-b: expected error due to missing credentials, but the lookup succeeded (cache leaked across namespaces)")
+	}
+}
+
 func mustRandomImage(t *testing.T) v1.Image {
 	t.Helper()
 	img, err := random.Image(10, 10)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `entrypointCache` in `pkg/pod/entrypoint_lookup_impl.go` is a global LRU
cache keyed only by image digest. Once an image's Entrypoint/Cmd is resolved
and cached using one namespace's pull credentials, any TaskRun in a
different namespace that references the same digest is served the cached
result without re-authenticating to the registry. A tenant that knows the
digest of another tenant's private image can learn its Entrypoint/Cmd this
way, without ever having pull credentials for that image. Only
Entrypoint/Cmd metadata is exposed; image layers, env vars, and filesystem
content are not affected.

This scopes the cache key to the namespace and service account name used to
resolve the image, in addition to the digest, so a cache entry is only
served to lookups made with the same credential context. This matches the
fix proposed in the linked issue. The trade-off is a lower cache hit rate in
single-tenant deployments (the same image may be resolved once per
namespace instead of once globally), which is acceptable given the small
cache size (1024 entries) and the correctness improvement.

**Validation**
- `go build ./...`
- `go test ./pkg/pod/...`
- Added `TestGetImageCacheScopedByNamespace`, which populates the cache via
  an authenticated lookup in one namespace, then performs a lookup for the
  same digest from a second namespace with no pull credentials. Confirmed
  this test fails on the pre-fix code (the second lookup succeeds by
  reusing the first namespace's cached result) and passes after the fix
  (the second lookup fails with an authentication error, since it no
  longer hits the cache).
- `golangci-lint run ./pkg/pod/...`: no new findings in the changed files.
- `go vet ./pkg/pod/...` and `gofmt -l` on the changed files: clean.

Note: this repo's PR CI is gated behind Prow (`ok-to-test`) for
non-collaborators — happy to address anything it surfaces once triggered.

Fixes #10633

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix a bug where the entrypoint lookup cache could leak an image's Entrypoint/Cmd across namespaces: results cached using one namespace's pull credentials are no longer served to a different namespace/service account looking up the same image digest.
```