### PR TITLE
Allow tt.params as a valid variable-reference prefix

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -42,10 +42,11 @@ var (
 )
 
 const (
-	taskRef      = "taskRef"
-	taskSpec     = "taskSpec"
-	pipelineRef  = "pipelineRef"
-	pipelineSpec = "pipelineSpec"
+	taskRef        = "taskRef"
+	taskSpec       = "taskSpec"
+	pipelineRef    = "pipelineRef"
+	pipelineSpec   = "pipelineSpec"
+	ttParamsPrefix = "tt.params"
 )
 
 // SupportedVerbs returns the operations that validation should be called for
@@ -871,15 +872,17 @@ func validateMatrix(ctx context.Context, tasks []PipelineTask) (errs *apis.Field
 }
 
 func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) (errs *apis.FieldError) {
-	validPrefixes := sets.NewString("params", "tasks", "finally", "context", "workspaces", "results")
+	validPrefixes := sets.NewString("params", "tasks", "finally", "context", "workspaces", "results", ttParamsPrefix)
 	for idx, task := range tasks {
 		for _, param := range task.Params {
 			if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
 				for _, expression := range expressions {
-					prefix := strings.SplitN(expression, ".", 2)[0]
-					if !validPrefixes.Has(prefix) {
+					fields := strings.SplitN(expression, ".", 3)
+					if !validPrefixes.Has(fields[0]) &&
+						!(len(fields) > 1 && validPrefixes.Has(fields[0]+"."+fields[1]) &&
+							(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
 						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 							"value",
 						).ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
 					}
@@ -889,10 +892,12 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		for i, we := range task.When {
 			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
 				for _, expression := range expressions {
-					prefix := strings.SplitN(expression, ".", 2)[0]
-					if !validPrefixes.Has(prefix) {
+					fields := strings.SplitN(expression, ".", 3)
+					if !validPrefixes.Has(fields[0]) &&
+						!(len(fields) > 1 && validPrefixes.Has(fields[0]+"."+fields[1]) &&
+							(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
 						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 							"",
 						).ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
 					}
@@ -903,10 +908,13 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 			for _, param := range task.Matrix.Params {
 				if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
 					for _, expression := range expressions {
-						prefix := strings.SplitN(expression, ".", 2)[0]
-						if !validPrefixes.Has(prefix) {
+						fields := strings.SplitN(expression, ".", 3)
+						if !validPrefixes.Has(fields[0]) &&
+							!(len(fields) > 1 &&
+								validPrefixes.Has(fields[0]+"."+fields[1]) &&
+								(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
 							errs = errs.Also(apis.ErrInvalidValue(
-								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 								"value",
 							).ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
 						}
@@ -917,10 +925,13 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 				for _, param := range include.Params {
 					if expressions, ok := param.GetVarSubstitutionExpressions(); ok {
 						for _, expression := range expressions {
-							prefix := strings.SplitN(expression, ".", 2)[0]
-							if !validPrefixes.Has(prefix) {
+							fields := strings.SplitN(expression, ".", 3)
+							if !validPrefixes.Has(fields[0]) &&
+								!(len(fields) > 1 &&
+									validPrefixes.Has(fields[0]+"."+fields[1]) &&
+									(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
 								errs = errs.Also(apis.ErrInvalidValue(
-									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 									"value",
 								).ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
 							}

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -46,6 +46,36 @@ func TestPipeline_Validate_Success(t *testing.T) {
 			},
 		},
 	}, {
+		name: "tt.params reference in pipeline task param is allowed (Triggers-owned prefix)",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "MESSAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(tt.params.MESSAGE)"},
+					}},
+				}},
+			},
+		},
+	}, {
+		name: "tt.params reference in matrix param is allowed (Triggers-owned prefix)",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Matrix: &Matrix{
+						Params: Params{{
+							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tt.params.IMAGE)", "image2"}},
+						}},
+					},
+				}},
+			},
+		},
+	}, {
 		name: "pipelinetask custom task references",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
@@ -722,7 +752,61 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
+		},
+	}, {
+		name: "tt prefix without params segment is still rejected",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(tt.foo)"},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(tt.foo)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
+		},
+	}, {
+		name: "tt.params without a param name is still rejected",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(tt.params)"},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(tt.params)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
+		},
+	}, {
+		name: "tt.params with an empty param name is still rejected",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(tt.params.)"},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(tt.params.)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
 		},
 	}, {
@@ -742,7 +826,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.params[IMAGE].value"},
 		},
 	}, {
@@ -765,8 +849,28 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.include[0].params[IMAGE].value"},
+		},
+	}, {
+		name: "invalid variable reference in when expression",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					When: WhenExpressions{{
+						Input:    "$(invalid_ref)",
+						Operator: selection.In,
+						Values:   []string{"bar"},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].when[0]"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -42,10 +42,11 @@ var (
 )
 
 const (
-	taskRef      = "taskRef"
-	taskSpec     = "taskSpec"
-	pipelineRef  = "pipelineRef"
-	pipelineSpec = "pipelineSpec"
+	taskRef        = "taskRef"
+	taskSpec       = "taskSpec"
+	pipelineRef    = "pipelineRef"
+	pipelineSpec   = "pipelineSpec"
+	ttParamsPrefix = "tt.params"
 )
 
 // SupportedVerbs returns the operations that validation should be called for
@@ -853,15 +854,17 @@ func validateMatrix(ctx context.Context, tasks []PipelineTask) (errs *apis.Field
 }
 
 func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) (errs *apis.FieldError) {
-	validPrefixes := sets.NewString("params", "tasks", "finally", "context", "workspaces", "results")
+	validPrefixes := sets.NewString("params", "tasks", "finally", "context", "workspaces", "results", ttParamsPrefix)
 	for idx, task := range tasks {
 		for _, param := range task.Params {
 			if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
 				for _, expression := range expressions {
-					prefix := strings.SplitN(expression, ".", 2)[0]
-					if !validPrefixes.Has(prefix) {
+					fields := strings.SplitN(expression, ".", 3)
+					if !validPrefixes.Has(fields[0]) &&
+						!(len(fields) > 1 && validPrefixes.Has(fields[0]+"."+fields[1]) &&
+							(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
 						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 							"value",
 						).ViaFieldKey("params", param.Name).ViaFieldIndex(fieldPath, idx))
 					}
@@ -871,10 +874,12 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 		for i, we := range task.WhenExpressions {
 			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
 				for _, expression := range expressions {
-					prefix := strings.SplitN(expression, ".", 2)[0]
-					if !validPrefixes.Has(prefix) {
+					fields := strings.SplitN(expression, ".", 3)
+					if !validPrefixes.Has(fields[0]) &&
+						!(len(fields) > 1 && validPrefixes.Has(fields[0]+"."+fields[1]) &&
+							(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
 						errs = errs.Also(apis.ErrInvalidValue(
-							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+							fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 							"",
 						).ViaFieldIndex("when", i).ViaFieldIndex(fieldPath, idx))
 					}
@@ -885,10 +890,13 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 			for _, param := range task.Matrix.Params {
 				if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
 					for _, expression := range expressions {
-						prefix := strings.SplitN(expression, ".", 2)[0]
-						if !validPrefixes.Has(prefix) {
+						fields := strings.SplitN(expression, ".", 3)
+						if !validPrefixes.Has(fields[0]) &&
+							!(len(fields) > 1 &&
+								validPrefixes.Has(fields[0]+"."+fields[1]) &&
+								(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
 							errs = errs.Also(apis.ErrInvalidValue(
-								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+								fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 								"value",
 							).ViaFieldKey("matrix.params", param.Name).ViaFieldIndex(fieldPath, idx))
 						}
@@ -899,10 +907,13 @@ func validateVarSubstitutionExpressions(tasks []PipelineTask, fieldPath string) 
 				for _, param := range include.Params {
 					if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
 						for _, expression := range expressions {
-							prefix := strings.SplitN(expression, ".", 2)[0]
-							if !validPrefixes.Has(prefix) {
+							fields := strings.SplitN(expression, ".", 3)
+							if !validPrefixes.Has(fields[0]) &&
+								!(len(fields) > 1 &&
+									validPrefixes.Has(fields[0]+"."+fields[1]) &&
+									(fields[0]+"."+fields[1] != ttParamsPrefix || (len(fields) > 2 && fields[2] != ""))) {
 								errs = errs.Also(apis.ErrInvalidValue(
-									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
+									fmt.Sprintf("invalid variable reference %q, must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead", "$("+expression+")"),
 									"value",
 								).ViaFieldKey("params", param.Name).ViaFieldIndex("matrix.include", i).ViaFieldIndex(fieldPath, idx))
 							}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -46,6 +46,36 @@ func TestPipeline_Validate_Success(t *testing.T) {
 			},
 		},
 	}, {
+		name: "tt.params reference in pipeline task param is allowed (Triggers-owned prefix)",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "MESSAGE", Value: ParamValue{Type: ParamTypeString, StringVal: "$(tt.params.MESSAGE)"},
+					}},
+				}},
+			},
+		},
+	}, {
+		name: "tt.params reference in matrix param is allowed (Triggers-owned prefix)",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Matrix: &Matrix{
+						Params: Params{{
+							Name: "IMAGE", Value: ParamValue{Type: ParamTypeArray, ArrayVal: []string{"$(tt.params.IMAGE)", "image2"}},
+						}},
+					},
+				}},
+			},
+		},
+	}, {
 		name: "pipelinetask custom task references",
 		p: &Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
@@ -649,7 +679,61 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(env_value_set_from_yq)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
+		},
+	}, {
+		name: "tt prefix without params segment is still rejected",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(tt.foo)"},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(tt.foo)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
+		},
+	}, {
+		name: "tt.params without a param name is still rejected",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(tt.params)"},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(tt.params)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
+		},
+	}, {
+		name: "tt.params with an empty param name is still rejected",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Params: Params{{
+						Name: "SCRIPT", Value: ParamValue{Type: ParamTypeString, StringVal: "echo $(tt.params.)"},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(tt.params.)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].params[SCRIPT].value"},
 		},
 	}, {
@@ -669,7 +753,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.params[IMAGE].value"},
 		},
 	}, {
@@ -692,8 +776,28 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, or results; if you meant a shell variable, use ${VAR} instead`,
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
 			Paths:   []string{"spec.tasks[0].matrix.include[0].params[IMAGE].value"},
+		},
+	}, {
+		name: "invalid variable reference in when expression",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					WhenExpressions: WhenExpressions{{
+						Input:    "$(invalid_ref)",
+						Operator: selection.In,
+						Values:   []string{"bar"},
+					}},
+				}},
+			},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid variable reference "$(invalid_ref)", must start with a valid prefix: params, tasks, finally, context, workspaces, results, or tt.params; if you meant a shell variable, use ${VAR} instead`,
+			Paths:   []string{"spec.tasks[0].when[0]"},
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
Triggers embeds $(tt.params.<name>) in resource templates; an unresolved ref survives into the created resource and fails the strict prefix check added in #10050. Allow tt.params as a pass-through in v1 and v1beta1.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Pipelines can now reference `$(tt.params.<name>)` in task params, `when` expressions, and matrix params/includes. This lets a `PipelineSpec` embedded by Tekton Triggers keep its `tt.params.*` substitutions without failing pipeline validation.
```
