### PR TITLE
fix: Make controller-managed labels immutable via webhook

### DIFF
--- a/pkg/apis/pipeline/v1/immutable_labels_test.go
+++ b/pkg/apis/pipeline/v1/immutable_labels_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/test/diff"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/system"
+	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
+)
+
+// withCaller attaches admission UserInfo to ctx for the given caller identity:
+// a ServiceAccount in the Tekton system namespace (the controller) when
+// asController is true, otherwise an ordinary user outside that namespace.
+func withCaller(ctx context.Context, asController bool) context.Context {
+	ui := &authenticationv1.UserInfo{Username: "system:serviceaccount:default:some-user"}
+	if asController {
+		ui = &authenticationv1.UserInfo{
+			Username: "system:serviceaccount:" + system.Namespace() + ":tekton-pipelines-controller",
+			Groups:   []string{"system:serviceaccounts:" + system.Namespace()},
+		}
+	}
+	return apis.WithUserInfo(ctx, ui)
+}
+
+func TestPipelineRun_ValidateImmutableLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		baselineList  map[string]string
+		updatedLabels map[string]string
+		asController  bool
+		noUserInfo    bool
+		expectedError apis.FieldError
+	}{{
+		name:          "non-managed label added by user is allowed",
+		baselineList:  map[string]string{},
+		updatedLabels: map[string]string{"example.com/team": "blue"},
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "controller-managed label first stamped from empty is allowed",
+		baselineList:  map[string]string{},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "my-pipeline"},
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "controller may change a controller-managed label",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: "parent-pipeline"},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "child-own-name"},
+		asController:  true,
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "controller-managed label unchanged is allowed",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: "my-pipeline"},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "my-pipeline"},
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "user mutating a controller-managed label is rejected",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: "my-pipeline"},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "user-edited"},
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipeline" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipeline]"},
+		},
+	}, {
+		name:          "user removing a controller-managed label is rejected",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: "my-pipeline"},
+		updatedLabels: map[string]string{},
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipeline" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipeline]"},
+		},
+	}, {
+		name:          "empty controller-managed label present is immutable",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: ""},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "user-edited"},
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipeline" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipeline]"},
+		},
+	}, {
+		name:          "no user info falls back to enforcing immutability",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: "my-pipeline"},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "user-edited"},
+		noUserInfo:    true,
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipeline" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipeline]"},
+		},
+	}, {
+		name: "multiple controller-managed labels mutated by user are all rejected",
+		baselineList: map[string]string{
+			pipeline.PipelineLabelKey:     "my-pipeline",
+			pipeline.PipelineRunLabelKey:  "my-pipelinerun",
+			pipeline.PipelineTaskLabelKey: "my-task",
+		},
+		updatedLabels: map[string]string{
+			pipeline.PipelineLabelKey:     "user-edited",
+			pipeline.PipelineRunLabelKey:  "user-edited",
+			pipeline.PipelineTaskLabelKey: "user-edited",
+		},
+		expectedError: *apis.ErrInvalidValue(`label "tekton.dev/pipeline" is immutable once set`, "metadata.labels.[tekton.dev/pipeline]").
+			Also(apis.ErrInvalidValue(`label "tekton.dev/pipelineRun" is immutable once set`, "metadata.labels.[tekton.dev/pipelineRun]")).
+			Also(apis.ErrInvalidValue(`label "tekton.dev/pipelineTask" is immutable once set`, "metadata.labels.[tekton.dev/pipelineTask]")),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseline := &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "pr", Labels: tt.baselineList},
+				Spec:       v1.PipelineRunSpec{PipelineRef: &v1.PipelineRef{Name: "foo"}},
+			}
+			updated := &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "pr", Labels: tt.updatedLabels},
+				Spec:       v1.PipelineRunSpec{PipelineRef: &v1.PipelineRef{Name: "foo"}},
+			}
+			ctx := apis.WithinUpdate(t.Context(), baseline)
+			if !tt.noUserInfo {
+				ctx = withCaller(ctx, tt.asController)
+			}
+			err := updated.Validate(ctx)
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("PipelineRun.Validate() label immutability errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/internal/resultref"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -49,6 +50,14 @@ func (pr *PipelineRun) Validate(ctx context.Context) *apis.FieldError {
 
 	if pr.IsPending() && pr.HasStarted() {
 		errs = errs.Also(apis.ErrInvalidValue("PipelineRun cannot be Pending after it is started", "spec.status"))
+	}
+
+	// Controller-managed labels are immutable except for Tekton's own components,
+	// which stamp and normalize them (see IsControllerServiceAccount).
+	if apis.IsInUpdate(ctx) && !pipeline.IsControllerServiceAccount(ctx) {
+		if oldObj, ok := apis.GetBaseline(ctx).(*PipelineRun); ok && oldObj != nil {
+			errs = errs.Also(pipeline.ValidateImmutableLabels(oldObj.Labels, pr.Labels, pipeline.ControllerManagedLabels))
+		}
 	}
 
 	return errs.Also(pr.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))

--- a/pkg/apis/pipeline/v1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -49,6 +50,14 @@ func (tr *TaskRun) Validate(ctx context.Context) *apis.FieldError {
 
 	if tr.IsPending() && tr.HasStarted() {
 		errs = errs.Also(apis.ErrInvalidValue("TaskRun cannot be Pending after it is started", "spec.status"))
+	}
+
+	// Controller-managed labels are immutable except for Tekton's own components,
+	// which stamp and normalize them (see IsControllerServiceAccount).
+	if apis.IsInUpdate(ctx) && !pipeline.IsControllerServiceAccount(ctx) {
+		if oldObj, ok := apis.GetBaseline(ctx).(*TaskRun); ok && oldObj != nil {
+			errs = errs.Also(pipeline.ValidateImmutableLabels(oldObj.Labels, tr.Labels, pipeline.ControllerManagedLabels))
+		}
 	}
 
 	return errs.Also(tr.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))

--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	cfgtesting "github.com/tektoncd/pipeline/pkg/apis/config/testing"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -1314,6 +1315,92 @@ func TestTaskRunSpec_ValidateUpdate_FinalizerChanges(t *testing.T) {
 				} else if !strings.Contains(err.Error(), tt.expectedError) {
 					t.Errorf("Expected error containing %q, but got: %v", tt.expectedError, err)
 				}
+			}
+		})
+	}
+}
+
+func TestTaskRun_ValidateImmutableLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		baselineList  map[string]string
+		updatedLabels map[string]string
+		asController  bool
+		noUserInfo    bool
+		expectedError apis.FieldError
+	}{{
+		name:          "non-managed label added by user is allowed",
+		baselineList:  map[string]string{},
+		updatedLabels: map[string]string{"example.com/team": "blue"},
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "controller-managed label first stamped from empty is allowed",
+		baselineList:  map[string]string{},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "my-pipeline"},
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "controller may change a controller-managed label",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: "parent-pipeline"},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "child-own-name"},
+		asController:  true,
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "controller-managed label unchanged is allowed",
+		baselineList:  map[string]string{pipeline.PipelineRunLabelKey: "my-pipelinerun"},
+		updatedLabels: map[string]string{pipeline.PipelineRunLabelKey: "my-pipelinerun"},
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "user mutating a controller-managed label is rejected",
+		baselineList:  map[string]string{pipeline.PipelineRunLabelKey: "my-pipelinerun"},
+		updatedLabels: map[string]string{pipeline.PipelineRunLabelKey: "user-edited"},
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipelineRun" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipelineRun]"},
+		},
+	}, {
+		name:          "user removing a controller-managed label is rejected",
+		baselineList:  map[string]string{pipeline.PipelineTaskLabelKey: "my-task"},
+		updatedLabels: map[string]string{},
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipelineTask" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipelineTask]"},
+		},
+	}, {
+		name:          "empty controller-managed label present is immutable",
+		baselineList:  map[string]string{pipeline.PipelineRunLabelKey: ""},
+		updatedLabels: map[string]string{pipeline.PipelineRunLabelKey: "user-edited"},
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipelineRun" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipelineRun]"},
+		},
+	}, {
+		name:          "no user info falls back to enforcing immutability",
+		baselineList:  map[string]string{pipeline.PipelineRunLabelKey: "my-pipelinerun"},
+		updatedLabels: map[string]string{pipeline.PipelineRunLabelKey: "user-edited"},
+		noUserInfo:    true,
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipelineRun" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipelineRun]"},
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseline := &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "tr", Labels: tt.baselineList},
+				Spec:       v1.TaskRunSpec{TaskRef: &v1.TaskRef{Name: "foo"}},
+			}
+			updated := &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "tr", Labels: tt.updatedLabels},
+				Spec:       v1.TaskRunSpec{TaskRef: &v1.TaskRef{Name: "foo"}},
+			}
+			ctx := apis.WithinUpdate(t.Context(), baseline)
+			if !tt.noUserInfo {
+				ctx = withCaller(ctx, tt.asController)
+			}
+			err := updated.Validate(ctx)
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("TaskRun.Validate() label immutability errors diff %s", diff.PrintWantGot(d))
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/immutable_labels_test.go
+++ b/pkg/apis/pipeline/v1beta1/immutable_labels_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/system"
+	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
+)
+
+// These tests ensure the immutable controller-managed label check is also
+// enforced through the still-served v1beta1 API, so updates cannot bypass it.
+
+// withCaller attaches admission UserInfo to ctx for the given caller identity:
+// a ServiceAccount in the Tekton system namespace (the controller) when
+// asController is true, otherwise an ordinary user outside that namespace.
+func withCaller(ctx context.Context, asController bool) context.Context {
+	ui := &authenticationv1.UserInfo{Username: "system:serviceaccount:default:some-user"}
+	if asController {
+		ui = &authenticationv1.UserInfo{
+			Username: "system:serviceaccount:" + system.Namespace() + ":tekton-pipelines-controller",
+			Groups:   []string{"system:serviceaccounts:" + system.Namespace()},
+		}
+	}
+	return apis.WithUserInfo(ctx, ui)
+}
+
+func TestPipelineRun_ValidateImmutableLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		baselineList  map[string]string
+		updatedLabels map[string]string
+		asController  bool
+		noUserInfo    bool
+		expectedError apis.FieldError
+	}{{
+		name:          "controller-managed label first stamped from empty is allowed",
+		baselineList:  map[string]string{},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "my-pipeline"},
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "controller may change a controller-managed label",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: "parent-pipeline"},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "child-own-name"},
+		asController:  true,
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "user mutating a controller-managed label is rejected",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: "my-pipeline"},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "user-edited"},
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipeline" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipeline]"},
+		},
+	}, {
+		name:          "empty controller-managed label present is immutable",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: ""},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "user-edited"},
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipeline" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipeline]"},
+		},
+	}, {
+		name:          "no user info falls back to enforcing immutability",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: "my-pipeline"},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "user-edited"},
+		noUserInfo:    true,
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipeline" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipeline]"},
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseline := &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "pr", Labels: tt.baselineList},
+				Spec:       v1beta1.PipelineRunSpec{PipelineRef: &v1beta1.PipelineRef{Name: "foo"}},
+			}
+			updated := &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "pr", Labels: tt.updatedLabels},
+				Spec:       v1beta1.PipelineRunSpec{PipelineRef: &v1beta1.PipelineRef{Name: "foo"}},
+			}
+			ctx := apis.WithinUpdate(t.Context(), baseline)
+			if !tt.noUserInfo {
+				ctx = withCaller(ctx, tt.asController)
+			}
+			err := updated.Validate(ctx)
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("PipelineRun.Validate() label immutability errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestTaskRun_ValidateImmutableLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		baselineList  map[string]string
+		updatedLabels map[string]string
+		asController  bool
+		noUserInfo    bool
+		expectedError apis.FieldError
+	}{{
+		name:          "controller-managed label first stamped from empty is allowed",
+		baselineList:  map[string]string{},
+		updatedLabels: map[string]string{pipeline.PipelineRunLabelKey: "my-pipelinerun"},
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "controller may change a controller-managed label",
+		baselineList:  map[string]string{pipeline.PipelineLabelKey: "parent-pipeline"},
+		updatedLabels: map[string]string{pipeline.PipelineLabelKey: "child-own-name"},
+		asController:  true,
+		expectedError: apis.FieldError{},
+	}, {
+		name:          "user mutating a controller-managed label is rejected",
+		baselineList:  map[string]string{pipeline.PipelineRunLabelKey: "my-pipelinerun"},
+		updatedLabels: map[string]string{pipeline.PipelineRunLabelKey: "user-edited"},
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipelineRun" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipelineRun]"},
+		},
+	}, {
+		name:          "empty controller-managed label present is immutable",
+		baselineList:  map[string]string{pipeline.PipelineRunLabelKey: ""},
+		updatedLabels: map[string]string{pipeline.PipelineRunLabelKey: "user-edited"},
+		expectedError: apis.FieldError{
+			Message: `invalid value: label "tekton.dev/pipelineRun" is immutable once set`,
+			Paths:   []string{"metadata.labels.[tekton.dev/pipelineRun]"},
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseline := &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "tr", Labels: tt.baselineList},
+				Spec:       v1beta1.TaskRunSpec{TaskRef: &v1beta1.TaskRef{Name: "foo"}},
+			}
+			updated := &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "tr", Labels: tt.updatedLabels},
+				Spec:       v1beta1.TaskRunSpec{TaskRef: &v1beta1.TaskRef{Name: "foo"}},
+			}
+			ctx := apis.WithinUpdate(t.Context(), baseline)
+			if !tt.noUserInfo {
+				ctx = withCaller(ctx, tt.asController)
+			}
+			err := updated.Validate(ctx)
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("TaskRun.Validate() label immutability errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/internal/resultref"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -54,6 +55,14 @@ func (pr *PipelineRun) Validate(ctx context.Context) *apis.FieldError {
 
 	if pr.IsPending() && pr.HasStarted() {
 		errs = errs.Also(apis.ErrInvalidValue("PipelineRun cannot be Pending after it is started", "spec.status"))
+	}
+
+	// Mirrors the v1 check so updates through the still-served v1beta1 API cannot
+	// bypass controller-managed label immutability.
+	if apis.IsInUpdate(ctx) && !pipeline.IsControllerServiceAccount(ctx) {
+		if oldObj, ok := apis.GetBaseline(ctx).(*PipelineRun); ok && oldObj != nil {
+			errs = errs.Also(pipeline.ValidateImmutableLabels(oldObj.Labels, pr.Labels, pipeline.ControllerManagedLabels))
+		}
 	}
 
 	return errs.Also(pr.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -49,6 +50,14 @@ func (tr *TaskRun) Validate(ctx context.Context) *apis.FieldError {
 
 	if tr.IsPending() && tr.HasStarted() {
 		errs = errs.Also(apis.ErrInvalidValue("TaskRun cannot be Pending after it is started", "spec.status"))
+	}
+
+	// Mirrors the v1 check so updates through the still-served v1beta1 API cannot
+	// bypass controller-managed label immutability.
+	if apis.IsInUpdate(ctx) && !pipeline.IsControllerServiceAccount(ctx) {
+		if oldObj, ok := apis.GetBaseline(ctx).(*TaskRun); ok && oldObj != nil {
+			errs = errs.Also(pipeline.ValidateImmutableLabels(oldObj.Labels, tr.Labels, pipeline.ControllerManagedLabels))
+		}
 	}
 
 	return errs.Also(tr.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))

--- a/pkg/apis/pipeline/validation.go
+++ b/pkg/apis/pipeline/validation.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/system"
+)
+
+// ControllerManagedLabels are the labels stamped and trusted by the reconciler.
+// For example, pipeline-in-pipeline cycle detection reads PipelineLabelKey, so a
+// user must not be able to change these labels once the controller has set them.
+var ControllerManagedLabels = []string{
+	PipelineLabelKey,
+	PipelineTaskLabelKey,
+	PipelineRunLabelKey,
+}
+
+// IsControllerServiceAccount reports whether the admission request in ctx comes
+// from a ServiceAccount in the Tekton system namespace (the controller, webhook
+// and events controller). Those are Tekton's own trusted components and are
+// exempt from the controller-managed label immutability check so the reconciler
+// can stamp and normalise these labels. The caller's UserInfo is populated by
+// the apiserver and cannot be spoofed; it is absent (returns false) for calls
+// made outside the admission webhook path.
+func IsControllerServiceAccount(ctx context.Context) bool {
+	ui := apis.GetUserInfo(ctx)
+	if ui == nil {
+		return false
+	}
+	// e.g. system:serviceaccounts:tekton-pipelines
+	return slices.Contains(ui.Groups, "system:serviceaccounts:"+system.Namespace())
+}
+
+// ValidateImmutableLabels rejects any change to a controller-managed label once
+// it has been set. Presence of the key is treated as "set" (matching how the
+// reconciler reads these labels), so a managed label cannot be removed or have
+// its value changed once present, even if that value is empty. A key that is
+// absent from oldLabels is treated as "not set yet" so the controller can still
+// stamp it on first reconcile.
+func ValidateImmutableLabels(oldLabels, newLabels map[string]string, keys []string) (errs *apis.FieldError) {
+	for _, key := range keys {
+		oldVal, hadOld := oldLabels[key]
+		if !hadOld {
+			continue
+		}
+		if newVal, hasNew := newLabels[key]; !hasNew || newVal != oldVal {
+			errs = errs.Also(apis.ErrInvalidValue(
+				fmt.Sprintf("label %q is immutable once set", key),
+				"",
+			).ViaFieldKey("labels", key).ViaField("metadata"))
+		}
+	}
+	return errs
+}

--- a/test/pipelinerun_pinp_test.go
+++ b/test/pipelinerun_pinp_test.go
@@ -980,3 +980,42 @@ func TestPipelineRun_PinP_PipelineRefInFinally(t *testing.T) {
 	assertPinP(ctx, t, c, expectedChildPR)
 	assertEvents(ctx, t, expectedEventsAmount, expectedKinds, c, namespace)
 }
+
+// @test:execution=parallel
+// TestPipelineRun_PinP_ControllerManagedLabelIsImmutable verifies that once the
+// controller stamps a controller-managed label (tekton.dev/pipeline) on a
+// PipelineRun, a user cannot mutate it via an update: the validating webhook
+// rejects the change. This closes the label-tampering vector that could
+// otherwise be used to bypass PinP cycle detection.
+func TestPipelineRun_PinP_ControllerManagedLabelIsImmutable(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{
+		"enable-api-fields": "alpha",
+	}))
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	// GIVEN: a PinP parent PipelineRun that runs to success, so the controller
+	// stamps the tekton.dev/pipeline label on it.
+	parentPipeline, parentPipelineRun, _ := th.OnePipelineInPipeline(t, namespace, "pr-label-immutable")
+	createResourcesAndWaitForPipelineRunSuccess(ctx, t, c, namespace, []*v1.Pipeline{parentPipeline}, parentPipelineRun, nil)
+
+	// WHEN: a user tries to overwrite the controller-managed label.
+	pr, err := c.V1PipelineRunClient.Get(ctx, parentPipelineRun.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get PipelineRun %q: %s", parentPipelineRun.Name, err)
+	}
+	if pr.Labels[pipeline.PipelineLabelKey] == "" {
+		t.Fatalf("Expected controller to stamp %q label, but it was empty", pipeline.PipelineLabelKey)
+	}
+	pr.Labels[pipeline.PipelineLabelKey] = "user-edited"
+	_, err = c.V1PipelineRunClient.Update(ctx, pr, metav1.UpdateOptions{})
+
+	// THEN: the validating webhook rejects the mutation.
+	if err == nil || !strings.Contains(err.Error(), "is immutable once set") {
+		t.Fatalf("Expected webhook to reject mutation of %q label, but got: %v", pipeline.PipelineLabelKey, err)
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes: https://github.com/tektoncd/pipeline/issues/10635

Controller-managed labels (`tekton.dev/pipeline`, `tekton.dev/pipelineTask`, `tekton.dev/pipelineRun`) are set by the controller and trusted by the reconciler. For example, Pipelines-in-Pipelines cycle detection reads `tekton.dev/pipeline` to walk the ancestor chain. Until now a user with update access could change these labels on an existing PipelineRun/TaskRun and bypass that check.

This PR adds validation in the PipelineRun and TaskRun validating webhook to reject updates that mutate a controller-managed label once it has been set, for both the v1 and the still-served v1beta1 APIs.

- Presence-based immutability: once a managed label key is present it cannot be changed or removed, even if its value is empty (matching how the reconciler treats these labels). A key that is absent is treated as "not set yet" so the controller can still stamp it on first reconcile.

- Controller exemption: Tekton's own components are exempt so the reconciler can stamp and normalize these labels. The exemption is derived from the admission request's UserInfo (populated by the apiserver, cannot be spoofed): a caller is trusted when it is a ServiceAccount in the Tekton system namespace (system:serviceaccounts:<system-namespace> group). This avoids hardcoding the controller ServiceAccount name and has no upgrade impact if it is renamed.

- Shared ValidateImmutableLabels / IsControllerServiceAccount helpers wired into PipelineRun.Validate and TaskRun.Validate (v1 and v1beta1) for update requests.

- Unit tests for both resources and both API versions, including the controller-exempt and first-stamp cases.

- e2e test verifying the webhook rejects mutating tekton.dev/pipeline on an established PipelineRun.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Controller-managed labels (tekton.dev/pipeline, tekton.dev/pipelineTask, tekton.dev/pipelineRun) are now immutable once set and cannot be changed by users updating a PipelineRun or TaskRun.
```
Assissted by: Claude

/kind bug