### PR TITLE
Use non-expandable here-string for Windows script placement

### DIFF
--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -179,9 +179,9 @@ func placeScriptInContainer(script, scriptFile string, c *corev1.Container, init
 	// script file in a known location in the scripts volume.
 	if requiresWindows {
 		command, args, script, scriptFile := extractWindowsScriptComponents(script, scriptFile)
-		initContainer.Args[1] += fmt.Sprintf(`@"
+		initContainer.Args[1] += fmt.Sprintf(`@'
 %s
-"@ | Out-File -FilePath %s
+'@ | Out-File -FilePath %s
 `, script, scriptFile)
 
 		c.Command = command

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -781,17 +781,17 @@ no-shebang`,
 		Name:    "place-scripts",
 		Image:   images.ShellImageWin,
 		Command: []string{"pwsh"},
-		Args: []string{"-Command", `@"
+		Args: []string{"-Command", `@'
 #!win pwsh -File
 script-1
-"@ | Out-File -FilePath /tekton/scripts/script-0-9l9zj
-@"
+'@ | Out-File -FilePath /tekton/scripts/script-0-9l9zj
+@'
 #!win powershell -File
 script-3
-"@ | Out-File -FilePath /tekton/scripts/script-2-mz4c7.ps1
-@"
+'@ | Out-File -FilePath /tekton/scripts/script-2-mz4c7.ps1
+@'
 no-shebang
-"@ | Out-File -FilePath /tekton/scripts/script-3-mssqb.cmd
+'@ | Out-File -FilePath /tekton/scripts/script-3-mssqb.cmd
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		SecurityContext: WindowsSecurityContext,
@@ -863,18 +863,18 @@ sidecar-1`,
 		Name:    "place-scripts",
 		Image:   images.ShellImageWin,
 		Command: []string{"pwsh"},
-		Args: []string{"-Command", `@"
+		Args: []string{"-Command", `@'
 #!win pwsh -File
 script-1
-"@ | Out-File -FilePath /tekton/scripts/script-0-9l9zj
-@"
+'@ | Out-File -FilePath /tekton/scripts/script-0-9l9zj
+@'
 #!win powershell -File
 script-3
-"@ | Out-File -FilePath /tekton/scripts/script-2-mz4c7.ps1
-@"
+'@ | Out-File -FilePath /tekton/scripts/script-2-mz4c7.ps1
+@'
 #!win pwsh -File
 sidecar-1
-"@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-mssqb
+'@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-mssqb
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		SecurityContext: WindowsSecurityContext,
@@ -933,10 +933,10 @@ sidecar-1`,
 		Name:    "place-scripts",
 		Image:   images.ShellImageWin,
 		Command: []string{"pwsh"},
-		Args: []string{"-Command", `@"
+		Args: []string{"-Command", `@'
 #!win python
 sidecar-1
-"@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-9l9zj
+'@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-9l9zj
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 		SecurityContext: WindowsSecurityContext,
@@ -963,5 +963,34 @@ sidecar-1
 
 	if len(gotSidecars) != 1 {
 		t.Errorf("Wanted 1 sidecar, got %v", len(gotSidecars))
+	}
+}
+
+func TestConvertScripts_Windows_HereStringInjection(t *testing.T) {
+	names.TestingSeed()
+
+	gotInit, _, _ := convertScripts(images.ShellImage, images.ShellImageWin, []v1.Step{{
+		Script: `#!win pwsh -File
+Write-Host "$(params.x)"
+"@
+exit 1`,
+		Image: "step-1",
+	}}, []v1.Sidecar{}, nil, SecurityContextConfig{SetSecurityContext: true, SetReadOnlyRootFilesystem: true})
+	wantInit := &corev1.Container{
+		Name:    "place-scripts",
+		Image:   images.ShellImageWin,
+		Command: []string{"pwsh"},
+		Args: []string{"-Command", `@'
+#!win pwsh -File
+Write-Host "$(params.x)"
+"@
+exit 1
+'@ | Out-File -FilePath /tekton/scripts/script-0-9l9zj
+`},
+		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		SecurityContext: WindowsSecurityContext,
+	}
+	if d := cmp.Diff(wantInit, gotInit); d != "" {
+		t.Errorf("Init Container Diff %s", diff.PrintWantGot(d))
 	}
 }


### PR DESCRIPTION
Fixes #10632

## Problem

In `pkg/pod/script.go`, the `place-scripts` init container builds PowerShell here-strings for Windows scripts using expandable syntax (`@"..."@`). This allows early termination of the here-string if the script content contains `"@` on its own line.

After `$(params.x)` substitution by the Kubernetes API server, a script like:
```
Write-Host "$(params.x)"
"@
exit 1
```
would have the here-string terminated after line 1, leaving `exit 1` to be interpreted as a PowerShell command in the init container.

**Linux** was already safe — it uses single-quoted heredoc (`<< 'EOF'`) which prevents shell expansion.

## Fix

Switch to PowerShell non-expandable here-strings (`@'...'@`), which is the equivalent of single-quoted heredoc in shell — no variable expansion, no special character interpretation:

```diff
- initContainer.Args[1] += fmt.Sprintf(`@"
- %s
- "@ | Out-File -FilePath %s
+ initContainer.Args[1] += fmt.Sprintf(`@'
+ %s
+ '@ | Out-File -FilePath %s
```

The only sequence that terminates `@'...'@` is `'@` on its own line, which is far less likely to appear in script content.

## Testing

- Updated existing Windows script tests (`TestConvertScripts_Windows`, `TestConvertScripts_Windows_WithSidecar`, `TestConvertScripts_Windows_SidecarOnly`)
- Added new regression test `TestConvertScripts_Windows_HereStringInjection` that verifies scripts containing `"@` are correctly preserved
- All `pkg/pod` tests pass

## Context

This is defense-in-depth. The root cause is that `$(params.x)` is raw string interpolation by design. Users should pass untrusted values through environment variables rather than direct param substitution in scripts. This applies to both Linux and Windows.

```release-note
bugfix: Use non-expandable here-string for Windows script placement to prevent early termination when script content contains `"@`.
```
